### PR TITLE
Use alwaysOn() sampler

### DIFF
--- a/custom/src/main/java/com/splunk/opentelemetry/SplunkTracerCustomizer.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/SplunkTracerCustomizer.java
@@ -44,8 +44,7 @@ public class SplunkTracerCustomizer implements TracerCustomizer {
       tracerManagement.addSpanProcessor(new JdbcSpanRenamingProcessor());
     }
 
-    tracerManagement.updateActiveTraceConfig(tracerManagement.getActiveTraceConfig().toBuilder()
-            .setSampler(Sampler.alwaysOn())
-            .build());
+    tracerManagement.updateActiveTraceConfig(
+        tracerManagement.getActiveTraceConfig().toBuilder().setSampler(Sampler.alwaysOn()).build());
   }
 }

--- a/custom/src/main/java/com/splunk/opentelemetry/SplunkTracerCustomizer.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/SplunkTracerCustomizer.java
@@ -18,6 +18,7 @@ package com.splunk.opentelemetry;
 
 import io.opentelemetry.javaagent.spi.TracerCustomizer;
 import io.opentelemetry.sdk.trace.TracerSdkManagement;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
 
 public class SplunkTracerCustomizer implements TracerCustomizer {
 
@@ -42,5 +43,9 @@ public class SplunkTracerCustomizer implements TracerCustomizer {
     if (jdbcSpanLowCardinalityNameEnabled()) {
       tracerManagement.addSpanProcessor(new JdbcSpanRenamingProcessor());
     }
+
+    tracerManagement.updateActiveTraceConfig(tracerManagement.getActiveTraceConfig().toBuilder()
+            .setSampler(Sampler.alwaysOn())
+            .build());
   }
 }

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/SpringBootSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/SpringBootSmokeTest.java
@@ -28,7 +28,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 class SpringBootSmokeTest extends SmokeTest {
 
   private String getTargetImage(int jdk) {
-    return "open-telemetry-docker-dev.bintray.io/java/smoke-springboot-jdk" + jdk + ":latest";
+    return "open-telemetry-docker-dev.bintray.io/java/smoke-springboot-jdk"
+        + jdk
+        + ":20201105.347264626";
   }
 
   @ParameterizedTest(name = "{index} => SpringBoot SmokeTest On JDK{0}.")


### PR DESCRIPTION
Will always export the trace, even if the incoming b3 headers do not contain the `x-b3-sampled` one