### PR TITLE
JBoss EAP SmokeTest and images for the test-matrix.

### DIFF
--- a/matrix/.gitignore
+++ b/matrix/.gitignore
@@ -1,0 +1,1 @@
+jboss*.zip

--- a/matrix/README.md
+++ b/matrix/README.md
@@ -34,6 +34,9 @@ $ sh buildDockerImage.sh -v 12.2.1.4 -d -s
 ```
 This will build the docker image `oracle/weblogic:12.2.1.4-developer`
 
+Now, when the Base WebLogic Image is built, you can run `./gradlew weblogicImage-12.2.1.4-jdkdeveloper` to build the
+image with the test app deployed which can be used by SmokeTests.
+
 #### WebLogic 14
 Follow these instructions and build _developer_ (`-d` flag) image of
 [WebLogic 14.1.1.0](https://github.com/oracle/docker-images/tree/master/OracleWebLogic/dockerfiles/14.1.1.0)
@@ -48,3 +51,15 @@ $ sh buildDockerImage.sh -v 14.1.1.0 -d -s -j 11
 ```
 
 This will build docker images `oracle/weblogic:14.1.1.0-developer-8` and `oracle/weblogic:14.1.1.0-developer-11` respectively.
+
+Now, when the Base WebLogic Image is built, you can run `./gradlew weblogicImage-14.1.1.0-jdkdeveloper-8` and
+`weblogicImage-14.1.1.0-jdkdeveloper-11` to build images with the test app deployed which can be used by SmokeTests.
+
+### JBoss EAP
+To build JBoss EAP images you need to download following files to the `src/main/docker/jboss-eap` directory:
+
+* [jboss-eap-7.1.0.zip](https://developers.redhat.com/download-manager/file/jboss-eap-7.1.0.zip)
+* [jboss-eap-7.3.0.zip](https://developers.redhat.com/download-manager/file/jboss-eap-7.3.0.zip)
+
+Now you can run gradle targets `jboss-eapImage-7.1.0-jdk8`, `jboss-eapImage-7.3.0-jdk11`, `jboss-eapImage-7.3.0-jdk8`
+to build Docker images with the test app deployed which can be used by SmokeTests.

--- a/matrix/build.gradle
+++ b/matrix/build.gradle
@@ -1,5 +1,4 @@
 import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
-import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
   id 'war'
@@ -19,10 +18,6 @@ dependencies {
   implementation("io.opentelemetry:opentelemetry-extension-annotations:${versions["opentelemetry"]}")
 }
 
-def dockerFileName(String template) {
-  template.replace("-dockerfile.template", ".dockerfile")
-}
-
 def dockerWorkingDir = new File(project.buildDir, "docker")
 
 def buildProprietaryTestImagesTask = tasks.create("buildProprietaryTestImages") {
@@ -34,22 +29,23 @@ def targets = [
    "weblogic" : [
         "12.2.1.4" : ["developer"],
         "14.1.1.0" : ["developer-8", "developer-11"]
-   ]
+   ],
+    "jboss-eap" : [
+        "7.1.0" : ["8"],
+        "7.3.0" : ["8", "11"]
+    ]
 ]
 
 targets.forEach { server, data ->
+  String dockerFileName = "${server}.dockerfile"
   data.forEach { version, jdks ->
     jdks.forEach { jdk ->
-      def template = "$server-dockerfile.template"
-
       def prepareTask = tasks.register("${server}ImagePrepare-$version-jdk$jdk", Copy) {
         def warTask = project.tasks.named("war").get()
         it.dependsOn(warTask)
         it.into(dockerWorkingDir)
-        it.from("src") {
-          it.filter(ReplaceTokens, "tokens" : ["version" : version, "jdk" : jdk])
-          it.rename { f -> dockerFileName(f) }
-        }
+        it.from("src/${dockerFileName}")
+        it.from("src/main/docker/${server}")
         it.from(warTask.archiveFile) {
           rename { _ -> "app.war" }
         }
@@ -62,7 +58,9 @@ targets.forEach { server, data ->
 
         it.inputDir = dockerWorkingDir
         it.images.add "splunk-$server:$version-jdk$jdk"
-        it.dockerFile = new File(dockerWorkingDir, dockerFileName(template))
+        it.buildArgs.set(["version": version, "jdk": jdk])
+
+        it.dockerFile = new File(dockerWorkingDir, dockerFileName)
       }
 
       buildProprietaryTestImagesTask.dependsOn(buildTask)

--- a/matrix/src/jboss-eap.dockerfile
+++ b/matrix/src/jboss-eap.dockerfile
@@ -1,0 +1,52 @@
+ARG jdk
+FROM adoptopenjdk:${jdk}-hotspot-focal
+
+# Create a user and group used to launch processes
+# The user ID 1000 is the default for the first "regular" user on Fedora/RHEL,
+# so there is a high chance that this ID will be equal to the current user
+# making it easier to use volumes (no permission issues)
+RUN groupadd -r jboss -g 1000 && useradd -u 1000 -r -g jboss -m -d /opt/jboss -s /sbin/nologin -c "JBoss user" jboss && \
+    chmod 755 /opt/jboss && \
+    apt-get update && \
+    apt-get install unzip
+
+# Set the working directory to jboss' user home directory
+
+# Specify the user which should be used to execute all commands below
+#USER jboss
+
+# Set the JBOSS_EAP_VERSION env variable
+ARG version
+ENV JBOSS_EAP_VERSION=${version}
+ENV JBOSS_HOME /opt/jboss/jboss-eap
+ENV JBOSS_INSTALL_DIR /opt/jboss
+
+#USER root
+COPY jboss-eap-${JBOSS_EAP_VERSION}.zip $JBOSS_INSTALL_DIR
+
+# Add the EAS distribution to /opt, and make wildfly the owner of the extracted tar content
+# Make sure the distribution is available from a well-known place
+
+RUN unzip $JBOSS_INSTALL_DIR/jboss-eap-${JBOSS_EAP_VERSION}.zip -d $JBOSS_INSTALL_DIR \
+    && rm $JBOSS_INSTALL_DIR/jboss-eap-${JBOSS_EAP_VERSION}.zip \
+    && mv $JBOSS_INSTALL_DIR/jboss-eap-* $JBOSS_HOME
+
+COPY app.war ${JBOSS_HOME}/standalone/deployments/
+
+RUN chown -R jboss:0 ${JBOSS_HOME} \
+    && chmod -R g+rw ${JBOSS_HOME}
+
+USER jboss
+
+# Ensure signals are forwarded to the JVM process correctly for graceful shutdown
+ENV LAUNCH_JBOSS_IN_BACKGROUND true
+
+WORKDIR /opt/jboss/jboss-eap
+
+# Expose the ports we're interested in
+EXPOSE 8080
+
+# Set the default command to run on boot
+# This will boot WildFly in the standalone mode and bind to all interface
+CMD ["./bin/standalone.sh", "-b", "0.0.0.0"]
+

--- a/matrix/src/weblogic.dockerfile
+++ b/matrix/src/weblogic.dockerfile
@@ -1,4 +1,6 @@
-FROM oracle/weblogic:@version@-@jdk@
+ARG jdk
+ARG version
+FROM oracle/weblogic:$version-$jdk
 
 ARG APPLICATION_NAME
 ARG APPLICATION_FILE
@@ -10,7 +12,7 @@ ENV ORACLE_HOME=/u01/oracle \
     ADMIN_PORT="8080" \
     PATH=$PATH:/u01/oracle/oracle_common/common/bin:/u01/oracle/wlserver/common/bin:${DOMAIN_HOME}:${DOMAIN_HOME}/bin:/u01/oracle
 
-COPY --chown=oracle:root main/docker/weblogic/container-scripts/* /u01/oracle/
+COPY --chown=oracle:root container-scripts/* /u01/oracle/
 
 USER root
 RUN chmod +xw /u01/oracle/*.sh && \
@@ -21,7 +23,7 @@ RUN chmod +xw /u01/oracle/*.sh && \
     chmod -R 775 $DOMAIN_HOME/.. && \
     chown -R oracle:root ${PROPERTIES_FILE_DIR}
 
-COPY --chown=oracle:root main/docker/weblogic/properties/docker-build/domain*.properties ${PROPERTIES_FILE_DIR}/
+COPY --chown=oracle:root properties/docker-build/domain*.properties ${PROPERTIES_FILE_DIR}/
 
 USER oracle
 RUN /u01/oracle/createDomain.sh && \

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/JBossEapSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/JBossEapSmokeTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * This is the smoke test for OpenTelemetry Java agent with JBoss EAP. The test is ignored if there
+ * are no JBoss EAP images installed locally. See the manual in `matrix` sub-project for
+ * instructions on how to build required images.
+ */
+public class JBossEapSmokeTest extends ProprietaryAppServerTest {
+
+  public static final ExpectedServerAttributes JBOSS_EAP_7_1_SERVER_ATTRIBUTES =
+      new ExpectedServerAttributes("TODO", "JBoss EAP", "7.1.0.GA");
+  public static final ExpectedServerAttributes JBOSS_EAP_7_3_SERVER_ATTRIBUTES =
+      new ExpectedServerAttributes("TODO", "JBoss EAP", "7.3.0.GA");
+
+  private static Stream<Arguments> jboss() {
+    return Stream.of(
+        arguments("splunk-jboss-eap:7.1.0-jdk8", JBOSS_EAP_7_1_SERVER_ATTRIBUTES),
+        arguments("splunk-jboss-eap:7.3.0-jdk8", JBOSS_EAP_7_3_SERVER_ATTRIBUTES),
+        arguments("splunk-jboss-eap:7.3.0-jdk11", JBOSS_EAP_7_3_SERVER_ATTRIBUTES));
+  }
+
+  @ParameterizedTest(name = "[{index}] {0}")
+  @MethodSource("jboss")
+  void jbossSmokeTest(String imageName, ExpectedServerAttributes expectedServerAttributes)
+      throws IOException, InterruptedException {
+    assumeTrue(localDockerImageIsPresent(imageName));
+    startTarget(imageName);
+
+    // TODO support 404
+    //    assertServerHandler(expectedServerAttributes);
+    assertWebAppTrace(expectedServerAttributes);
+  }
+}

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/ProprietaryAppServerTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/ProprietaryAppServerTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry;
+
+import org.junit.jupiter.api.Assertions;
+import org.testcontainers.DockerClientFactory;
+
+/**
+ * This is the base class for smoke test for OpenTelemetry Java agent with proprietary app-servers.
+ * See the manual in `matrix` sub-project for instructions on how to build required images.
+ */
+abstract class ProprietaryAppServerTest extends AppServerTest {
+
+  protected void additionalWebAppTraceAssertions(
+      TraceInspector traces, ExpectedServerAttributes serverAttributes) {
+    Assertions.assertEquals(
+        1, traces.countSpansByName("GreetingServlet.withSpan"), "Span for the annotated method");
+  }
+
+  protected int totalNumberOfSpansInWebappTrace() {
+    // test app in proprietary images also has one additional span for WithSpan annotation.
+    return super.totalNumberOfSpansInWebappTrace() + 1;
+  }
+
+  protected boolean localDockerImageIsPresent(String imageName) {
+    try {
+      DockerClientFactory.lazyClient().inspectImageCmd(imageName).exec();
+      return true;
+    } catch (Exception e) {
+      System.out.println(e.getMessage());
+      return false;
+    }
+  }
+}

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/TomcatSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/TomcatSmokeTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.io.IOException;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -53,23 +52,22 @@ public class TomcatSmokeTest extends AppServerTest {
             TOMCAT9_SERVER_ATTRIBUTES));
   }
 
-  @Disabled("Test fails with non-root context of test app. Pending investigation")
   @ParameterizedTest(name = "[{index}] {0}")
   @MethodSource("supportedConfigurations")
   void tomcatSmokeTest(String imageName, ExpectedServerAttributes expectedServerAttributes)
       throws IOException, InterruptedException {
     startTarget(imageName);
 
-    assertServerHandler(expectedServerAttributes);
+    // TODO: Uncomment when
+    // https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/1902 is released
+    // upstream.
+    //    assertServerHandler(expectedServerAttributes);
     assertWebAppTrace(expectedServerAttributes);
   }
 
   public static class TomcatAttributes extends ExpectedServerAttributes {
     public TomcatAttributes(String version) {
-      super(
-          "/this-is-definitely-not-there-but-there-should-be-a-trace-nevertheless",
-          "tomcat",
-          version);
+      super("CoyoteAdapter.service", "tomcat", version);
     }
   }
 }

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/WebLogicSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/WebLogicSmokeTest.java
@@ -21,21 +21,20 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.io.IOException;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * This is the smoke test for OpenTelemetry Java agent with Oracle WebLogic. The test is ignored if
- * there are no WebLogic images installed locally. See the manual in src/weblogic directory for
+ * there are no WebLogic images installed locally. See the manual in `matrix` sub-project for
  * instructions on how to build required images.
  */
-class WebLogicSmokeTest extends AppServerTest {
+class WebLogicSmokeTest extends ProprietaryAppServerTest {
 
   // FIXME: awaiting https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/1630
-  private static final ExpectedServerAttributes WEBLOGIC_ATTRIBUTES =
-      new ExpectedServerAttributes("", "", "");
+  private static final AppServerTest.ExpectedServerAttributes WEBLOGIC_ATTRIBUTES =
+      new AppServerTest.ExpectedServerAttributes("", "", "");
 
   private static Stream<Arguments> supportedWlsConfigurations() {
     return Stream.of(
@@ -58,19 +57,6 @@ class WebLogicSmokeTest extends AppServerTest {
     assertWebAppTrace(WEBLOGIC_ATTRIBUTES);
 
     stopTarget();
-  }
-
-  @Override
-  protected void additionalWebAppTraceAssertions(
-      TraceInspector traces, ExpectedServerAttributes serverAttributes) {
-    Assertions.assertEquals(
-        1, traces.countSpansByName("GreetingServlet.withSpan"), "Span for the annotated method");
-  }
-
-  @Override
-  protected int totalNumberOfSpansInWebappTrace() {
-    // test app in proprietary images also has one additional span for WithSpan annotation.
-    return super.totalNumberOfSpansInWebappTrace() + 1;
   }
 
   @Override


### PR DESCRIPTION
As Weblogic, requires local images. When present:
![image](https://user-images.githubusercontent.com/347943/102525135-88dd0d80-40a2-11eb-93d7-f79d0b350d86.png)
