### PR TITLE
Fixed zipkin exporter service name runtime paramter in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Then the runtime parameters would be updated to:
 ```bash
 $ curl -L https://github.com/signalfx/splunk-otel-java/releases/latest/download/splunk-otel-javaagent-all.jar \
     -o splunk-otel-javaagent.jar
-$ java -javaagent:./splunk-otel-javaagent.jar -Dotel.zipkin.service.name=my-java-app \
+$ java -javaagent:./splunk-otel-javaagent.jar -Dotel.exporter.zipkin.service.name=my-java-app \
     -jar target/java-agent-example-1.0-SNAPSHOT-shaded.jar https://google.com
 ```
 


### PR DESCRIPTION
Here's a link to the relevant section in the opentelemetry-java-instrumentation README:
https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/README.md#zipkin-exporter