### PR TITLE
specify compatible otel API versions to extend manual instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ For more options see [here](https://github.com/open-telemetry/opentelemetry-java
 Documentation on how to manually instrument a Java application are available
 [here](https://github.com/open-telemetry/opentelemetry-java-instrumentation#manually-instrumenting).
 
+To extend the instrumentation with the OpenTelemetry Instrumentation for Java,
+you have to use a compatible API version. The Splunk distribution of 
+OpenTelemetry Java Instrumentation version 0.4.0 is compatible with the
+OpenTelemetry Instrumentation for Java version 0.12.0 and 0.12.1.
+
 ## Inject trace and span ID into logs
 
 Documentation on how to inject trace context into logs is available

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Documentation on how to manually instrument a Java application are available
 To extend the instrumentation with the OpenTelemetry Instrumentation for Java,
 you have to use a compatible API version. The Splunk distribution of 
 OpenTelemetry Java Instrumentation version 0.4.0 is compatible with the
-OpenTelemetry Instrumentation for Java version 0.12.0 and 0.12.1.
+OpenTelemetry Instrumentation for Java version 0.12.0 and API version 0.12.1.
 
 ## Inject trace and span ID into logs
 


### PR DESCRIPTION
- clarify that you need to use compatible API versions to extend Splunk distribution manual instrumentation
- specify compatible otel java versions