### PR TITLE
Collect WebLogic specific attributes

### DIFF
--- a/instrumentation/weblogic/build.gradle
+++ b/instrumentation/weblogic/build.gradle
@@ -1,0 +1,7 @@
+plugins {
+  id "java"
+}
+
+dependencies {
+  compileOnly('javax.servlet:servlet-api:2.2')
+}

--- a/instrumentation/weblogic/src/main/java/com/splunk/opentelemetry/middleware/weblogic/WebLogicAttributeCollector.java
+++ b/instrumentation/weblogic/src/main/java/com/splunk/opentelemetry/middleware/weblogic/WebLogicAttributeCollector.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.middleware.weblogic;
+
+import com.splunk.opentelemetry.javaagent.bootstrap.MiddlewareHolder;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+
+public class WebLogicAttributeCollector {
+  private static final String CONTEXT_ATTRIBUTE_NAME = "otel.weblogic.attributes";
+  public static final String REQUEST_ATTRIBUTE_NAME = "otel.middleware";
+
+  public static void attachMiddlewareAttributes(HttpServletRequest servletRequest) {
+    WebLogicEntity.Request request = WebLogicEntity.Request.wrap(servletRequest);
+
+    Map<?, ?> attributes = fetchMiddlewareAttributes(request.getContext());
+    request.instance.setAttribute(REQUEST_ATTRIBUTE_NAME, attributes);
+  }
+
+  private static Map<?, ?> fetchMiddlewareAttributes(WebLogicEntity.Context context) {
+    if (context.instance == null) {
+      return null;
+    }
+
+    Object value = context.instance.getAttribute(CONTEXT_ATTRIBUTE_NAME);
+
+    if (value instanceof Map<?, ?>) {
+      return (Map<?, ?>) value;
+    }
+
+    // Do this here to avoid duplicate work
+    storeMiddlewareIdentity(context);
+
+    Map<String, String> middleware = collectMiddlewareAttributes(context);
+    context.instance.setAttribute(CONTEXT_ATTRIBUTE_NAME, middleware);
+    return middleware;
+  }
+
+  private static void storeMiddlewareIdentity(WebLogicEntity.Context context) {
+    MiddlewareHolder.trySetName("WebLogic Server");
+    MiddlewareHolder.trySetVersion(detectVersion(context));
+  }
+
+  private static Map<String, String> collectMiddlewareAttributes(WebLogicEntity.Context context) {
+    WebLogicEntity.Bean applicationBean = context.getBean();
+    WebLogicEntity.Bean webServerBean = context.getServer().getBean();
+    WebLogicEntity.Bean serverBean = webServerBean.getParent();
+    WebLogicEntity.Bean clusterBean = WebLogicEntity.Bean.wrap(serverBean.getAttribute("Cluster"));
+    WebLogicEntity.Bean domainBean = serverBean.getParent();
+
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put("middleware.weblogic.domain", domainBean.getName());
+    attributes.put("middleware.weblogic.cluster", clusterBean.getName());
+    attributes.put("middleware.weblogic.server", webServerBean.getName());
+    attributes.put("middleware.weblogic.application", applicationBean.getName());
+
+    return attributes;
+  }
+
+  private static String detectVersion(WebLogicEntity.Context context) {
+    String serverInfo = context.instance.getServerInfo();
+
+    if (serverInfo != null) {
+      for (String token : serverInfo.split(" ")) {
+        if (token.length() > 0 && Character.isDigit(token.charAt(0))) {
+          return token;
+        }
+      }
+    }
+
+    return "";
+  }
+}

