### PR TITLE
Explicitly include guava version to avoid conflicts with upstream.

### DIFF
--- a/custom/build.gradle
+++ b/custom/build.gradle
@@ -11,9 +11,9 @@ dependencies {
   implementation("io.opentelemetry:opentelemetry-exporter-jaeger-thrift:${versions["opentelemetry"]}")
   implementation("io.opentelemetry.javaagent:opentelemetry-javaagent-spi:${versions["opentelemetryJavaagent"]}")
   implementation("io.jaegertracing:jaeger-client:1.5.0")
-  annotationProcessor("com.google.auto.service:auto-service:1.0-rc3")
+  annotationProcessor("com.google.auto.service:auto-service:1.0-rc7")
   annotationProcessor("com.google.auto:auto-common:0.8")
-  implementation("com.google.auto.service:auto-service:1.0-rc3")
+  implementation("com.google.auto.service:auto-service:1.0-rc7")
   implementation("com.google.auto:auto-common:0.8")
 }
 

--- a/custom/build.gradle
+++ b/custom/build.gradle
@@ -11,10 +11,11 @@ dependencies {
   implementation("io.opentelemetry:opentelemetry-exporter-jaeger-thrift:${versions["opentelemetry"]}")
   implementation("io.opentelemetry.javaagent:opentelemetry-javaagent-spi:${versions["opentelemetryJavaagent"]}")
   implementation("io.jaegertracing:jaeger-client:1.5.0")
-  annotationProcessor("com.google.auto.service:auto-service:1.0-rc7")
+  annotationProcessor("com.google.auto.service:auto-service:1.0-rc3")
   annotationProcessor("com.google.auto:auto-common:0.8")
-  implementation("com.google.auto.service:auto-service:1.0-rc7")
+  implementation("com.google.auto.service:auto-service:1.0-rc3")
   implementation("com.google.auto:auto-common:0.8")
+  implementation("com.google.guava:guava:29.0-android")
 }
 
 tasks {

--- a/instrumentation/build.gradle
+++ b/instrumentation/build.gradle
@@ -15,9 +15,9 @@ subprojects {
                 compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-api:${versions.opentelemetryJavaagent}")
                 compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-spi:${versions.opentelemetryJavaagent}")
                 compileOnly("net.bytebuddy:byte-buddy:1.10.10")
-                annotationProcessor("com.google.auto.service:auto-service:1.0-rc3")
+                annotationProcessor("com.google.auto.service:auto-service:1.0-rc7")
                 annotationProcessor("com.google.auto:auto-common:0.8")
-                implementation("com.google.auto.service:auto-service:1.0-rc3")
+                implementation("com.google.auto.service:auto-service:1.0-rc7")
                 implementation("com.google.auto:auto-common:0.8")
                 compileOnly(project(":bootstrap"))
             }

--- a/instrumentation/build.gradle
+++ b/instrumentation/build.gradle
@@ -15,9 +15,10 @@ subprojects {
                 compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-api:${versions.opentelemetryJavaagent}")
                 compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-spi:${versions.opentelemetryJavaagent}")
                 compileOnly("net.bytebuddy:byte-buddy:1.10.10")
-                annotationProcessor("com.google.auto.service:auto-service:1.0-rc7")
+                annotationProcessor("com.google.auto.service:auto-service:1.0-rc3")
                 annotationProcessor("com.google.auto:auto-common:0.8")
-                implementation("com.google.auto.service:auto-service:1.0-rc7")
+                implementation("com.google.auto.service:auto-service:1.0-rc3")
+                implementation("com.google.guava:guava:29.0-android")
                 implementation("com.google.auto:auto-common:0.8")
                 compileOnly(project(":bootstrap"))
             }


### PR DESCRIPTION
This old version caused an old version of `Preconditions` to sneak into the shadowed jar -- which, especially when combined with #79, made the agent startup fail when configured with oltp exporter.