### PR TITLE
Fix snapshot builds.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ boolean snapshot = getProperty("snapshot") == 'yes'
 
 def versions = [
     'opentelemetry'         : snapshot ? "0.14.0-SNAPSHOT" : "0.13.1",
-    'opentelemetryJavaagent': snapshot ? "0.14.0-SNAPSHOT" : '0.13.0'
+    'opentelemetryJavaagent': snapshot ? "0.14.0-SNAPSHOT" : '0.13.1'
 ]
 
 subprojects {
@@ -38,6 +38,11 @@ subprojects {
       url = uri("https://oss.jfrog.org/artifactory/oss-snapshot-local")
     }
     mavenCentral()
+    if(snapshot){
+      maven {
+        url = uri("https://oss.sonatype.org/content/repositories/snapshots")
+      }
+    }
   }
 
   dependencies {


### PR DESCRIPTION
Upstream opentelemetry-java-instrumentation publishes snapshots to sonatype, so if we're doing a snapshot build let's include that repo.

The snapshot builds that are supposed to run 2 hours after the upstream builds have been failing, and I think this will fix that.