### PR TITLE
deprecating instrumentation libary span processing via config property

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ System property values take priority over corresponding environment variables.
 | otel.trace.methods                  | OTEL_TRACE_METHODS                 | unset          | Same as adding `@WithSpan` annotation functionality for the target method string. <details><summary>Format</summary>`my.package.MyClass1[method1,method2];my.package.MyClass2[method3]`</details>                                                                                                                                                                                                            |
 | otel.trace.annotated.methods.exclude     | OTEL_TRACE_ANNOTATED_METHODS_EXCLUDE    | unset          | Suppress `@WithSpan` instrumentation for specific methods. <details><summary>Format</summary>`my.package.MyClass1[method1,method2];my.package.MyClass2[method3]`</details>                                                                                                                                                                                                                                |
 
+### Splunk distribution configuration
+| System property                                    | Environment variable                              | Default value | Notes                                                                                                                                         |
+| -------------------------------------------------- | ------------------------------------------------- | --------------| --------------------------------------------------------------------------------------------------------------------------------------------- |
+| splunk.otel.config.span.processor.instrlib.enabled | SPLUNK_OTEL_CONFIG_SPAN_PROCESSOR_INSTRLIB_ENABLED| `false`       | Enables span processing adding library instrumentation properties. Deprecated feature for customers not on the newest OpenTelemetry Collector |
+
 ## Manually instrument a Java application
 
 Documentation on how to manually instrument a Java application are available

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ subprojects {
   }
 
   dependencies {
+    testImplementation("org.mockito:mockito-core:3.3.3")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.6.2")
   }

--- a/custom/src/main/java/com/splunk/opentelemetry/InstrumentationLibraryTracerCustomizer.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/InstrumentationLibraryTracerCustomizer.java
@@ -16,12 +16,33 @@
 
 package com.splunk.opentelemetry;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.opentelemetry.javaagent.bootstrap.spi.TracerCustomizer;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 
 public class InstrumentationLibraryTracerCustomizer implements TracerCustomizer {
+
+  @VisibleForTesting
+  static final String PROPERTY_SPAN_PROCESSOR_INSTR_LIB_ENABLED =
+      "splunk.otel.config.span.processor.instrlib.enabled";
+
+  private static String propertyToEnv(String property) {
+    return property.replace(".", "_").toUpperCase();
+  }
+
+  private static boolean spanProcessorInstrumentationLibraryEnabled() {
+    String value = System.getProperty(PROPERTY_SPAN_PROCESSOR_INSTR_LIB_ENABLED);
+    if (value == null) {
+      value = System.getenv(propertyToEnv(PROPERTY_SPAN_PROCESSOR_INSTR_LIB_ENABLED));
+    }
+    return ("true".equalsIgnoreCase(value));
+  }
+
   @Override
   public void configure(TracerSdkProvider tracerSdkProvider) {
-    tracerSdkProvider.addSpanProcessor(new InstrumentationLibrarySpanProcessor());
+
+    if (spanProcessorInstrumentationLibraryEnabled()) {
+      tracerSdkProvider.addSpanProcessor(new InstrumentationLibrarySpanProcessor());
+    }
   }
 }

--- a/custom/src/test/java/com/splunk/opentelemetry/InstrumentationLibraryTracerCustomizerTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/InstrumentationLibraryTracerCustomizerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry;
+
+import static com.splunk.opentelemetry.InstrumentationLibraryTracerCustomizer.PROPERTY_SPAN_PROCESSOR_INSTR_LIB_ENABLED;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+
+import io.opentelemetry.sdk.trace.TracerSdkProvider;
+import org.junit.jupiter.api.Test;
+
+public class InstrumentationLibraryTracerCustomizerTest {
+
+  @Test
+  public void shouldAddSpanProcessorIfPropertySetToTrue() {
+
+    // given
+    TracerSdkProvider tracerSdkProvider = mock(TracerSdkProvider.class);
+    InstrumentationLibraryTracerCustomizer underTest = new InstrumentationLibraryTracerCustomizer();
+    System.setProperty(PROPERTY_SPAN_PROCESSOR_INSTR_LIB_ENABLED, "true");
+
+    // when
+    underTest.configure(tracerSdkProvider);
+
+    // then
+    then(tracerSdkProvider)
+        .should()
+        .addSpanProcessor(isA(InstrumentationLibrarySpanProcessor.class));
+  }
+
+  @Test
+  public void shouldNotAddSpanProcessorIfPropertySetToAnythingElse() {
+
+    // given
+    TracerSdkProvider tracerSdkProvider = mock(TracerSdkProvider.class);
+    InstrumentationLibraryTracerCustomizer underTest = new InstrumentationLibraryTracerCustomizer();
+    System.setProperty(PROPERTY_SPAN_PROCESSOR_INSTR_LIB_ENABLED, "enabled");
+
+    // when
+    underTest.configure(tracerSdkProvider);
+
+    // then
+    then(tracerSdkProvider)
+        .should(never())
+        .addSpanProcessor(isA(InstrumentationLibrarySpanProcessor.class));
+  }
+
+  @Test
+  public void shouldNotAddSpanProcessorIfPropertyNotSet() {
+
+    // given
+    TracerSdkProvider tracerSdkProvider = mock(TracerSdkProvider.class);
+    InstrumentationLibraryTracerCustomizer underTest = new InstrumentationLibraryTracerCustomizer();
+    System.clearProperty(PROPERTY_SPAN_PROCESSOR_INSTR_LIB_ENABLED);
+
+    // when
+    underTest.configure(tracerSdkProvider);
+
+    // then
+    then(tracerSdkProvider)
+        .should(never())
+        .addSpanProcessor(isA(InstrumentationLibrarySpanProcessor.class));
+  }
+}

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/SpringBootSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/SpringBootSmokeTest.java
@@ -19,6 +19,8 @@ package com.splunk.opentelemetry;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import okhttp3.Request;
@@ -32,8 +34,14 @@ class SpringBootSmokeTest extends SmokeTest {
     return "open-telemetry-docker-dev.bintray.io/java/smoke-springboot-jdk" + jdk + ":latest";
   }
 
+  @Override
+  protected Map<String, String> getExtraEnv() {
+    return Collections.singletonMap("SPLUNK_OTEL_CONFIG_SPAN_PROCESSOR_INSTRLIB_ENABLED", "true");
+  }
+
   @Test
   public void springBootSmokeTestOnJDK() throws IOException, InterruptedException {
+
     startTarget(8);
     String url = String.format("http://localhost:%d/greeting", target.getMappedPort(8080));
     Request request = new Request.Builder().url(url).get().build();


### PR DESCRIPTION
Resolves #14 

Since new OTLP Collector supports passing zipkin/jeager instrumentaiton library as span tags, span processing needs to be deprecated.
- `splunk.otel.config.span.processor.instrlib.enabled` property, set to false by default
- added unit tests to confirm the behaviour