### PR TITLE
add maven local repository

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ subprojects {
 
   repositories {
     jcenter()
+    mavenLocal()
     maven {
       url = uri("https://dl.bintray.com/open-telemetry/maven")
     }


### PR DESCRIPTION
add maven local repository to enable using artefacts from opentelemetry-java-instrumentation built with ./gradlew publishToMavenLocal