--- a/instrumentation/weblogic/src/main/java/com/splunk/opentelemetry/middleware/weblogic/WebLogicEntity.java
+++ b/instrumentation/weblogic/src/main/java/com/splunk/opentelemetry/middleware/weblogic/WebLogicEntity.java
@@ -232,8 +232,8 @@ public class WebLogicEntity {
 
     public static Bean wrap(Object instance) {
       return instance != null
-          && MBEAN_CLASS != null
-          && MBEAN_CLASS.isAssignableFrom(instance.getClass())
+              && MBEAN_CLASS != null
+              && MBEAN_CLASS.isAssignableFrom(instance.getClass())
           ? new Bean(instance)
           : NULL;
     }

--- a/instrumentation/weblogic/src/main/java/com/splunk/opentelemetry/middleware/weblogic/WebLogicEntity.java
+++ b/instrumentation/weblogic/src/main/java/com/splunk/opentelemetry/middleware/weblogic/WebLogicEntity.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.middleware.weblogic;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletRequest;
+
+/** Provides wrappers around WebLogic internal class instances. */
+public class WebLogicEntity {
+  private static final MethodHandle REQUEST_GET_CONTEXT;
+  private static final MethodHandle CONTEXT_GET_MBEAN;
+  private static final MethodHandle CONTEXT_GET_SERVER;
+  private static final MethodHandle SERVER_GET_MBEAN;
+  private static final MethodHandle MBEAN_GET_PARENT;
+  private static final MethodHandle MBEAN_GET_KEY;
+  private static final Class<?> MBEAN_CLASS;
+  private static final MethodHandle MBEAN_GET_ATTRIBUTE;
+
+  static {
+    MethodHandle requestGetContext;
+    MethodHandle contextGetMBean;
+    MethodHandle contextGetServer;
+    MethodHandle serverGetMBean;
+    MethodHandle mbeanGetParent;
+    MethodHandle mbeanGetKey;
+    MethodHandle mbeanGetAttribute;
+    Class<?> mbeanClass;
+
+    try {
+      requestGetContext =
+          MethodHandles.publicLookup()
+              .findVirtual(
+                  Class.forName("weblogic.servlet.internal.ServletRequestImpl"),
+                  "getContext",
+                  MethodType.methodType(
+                      Class.forName("weblogic.servlet.internal.WebAppServletContext")));
+    } catch (Exception e) {
+      requestGetContext = null;
+    }
+
+    REQUEST_GET_CONTEXT = requestGetContext;
+
+    try {
+      contextGetMBean =
+          MethodHandles.publicLookup()
+              .findVirtual(
+                  Class.forName("weblogic.servlet.internal.WebAppServletContext"),
+                  "getMBean",
+                  MethodType.methodType(
+                      Class.forName("weblogic.management.configuration.WebAppComponentMBean")));
+    } catch (Exception e) {
+      contextGetMBean = null;
+    }
+
+    CONTEXT_GET_MBEAN = contextGetMBean;
+
+    try {
+      contextGetServer =
+          MethodHandles.publicLookup()
+              .findVirtual(
+                  Class.forName("weblogic.servlet.internal.WebAppServletContext"),
+                  "getServer",
+                  MethodType.methodType(Class.forName("weblogic.servlet.internal.HttpServer")));
+    } catch (Exception e) {
+      contextGetServer = null;
+    }
+
+    CONTEXT_GET_SERVER = contextGetServer;
+
+    try {
+      serverGetMBean =
+          MethodHandles.publicLookup()
+              .findVirtual(
+                  Class.forName("weblogic.servlet.internal.HttpServer"),
+                  "getMBean",
+                  MethodType.methodType(
+                      Class.forName("weblogic.management.configuration.WebServerMBean")));
+    } catch (Exception e) {
+      serverGetMBean = null;
+    }
+
+    SERVER_GET_MBEAN = serverGetMBean;
+
+    try {
+      mbeanGetParent =
+          MethodHandles.publicLookup()
+              .findVirtual(
+                  Class.forName("weblogic.descriptor.DescriptorBean"),
+                  "getParentBean",
+                  MethodType.methodType(Class.forName("weblogic.descriptor.DescriptorBean")));
+    } catch (Exception e) {
+      mbeanGetParent = null;
+    }
+
+    MBEAN_GET_PARENT = mbeanGetParent;
+
+    try {
+      mbeanGetKey =
+          MethodHandles.publicLookup()
+              .findVirtual(
+                  Class.forName("weblogic.descriptor.internal.AbstractDescriptorBean"),
+                  "_getKey",
+                  MethodType.methodType(Object.class));
+    } catch (Exception e) {
+      mbeanGetKey = null;
+    }
+
+    MBEAN_GET_KEY = mbeanGetKey;
+
+    try {
+      mbeanGetAttribute =
+          MethodHandles.publicLookup()
+              .findVirtual(
+                  Class.forName("javax.management.DynamicMBean"),
+                  "getAttribute",
+                  MethodType.methodType(Object.class, String.class));
+    } catch (Exception e) {
+      mbeanGetAttribute = null;
+    }
+
+    MBEAN_GET_ATTRIBUTE = mbeanGetAttribute;
+
+    try {
+      mbeanClass = Class.forName("weblogic.management.WebLogicMBean");
+    } catch (Exception e) {
+      mbeanClass = null;
+    }
+
+    MBEAN_CLASS = mbeanClass;
+  }
+
+  public static class Request {
+    private static final Request NULL = new Request(null);
+
+    public final ServletRequest instance;
+
+    private Request(ServletRequest instance) {
+      this.instance = instance;
+    }
+
+    public static Request wrap(ServletRequest instance) {
+      return instance != null ? new Request(instance) : NULL;
+    }
+
+    public Context getContext() {
+      try {
+        return Context.wrap(
+            REQUEST_GET_CONTEXT != null ? REQUEST_GET_CONTEXT.invoke(instance) : null);
+      } catch (Throwable throwable) {
+        return Context.NULL;
+      }
+    }
+  }
+
+  public static class Context {
+    private static final Context NULL = new Context(null);
+
+    public final ServletContext instance;
+
+    private Context(ServletContext instance) {
+      this.instance = instance;
+    }
+
+    public static Context wrap(Object instance) {
+      return instance instanceof ServletContext ? new Context((ServletContext) instance) : NULL;
+    }
+
+    public Bean getBean() {
+      try {
+        return Bean.wrap(CONTEXT_GET_MBEAN != null ? CONTEXT_GET_MBEAN.invoke(instance) : null);
+      } catch (Throwable throwable) {
+        return Bean.NULL;
+      }
+    }
+
+    public Server getServer() {
+      try {
+        return Server.wrap(CONTEXT_GET_SERVER != null ? CONTEXT_GET_SERVER.invoke(instance) : null);
+      } catch (Throwable throwable) {
+        return Server.NULL;
+      }
+    }
+  }
+
+  public static class Server {
+    private static final Server NULL = new Server(null);
+
+    public final Object instance;
+
+    private Server(Object instance) {
+      this.instance = instance;
+    }
+
+    public static Server wrap(Object instance) {
+      return instance != null ? new Server(instance) : NULL;
+    }
+
+    public Bean getBean() {
+      try {
+        return Bean.wrap(SERVER_GET_MBEAN != null ? SERVER_GET_MBEAN.invoke(instance) : null);
+      } catch (Throwable throwable) {
+        return Bean.NULL;
+      }
+    }
+  }
+
+  public static class Bean {
+    private static final Bean NULL = new Bean(null);
+
+    public final Object instance;
+
+    private Bean(Object instance) {
+      this.instance = instance;
+    }
+
+    public static Bean wrap(Object instance) {
+      return instance != null
+          && MBEAN_CLASS != null
+          && MBEAN_CLASS.isAssignableFrom(instance.getClass())
+          ? new Bean(instance)
+          : NULL;
+    }
+
+    public String getName() {
+      try {
+        Object key = MBEAN_GET_KEY != null ? MBEAN_GET_KEY.invoke(instance) : null;
+        return key != null ? key.toString() : null;
+      } catch (Throwable throwable) {
+        return null;
+      }
+    }
+
+    public Bean getParent() {
+      try {
+        return Bean.wrap(MBEAN_GET_PARENT != null ? MBEAN_GET_PARENT.invoke(instance) : null);
+      } catch (Throwable throwable) {
+        return Bean.NULL;
+      }
+    }
+
+    public Object getAttribute(String name) {
+      try {
+        return MBEAN_GET_ATTRIBUTE != null ? MBEAN_GET_ATTRIBUTE.invoke(instance, name) : null;
+      } catch (Throwable throwable) {
+        return null;
+      }
+    }
+  }
+}

--- a/instrumentation/weblogic/src/main/java/com/splunk/opentelemetry/middleware/weblogic/WebLogicInstrumentationModule.java
+++ b/instrumentation/weblogic/src/main/java/com/splunk/opentelemetry/middleware/weblogic/WebLogicInstrumentationModule.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.middleware.weblogic;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge;
+import io.opentelemetry.javaagent.tooling.InstrumentationModule;
+import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.AgentElementMatchers.extendsClass;
+import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.ClassLoaderMatcher.hasClassesNamed;
+import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.isPrivate;
+import static net.bytebuddy.matcher.ElementMatchers.isProtected;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+/**
+ * Adds an instrumentation to collect middleware attributes for WebLogic Server 12 and 14. As span
+ * detection on WebLogic does not require any special logic, this does not initiate servlet spans by
+ * itself, but saves the special attributes as a map to a servlet request attribute, which is then
+ * later read when span is started by generic servlet instrumentation.
+ */
+@AutoService(InstrumentationModule.class)
+public class WebLogicInstrumentationModule extends InstrumentationModule {
+  public WebLogicInstrumentationModule() {
+    super("weblogic");
+  }
+
+  @Override
+  public int getOrder() {
+    // Make sure this runs after default servlet instrumentations so that server span would already be available.
+    return 1;
+  }
+
+  @Override
+  public List<TypeInstrumentation> typeInstrumentations() {
+    return Arrays.asList(
+        new MiddlewareInstrumentation(),
+        new ServletInstrumentation()
+    );
+  }
+
+  private static class MiddlewareInstrumentation implements TypeInstrumentation {
+    @Override
+    public ElementMatcher<? super TypeDescription> typeMatcher() {
+      return named("weblogic.servlet.internal.WebAppServletContext$ServletInvocationAction");
+    }
+
+    @Override
+    public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
+      return singletonMap(
+          named("wrapRun")
+              .and(takesArgument(1, named("javax.servlet.http.HttpServletRequest")))
+              .and(isPrivate()),
+          WebLogicInstrumentationModule.class.getName() + "$MiddlewareAdvice");
+    }
+  }
+
+  private static class MiddlewareAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void start(@Advice.Argument(1) HttpServletRequest servletRequest) {
+      WebLogicAttributeCollector.attachMiddlewareAttributes(servletRequest);
+    }
+  }
+
+  private static class ServletInstrumentation implements TypeInstrumentation {
+    @Override
+    public ElementMatcher<ClassLoader> classLoaderOptimization() {
+      return hasClassesNamed("javax.servlet.http.HttpServlet");
+    }
+
+    @Override
+    public ElementMatcher<TypeDescription> typeMatcher() {
+      return extendsClass(named("javax.servlet.http.HttpServlet"));
+    }
+
+    @Override
+    public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
+      return singletonMap(
+          named("service")
+              .or(nameStartsWith("do")) // doGet, doPost, etc
+              .and(takesArgument(0, named("javax.servlet.http.HttpServletRequest")))
+              .and(takesArgument(1, named("javax.servlet.http.HttpServletResponse")))
+              .and(isProtected().or(isPublic())),
+          WebLogicInstrumentationModule.class.getName() + "$ServletAdvice");
+    }
+  }
+
+  private static class ServletAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void start(
+        @Advice.Argument(value = 0, readOnly = false) HttpServletRequest request) {
+      Object value = request.getAttribute("otel.middleware");
+
+      if (value instanceof Map<?, ?>) {
+        Span span = Java8BytecodeBridge.currentSpan();
+
+        if (span != null) {
+          for (Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
+            if (entry.getValue() != null) {
+              span.setAttribute(entry.getKey().toString(), entry.getValue().toString());
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @Override
+  protected String[] additionalHelperClassNames() {
+    String packageName = this.getClass().getPackage().getName();
+
+    return new String[] {
+        packageName + ".WebLogicAttributeCollector",
+        packageName + ".WebLogicEntity",
+        packageName + ".WebLogicEntity$Request",
+        packageName + ".WebLogicEntity$Context",
+        packageName + ".WebLogicEntity$Server",
+        packageName + ".WebLogicEntity$Bean"
+    };
+  }
+}

--- a/instrumentation/weblogic/src/main/java/com/splunk/opentelemetry/middleware/weblogic/WebLogicInstrumentationModule.java
+++ b/instrumentation/weblogic/src/main/java/com/splunk/opentelemetry/middleware/weblogic/WebLogicInstrumentationModule.java
@@ -16,6 +16,16 @@
 
 package com.splunk.opentelemetry.middleware.weblogic;
 
+import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.AgentElementMatchers.extendsClass;
+import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.ClassLoaderMatcher.hasClassesNamed;
+import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.isPrivate;
+import static net.bytebuddy.matcher.ElementMatchers.isProtected;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
 import com.google.auto.service.AutoService;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge;
@@ -29,16 +39,6 @@ import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-
-import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.AgentElementMatchers.extendsClass;
-import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.ClassLoaderMatcher.hasClassesNamed;
-import static java.util.Collections.singletonMap;
-import static net.bytebuddy.matcher.ElementMatchers.isPrivate;
-import static net.bytebuddy.matcher.ElementMatchers.isProtected;
-import static net.bytebuddy.matcher.ElementMatchers.isPublic;
-import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
-import static net.bytebuddy.matcher.ElementMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 /**
  * Adds an instrumentation to collect middleware attributes for WebLogic Server 12 and 14. As span
@@ -54,16 +54,14 @@ public class WebLogicInstrumentationModule extends InstrumentationModule {
 
   @Override
   public int getOrder() {
-    // Make sure this runs after default servlet instrumentations so that server span would already be available.
+    // Make sure this runs after default servlet instrumentations so that server span would already
+    // be available.
     return 1;
   }
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return Arrays.asList(
-        new MiddlewareInstrumentation(),
-        new ServletInstrumentation()
-    );
+    return Arrays.asList(new MiddlewareInstrumentation(), new ServletInstrumentation());
   }
 
   private static class MiddlewareInstrumentation implements TypeInstrumentation {
@@ -137,12 +135,12 @@ public class WebLogicInstrumentationModule extends InstrumentationModule {
     String packageName = this.getClass().getPackage().getName();
 
     return new String[] {
-        packageName + ".WebLogicAttributeCollector",
-        packageName + ".WebLogicEntity",
-        packageName + ".WebLogicEntity$Request",
-        packageName + ".WebLogicEntity$Context",
-        packageName + ".WebLogicEntity$Server",
-        packageName + ".WebLogicEntity$Bean"
+      packageName + ".WebLogicAttributeCollector",
+      packageName + ".WebLogicEntity",
+      packageName + ".WebLogicEntity$Request",
+      packageName + ".WebLogicEntity$Context",
+      packageName + ".WebLogicEntity$Server",
+      packageName + ".WebLogicEntity$Bean"
     };
   }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,6 +18,7 @@ include("agent",
   "instrumentation:glassfish",
   "instrumentation:liberty",
   "instrumentation:tomcat",
+  "instrumentation:weblogic",
   "instrumentation:wildfly",
   "smoke-tests",
   "matrix")

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/WebLogicSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/WebLogicSmokeTest.java
@@ -46,15 +46,18 @@ class WebLogicSmokeTest extends AppServerTest {
         arguments(proprietaryLinuxImage("splunk-weblogic:12.1.3-jdkdeveloper"), V12_1_ATTRIBUTES),
         arguments(proprietaryLinuxImage("splunk-weblogic:12.2.1.4-jdkdeveloper"), V12_2_ATTRIBUTES),
         arguments(proprietaryLinuxImage("splunk-weblogic:14.1.1.0-jdkdeveloper-8"), V14_ATTRIBUTES),
-        arguments(proprietaryLinuxImage("splunk-weblogic:14.1.1.0-jdkdeveloper-11"), V14_ATTRIBUTES));
+        arguments(
+            proprietaryLinuxImage("splunk-weblogic:14.1.1.0-jdkdeveloper-11"), V14_ATTRIBUTES));
   }
 
   @ParameterizedTest
   @MethodSource("supportedWlsConfigurations")
-  public void webLogicSmokeTest(TestImage image, ExpectedServerAttributes serverAttributes) throws IOException, InterruptedException {
+  public void webLogicSmokeTest(TestImage image, ExpectedServerAttributes serverAttributes)
+      throws IOException, InterruptedException {
     startTargetOrSkipTest(image);
 
-    // No assertServerHandler as there are no current plans to have a WebLogic server handler that creates spans
+    // No assertServerHandler as there are no current plans to have a WebLogic server handler that
+    // creates spans
     assertWebAppTrace(serverAttributes, image);
 
     stopTarget();

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/WebLogicSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/WebLogicSmokeTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import com.splunk.opentelemetry.helper.TestImage;
 import java.io.IOException;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -33,27 +34,28 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 class WebLogicSmokeTest extends AppServerTest {
 
-  // FIXME: awaiting https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/1630
-  private static final AppServerTest.ExpectedServerAttributes WEBLOGIC_ATTRIBUTES =
-      new AppServerTest.ExpectedServerAttributes("", "", "");
+  private static final AppServerTest.ExpectedServerAttributes V12_1_ATTRIBUTES =
+      new AppServerTest.ExpectedServerAttributes("", "WebLogic Server", "12.1.3.0.0");
+  private static final AppServerTest.ExpectedServerAttributes V12_2_ATTRIBUTES =
+      new AppServerTest.ExpectedServerAttributes("", "WebLogic Server", "12.2.1.4.0");
+  private static final AppServerTest.ExpectedServerAttributes V14_ATTRIBUTES =
+      new AppServerTest.ExpectedServerAttributes("", "WebLogic Server", "14.1.1.0.0");
 
   private static Stream<Arguments> supportedWlsConfigurations() {
     return Stream.of(
-        arguments(proprietaryLinuxImage("splunk-weblogic:12.1.3-jdkdeveloper")),
-        arguments(proprietaryLinuxImage("splunk-weblogic:12.2.1.4-jdkdeveloper")),
-        arguments(proprietaryLinuxImage("splunk-weblogic:14.1.1.0-jdkdeveloper-8")),
-        arguments(proprietaryLinuxImage("splunk-weblogic:14.1.1.0-jdkdeveloper-11")));
+        arguments(proprietaryLinuxImage("splunk-weblogic:12.1.3-jdkdeveloper"), V12_1_ATTRIBUTES),
+        arguments(proprietaryLinuxImage("splunk-weblogic:12.2.1.4-jdkdeveloper"), V12_2_ATTRIBUTES),
+        arguments(proprietaryLinuxImage("splunk-weblogic:14.1.1.0-jdkdeveloper-8"), V14_ATTRIBUTES),
+        arguments(proprietaryLinuxImage("splunk-weblogic:14.1.1.0-jdkdeveloper-11"), V14_ATTRIBUTES));
   }
 
   @ParameterizedTest
   @MethodSource("supportedWlsConfigurations")
-  public void webLogicSmokeTest(TestImage image) throws IOException, InterruptedException {
+  public void webLogicSmokeTest(TestImage image, ExpectedServerAttributes serverAttributes) throws IOException, InterruptedException {
     startTargetOrSkipTest(image);
 
-    // FIXME: APMI-1300
-    //    assertServerHandler(....)
-
-    assertWebAppTrace(WEBLOGIC_ATTRIBUTES, image);
+    // No assertServerHandler as there are no current plans to have a WebLogic server handler that creates spans
+    assertWebAppTrace(serverAttributes, image);
 
     stopTarget();
   }
@@ -61,7 +63,21 @@ class WebLogicSmokeTest extends AppServerTest {
   @Override
   protected void assertMiddlewareAttributesInWebAppTrace(
       ExpectedServerAttributes serverAttributes, TraceInspector traces) {
-    // FIXME: waiting for
-    // https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/1630
+    super.assertMiddlewareAttributesInWebAppTrace(serverAttributes, traces);
+
+    Assertions.assertEquals(
+        "domain1",
+        traces.getServerSpanAttribute("middleware.weblogic.domain"),
+        "WebLogic Domain attribute present");
+
+    Assertions.assertEquals(
+        "admin-server",
+        traces.getServerSpanAttribute("middleware.weblogic.server"),
+        "WebLogic Server attribute present");
+
+    Assertions.assertEquals(
+        "app",
+        traces.getServerSpanAttribute("middleware.weblogic.application"),
+        "WebLogic Application attribute present");
   }
 }


### PR DESCRIPTION
This adds collection of WebLogic-specific attributes to servlet spans, and also provides middleware name and version through `MiddlewareHolder`.

Sample output from the logging collector:
```
Attributes:
     -> middleware.name: STRING(WebLogic Server)
     -> middleware.version: STRING(12.2.1.4.0)
     -> middleware.weblogic.server: STRING(admin-server)
     -> middleware.weblogic.application: STRING(weblogic)
     -> middleware.weblogic.domain: STRING(domain1)
```

No spans are created at WebLogic instrumentation level (no custom logic required), so this adds an instrumentation that only collects the attribute values, stores them as a map into `otel.middleware` ServletRequest attribute. The map contents are copied over to the span in another instrumentation where the servlet span is currently active.

WebLogic classes are not published as a public dependency, therefore its classes are accessed with `Class.forName` and `MethodHandle` instead of compiling against its classes directly. These are resolved by `WebLogicEntity` during its static initialization, which also provides wrapper classes for WebLogic classes. As an optimization, the full set of attributes is not collected on every request, but they are cached to a servlet context attribute.