### PR TITLE
Java Agent Migration - add steps for shim and classpath

### DIFF
--- a/migration.md
+++ b/migration.md
@@ -54,7 +54,6 @@ distribution of Splunk Distribution of OpenTelemetry Java Instrumentation:
    annotation in the SignalFx Java Agent, ensure it's in your application's
    `classpath` as well. For an example of what this looks like, see this
    [SignalFx Java Agent example application](https://github.com/signalfx/tracing-examples/blob/master/signalfx-tracing/signalfx-java-tracing/okhttp-and-jedis/src/main/java/com/signalfx/tracing/examples/javaagent/App.java).
-   
 
 ## Changes in functionality
 

--- a/migration.md
+++ b/migration.md
@@ -46,6 +46,15 @@ distribution of Splunk Distribution of OpenTelemetry Java Instrumentation:
    setting.
 4. In your application startup script, replace `-javaagent:./signalfx-tracing.jar`
    with `-javaagent:/path/to/splunk-otel-javaagent-all.jar`.
+5. If you manually instrumented any code with an OpenTracing tracer, expose
+   the OpenTelemetry tracer as an implementation of an OpenTracing tracer with
+   the OpenTracing Shim. For more information, see
+   [OpenTelemetry - OpenTracing Shim](https://github.com/open-telemetry/opentelemetry-java/tree/master/opentracing-shim).
+   If you use another API for manual instrumentation, such as for the `@Trace`
+   annotation in the SignalFx Java Agent, ensure it's in your application's
+   `classpath` as well. For an example of what this looks like, see this
+   [SignalFx Java Agent example application](https://github.com/signalfx/tracing-examples/blob/master/signalfx-tracing/signalfx-java-tracing/okhttp-and-jedis/src/main/java/com/signalfx/tracing/examples/javaagent/App.java).
+   
 
 ## Changes in functionality
 


### PR DESCRIPTION
- adds a new step to the migration workflow that includes using the OpenTracing Shim and updating the `classpath`