### PR TITLE
Expose resource attributes as system properties to use them in logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,27 @@ you have to use a compatible API version. The Splunk distribution of
 OpenTelemetry Java Instrumentation version 0.5.0 is compatible with the
 OpenTelemetry Instrumentation for Java version 0.13.0 and API version 0.13.1.
 
-## Inject trace and span ID into logs
+## Correlating traces with logs
+
+To correlate traces with logs it is possible to add both trace (`traceId` and `spanId`) and 
+resource (e.g., `service.name` and `environment` attributes of the 
+[Resource](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/sdk.md)) contexts.
 
 Documentation on how to inject trace context into logs is available
 [here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/docs/logger-mdc-instrumentation.md).
+
+To log resource context, Splunk distribution exposes resource attributes as system properties prefixed with `otel.resource.`
+which can be used in logger configuration.
+Example configuration for log4j pattern:
+```xml
+<PatternLayout>
+  <pattern>service: ${sys:otel.resource.service.name}, env: ${sys:otel.resource.environment} %m%n</pattern>
+</PatternLayout>
+```
+or logback pattern:
+```xml
+<pattern>service: %property{otel.resource.service.name}, env: %property{otel.resource.environment}: %m%n</pattern>
+```
 
 ## Troubleshooting
 

--- a/custom/src/main/java/com/splunk/opentelemetry/middleware/MiddlewareAttributeSpanProcessor.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/middleware/MiddlewareAttributeSpanProcessor.java
@@ -30,14 +30,12 @@ public class MiddlewareAttributeSpanProcessor implements SpanProcessor {
   public void onStart(Context parentContext, ReadWriteSpan span) {
     String middlewareName = MiddlewareHolder.middlewareName.get();
     String middlewareVersion = MiddlewareHolder.middlewareVersion.get();
-    // Getting span kind is not the most straightforward or cheap operation apparently.
-    // TODO: Once this PR is merged and released, use span.getKind directly:
-    //    https://github.com/open-telemetry/opentelemetry-java/pull/2162
-    // Let's do quick cheap null checks first and exit quickly.
+
     if ((middlewareName == null && middlewareVersion == null)
-        || span.toSpanData().getKind() != Span.Kind.SERVER) {
+        || span.getKind() != Span.Kind.SERVER) {
       return;
     }
+
     if (middlewareName != null) {
       span.setAttribute(MiddlewareAttributes.MIDDLEWARE_NAME.key, middlewareName);
     }

--- a/custom/src/main/java/com/splunk/opentelemetry/resource/ResourceAttributesToSystemProperties.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/resource/ResourceAttributesToSystemProperties.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.resource;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.api.common.AttributeType;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.javaagent.spi.ComponentInstaller;
+import io.opentelemetry.sdk.resources.Resource;
+
+/**
+ * This component exposes String resource attributes as system properties with <code>otel.resource.
+ * </code> prefix. Resource attributes represented as separate system properties then can be used by
+ * logging frameworks to add resource attributes to logs without any additional instrumentation or
+ * integration code by just using standard ways to access system properties in logging patterns.
+ */
+@AutoService(ComponentInstaller.class)
+public class ResourceAttributesToSystemProperties implements ComponentInstaller {
+
+  @Override
+  public void beforeByteBuddyAgent() {}
+
+  @Override
+  public void afterByteBuddyAgent() {
+    Attributes attributes = Resource.getDefault().getAttributes();
+    attributes.forEach(
+        (k, v) -> {
+          if (k.getType() == AttributeType.STRING) {
+            System.setProperty("otel.resource." + k.getKey(), v.toString());
+          }
+        });
+  }
+}

--- a/instrumentation/compile-stub/README.md
+++ b/instrumentation/compile-stub/README.md
@@ -1,4 +1,4 @@
 # Compile stubs
 In case instrumentation code needs a class from the instrumented library that is not available in a public repository you can add a stub class that has the methods called from integration code to this module.
 
-This module is used only as a compile time dependency.
+This module is used only as a compile-time dependency.

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/AppServerTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/AppServerTest.java
@@ -48,7 +48,7 @@ public abstract class AppServerTest extends SmokeTest {
 
     Set<String> traceIds = traces.getTraceIds();
 
-    Assertions.assertEquals(traceIds.size(), 1, "There is one trace");
+    Assertions.assertEquals(1, traceIds.size(), "There is one trace");
     String theOneTraceId = new ArrayList<>(traceIds).get(0);
 
     String responseBody = response.body().string();

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/SmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/SmokeTest.java
@@ -51,7 +51,7 @@ import org.testcontainers.containers.wait.strategy.WaitStrategy;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
-abstract class SmokeTest {
+public abstract class SmokeTest {
   private static final Logger logger = LoggerFactory.getLogger(SmokeTest.class);
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -59,7 +59,7 @@ abstract class SmokeTest {
   protected static OkHttpClient client = OkHttpUtils.client();
 
   private static final Network network = Network.newNetwork();
-  protected static final String agentPath =
+  public static final String agentPath =
       System.getProperty("io.opentelemetry.smoketest.agent.shadowJar.path");
 
   protected boolean localDockerImageIsPresent(String imageName) {

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/logger/LoggerTestMain.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/logger/LoggerTestMain.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.logger;
+
+import org.slf4j.LoggerFactory;
+
+public class LoggerTestMain {
+  public static void main(String[] args) {
+    LoggerFactory.getLogger("LoggerIntegrationTest").trace("This is an important message");
+  }
+}

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/logger/ResourceAttributesForLoggingTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/logger/ResourceAttributesForLoggingTest.java
@@ -20,8 +20,6 @@ import com.splunk.opentelemetry.SmokeTest;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
@@ -61,7 +59,7 @@ public class ResourceAttributesForLoggingTest {
 
   private Process startProcessWithJavaagent() throws IOException {
     File javaBinary = new File(System.getProperty("java.home"), "bin/java");
-    String javaagent = "-javaagent:s" + SmokeTest.agentPath;
+    String javaagent = "-javaagent:" + SmokeTest.agentPath;
     String resourceAttributes =
         "-Dotel.resource.attributes=service.name=MyService,environment=development";
     String classpath = System.getProperty("java.class.path");
@@ -77,13 +75,5 @@ public class ResourceAttributesForLoggingTest {
     System.out.println(String.join(" ", strings));
     processBuilder.command(strings);
     return processBuilder.start();
-  }
-
-  private void transfer(InputStream from, OutputStream to) throws IOException {
-    byte[] buffer = new byte[65535];
-    int read;
-    while ((read = from.read(buffer, 0, buffer.length)) >= 0) {
-      to.write(buffer, 0, read);
-    }
   }
 }

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/logger/ResourceAttributesForLoggingTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/logger/ResourceAttributesForLoggingTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.logger;
+
+import com.splunk.opentelemetry.SmokeTest;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Main feature why we expose resource attributes as system properties is to be able to use them in
+ * logs. This is a smoke test, because there are several moving parts involved. If everything
+ * together doesn't work, there is no point in any simpler unit/integration test.
+ */
+public class ResourceAttributesForLoggingTest {
+
+  @Test
+  void resourceAttributesCanBeLogged() throws IOException, InterruptedException {
+    Assumptions.assumeTrue(SmokeTest.agentPath != null, "Agent path is specified");
+
+    Process process = startProcessWithJavaagent();
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    transfer(process.getInputStream(), out);
+    ByteArrayOutputStream err = new ByteArrayOutputStream();
+    transfer(process.getErrorStream(), err);
+
+    Assertions.assertTrue(process.waitFor(30L, TimeUnit.SECONDS), "Process exited");
+
+    int exitValue = process.exitValue();
+    if (exitValue != 0) {
+      System.err.println(err.toString());
+    }
+    Assertions.assertEquals(0, exitValue, "Process exited normally");
+    String stdout = out.toString();
+    Assertions.assertTrue(
+        stdout.contains(
+            "LoggerIntegrationTest - service=MyService, env=development: This is an important message"),
+        "Process output `" + stdout + "` contains log line with expected resource attributes");
+  }
+
+  private Process startProcessWithJavaagent() throws IOException {
+    File javaBinary = new File(System.getProperty("java.home"), "bin/java");
+    String javaagent = "-javaagent:" + SmokeTest.agentPath;
+    String resourceAttributes =
+        "-Dotel.resource.attributes=service.name=MyService,environment=development";
+    String classpath = System.getProperty("java.class.path");
+    String[] strings = {
+      javaBinary.getAbsolutePath(),
+      javaagent,
+      resourceAttributes,
+      "-cp",
+      classpath,
+      LoggerTestMain.class.getName()
+    };
+    ProcessBuilder processBuilder = new ProcessBuilder();
+    System.out.println(String.join(" ", strings));
+    processBuilder.command(strings);
+    return processBuilder.start();
+  }
+
+  private void transfer(InputStream from, OutputStream to) throws IOException {
+    byte[] buffer = new byte[65535];
+    int read;
+    while ((read = from.read(buffer, 0, buffer.length)) >= 0) {
+      to.write(buffer, 0, read);
+    }
+  }
+}

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/logger/ResourceAttributesForLoggingTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/logger/ResourceAttributesForLoggingTest.java
@@ -41,17 +41,17 @@ public class ResourceAttributesForLoggingTest {
     Process process = startProcessWithJavaagent();
 
     ByteArrayOutputStream out = new ByteArrayOutputStream();
-    transfer(process.getInputStream(), out);
+    process.getInputStream().transferTo(out);
     ByteArrayOutputStream err = new ByteArrayOutputStream();
-    transfer(process.getErrorStream(), err);
+    process.getErrorStream().transferTo(err);
 
     Assertions.assertTrue(process.waitFor(30L, TimeUnit.SECONDS), "Process exited");
 
-    int exitValue = process.exitValue();
-    if (exitValue != 0) {
-      System.err.println(err.toString());
-    }
-    Assertions.assertEquals(0, exitValue, "Process exited normally");
+    Assertions.assertEquals(
+        0,
+        process.exitValue(),
+        "Unexpected exit code. Process exited with stderr: \n" + err.toString());
+
     String stdout = out.toString();
     Assertions.assertTrue(
         stdout.contains(
@@ -61,7 +61,7 @@ public class ResourceAttributesForLoggingTest {
 
   private Process startProcessWithJavaagent() throws IOException {
     File javaBinary = new File(System.getProperty("java.home"), "bin/java");
-    String javaagent = "-javaagent:" + SmokeTest.agentPath;
+    String javaagent = "-javaagent:s" + SmokeTest.agentPath;
     String resourceAttributes =
         "-Dotel.resource.attributes=service.name=MyService,environment=development";
     String classpath = System.getProperty("java.class.path");

--- a/smoke-tests/src/test/resources/logback.xml
+++ b/smoke-tests/src/test/resources/logback.xml
@@ -7,10 +7,22 @@
     </encoder>
   </appender>
 
+  <!-- used by com.splunk.opentelemetry.logger.LoggerTestMain -->
+  <appender name="consoleWithResource" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%logger - service=%property{otel.resource.service.name}, env=%property{otel.resource.environment}: %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="LoggerIntegrationTest" level="trace">
+    <appender-ref ref="consoleWithResource"/>
+  </logger>
+
   <root level="INFO">
     <appender-ref ref="console"/>
   </root>
 
+  <logger name="LoggerIntegrationTest" level="trace"/>
   <logger name="io.opentelemetry" level="debug"/>
   <logger name="com.splunk" level="debug"/>
 


### PR DESCRIPTION
Correlating logs with traces requires logging at least some resource attributes. From the agent point of view, proposed solution imposes the least performance overhead, as it requires no constant run-time overhead whatsoever and properties can be access from all major logging frameworks directly.