### PR TITLE
Testing all proprietary Docker images in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,13 @@ jobs:
         with:
           java-version: 11
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
       - name: Build and test
         run: ./gradlew pullProprietaryTestImages build --scan --no-daemon
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,8 @@ jobs:
           java-version: 11
 
       - name: Build and test
-        run: ./gradlew build --scan --no-daemon
+        run: ./gradlew pullProprietaryTestImages build --scan --no-daemon
+
   build_windows:
     runs-on: windows-latest
     steps:

--- a/matrix/build.gradle
+++ b/matrix/build.gradle
@@ -11,11 +11,8 @@ tasks {
   }
 }
 
-def versions = ext['versions']
-
 dependencies {
   implementation("javax.servlet:javax.servlet-api:3.0.1")
-  implementation("io.opentelemetry:opentelemetry-extension-annotations:${versions["opentelemetry"]}")
 }
 
 def buildProprietaryTestImagesTask = tasks.create("buildProprietaryTestImages") {
@@ -27,7 +24,7 @@ def proprietaryTargets = [
     "weblogic" : [
        "12.1.3" : ["developer"],
        "12.2.1.4" : ["developer"],
-        "14.1.1.0" : ["developer-8", "developer-11"]
+       "14.1.1.0" : ["developer-8", "developer-11"]
     ],
     "jboss-eap" : [
         "7.1.0" : ["8"],
@@ -96,7 +93,7 @@ def createDockerTasks(parentTask, targets, isWindows) {
           description = "Builds Docker image with $server $version on JDK $jdk"
 
           it.inputDir = dockerWorkingDir
-          it.images.add("splunk-$server:$version-jdk$jdk" + (isWindows ? "-windows" : ""))
+          it.images.add("ghcr.io/signalfx/splunk-otel-$server:$version-jdk$jdk" + (isWindows ? "-windows" : ""))
 
           it.buildArgs.set(["jdk": jdk] + versionInfo)
 

--- a/matrix/build.gradle
+++ b/matrix/build.gradle
@@ -1,4 +1,5 @@
 import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+import com.bmuschko.gradle.docker.tasks.image.DockerPullImage
 
 plugins {
   id 'war'
@@ -20,6 +21,9 @@ def buildProprietaryTestImagesTask = tasks.create("buildProprietaryTestImages") 
   description = "Builds all Docker images for the test matrix for proprietary app servers"
 }
 
+//Intentially left without group to remain hidden
+def pullProprietaryTestImagesTask = tasks.create("pullProprietaryTestImages")
+
 def proprietaryTargets = [
     "weblogic" : [
        "12.1.3" : ["developer"],
@@ -32,7 +36,7 @@ def proprietaryTargets = [
     ]
 ]
 
-createDockerTasks(buildProprietaryTestImagesTask, proprietaryTargets, false)
+createDockerTasks(buildProprietaryTestImagesTask, pullProprietaryTestImagesTask, proprietaryTargets, false)
 
 def buildWindowsTestImagesTask = tasks.create("buildWindowsTestImages") {
   group = "build"
@@ -62,9 +66,9 @@ def windowsTargets = [
     ]
 ]
 
-createDockerTasks(buildWindowsTestImagesTask, windowsTargets, true)
+createDockerTasks(buildWindowsTestImagesTask, null, windowsTargets, true)
 
-def createDockerTasks(parentTask, targets, isWindows) {
+def createDockerTasks(parentTask, Task parentPullTask, targets, isWindows) {
   def dockerWorkingDir = new File(project.buildDir, "docker")
 
   targets.forEach { server, data ->
@@ -87,20 +91,30 @@ def createDockerTasks(parentTask, targets, isWindows) {
           }
         }
 
+        def fullDockerImageName = "ghcr.io/signalfx/splunk-otel-$server:$version-jdk$jdk" + (isWindows ? "-windows" : "")
+
         def buildTask = tasks.register("${server}Image-$version-jdk$jdk", DockerBuildImage) {
           it.dependsOn(prepareTask)
           group = "build"
           description = "Builds Docker image with $server $version on JDK $jdk"
 
-          it.inputDir = dockerWorkingDir
-          it.images.add("ghcr.io/signalfx/splunk-otel-$server:$version-jdk$jdk" + (isWindows ? "-windows" : ""))
+          it.inputDir.set(dockerWorkingDir)
+          it.images.add(fullDockerImageName)
 
           it.buildArgs.set(["jdk": jdk] + versionInfo)
 
-          it.dockerFile = new File(dockerWorkingDir, dockerFileName)
+          it.dockerFile.set(new File(dockerWorkingDir, dockerFileName))
         }
 
         parentTask.dependsOn(buildTask)
+
+        if(parentPullTask != null){
+          def pullTask = tasks.register("${server}ImagePull-$version-jdk$jdk", DockerPullImage) {
+            it.image.set(fullDockerImageName)
+          }
+
+          parentPullTask.dependsOn(pullTask)
+        }
       }
     }
   }

--- a/matrix/src/jboss-eap.dockerfile
+++ b/matrix/src/jboss-eap.dockerfile
@@ -10,18 +10,15 @@ RUN groupadd -r jboss -g 1000 && useradd -u 1000 -r -g jboss -m -d /opt/jboss -s
     apt-get update && \
     apt-get install unzip
 
-# Set the working directory to jboss' user home directory
-
-# Specify the user which should be used to execute all commands below
-#USER jboss
-
 # Set the JBOSS_EAP_VERSION env variable
 ARG version
 ENV JBOSS_EAP_VERSION=${version}
+# Set the working directory to jboss' user home directory
 ENV JBOSS_HOME /opt/jboss/jboss-eap
 ENV JBOSS_INSTALL_DIR /opt/jboss
 
-#USER root
+# Specify the user which should be used to execute all commands below
+USER jboss
 COPY jboss-eap-${JBOSS_EAP_VERSION}.zip $JBOSS_INSTALL_DIR
 
 # Add the EAS distribution to /opt, and make wildfly the owner of the extracted tar content
@@ -30,13 +27,6 @@ COPY jboss-eap-${JBOSS_EAP_VERSION}.zip $JBOSS_INSTALL_DIR
 RUN unzip $JBOSS_INSTALL_DIR/jboss-eap-${JBOSS_EAP_VERSION}.zip -d $JBOSS_INSTALL_DIR \
     && rm $JBOSS_INSTALL_DIR/jboss-eap-${JBOSS_EAP_VERSION}.zip \
     && mv $JBOSS_INSTALL_DIR/jboss-eap-* $JBOSS_HOME
-
-COPY app.war ${JBOSS_HOME}/standalone/deployments/
-
-RUN chown -R jboss:0 ${JBOSS_HOME} \
-    && chmod -R g+rw ${JBOSS_HOME}
-
-USER jboss
 
 # Ensure signals are forwarded to the JVM process correctly for graceful shutdown
 ENV LAUNCH_JBOSS_IN_BACKGROUND true
@@ -50,3 +40,4 @@ EXPOSE 8080
 # This will boot WildFly in the standalone mode and bind to all interface
 CMD ["./bin/standalone.sh", "-b", "0.0.0.0"]
 
+COPY app.war ${JBOSS_HOME}/standalone/deployments/

--- a/matrix/src/main/java/com/splunk/opentelemetry/appservers/javaee/GreetingServlet.java
+++ b/matrix/src/main/java/com/splunk/opentelemetry/appservers/javaee/GreetingServlet.java
@@ -16,7 +16,6 @@
 
 package com.splunk.opentelemetry.appservers.javaee;
 
-import io.opentelemetry.extension.annotations.WithSpan;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -42,19 +41,13 @@ public class GreetingServlet extends HttpServlet {
       String responseBody = buffer.toString("UTF-8");
       ServletOutputStream outputStream = resp.getOutputStream();
       outputStream.print(
-          withSpan(
-              bytesRead
-                  + " bytes read by "
-                  + urlConnection.getClass().getName()
-                  + "\n"
-                  + responseBody));
+          bytesRead
+          + " bytes read by "
+          + urlConnection.getClass().getName()
+          + "\n"
+          + responseBody);
       outputStream.flush();
     }
-  }
-
-  @WithSpan
-  public String withSpan(String responseBody) {
-    return responseBody;
   }
 
   // We have to run on Java 8, so no Java 9 stream transfer goodies for us.

--- a/matrix/src/main/java/com/splunk/opentelemetry/appservers/javaee/GreetingServlet.java
+++ b/matrix/src/main/java/com/splunk/opentelemetry/appservers/javaee/GreetingServlet.java
@@ -41,11 +41,7 @@ public class GreetingServlet extends HttpServlet {
       String responseBody = buffer.toString("UTF-8");
       ServletOutputStream outputStream = resp.getOutputStream();
       outputStream.print(
-          bytesRead
-          + " bytes read by "
-          + urlConnection.getClass().getName()
-          + "\n"
-          + responseBody);
+          bytesRead + " bytes read by " + urlConnection.getClass().getName() + "\n" + responseBody);
       outputStream.flush();
     }
   }

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/AppServerTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/AppServerTest.java
@@ -41,7 +41,7 @@ public abstract class AppServerTest extends SmokeTest {
    *   3. Server http span for http://localhost:8080/headers
    * </code>
    */
-  protected void assertWebAppTrace(ExpectedServerAttributes serverAttributes, TestImage testImage)
+  protected void assertWebAppTrace(ExpectedServerAttributes serverAttributes)
       throws IOException, InterruptedException {
     String url = getUrl("/app/greeting", false);
 
@@ -72,13 +72,8 @@ public abstract class AppServerTest extends SmokeTest {
         traces.countFilteredAttributes("http.url", getUrl("/app/headers", true)),
         "Client and server spans for the remote call");
 
-    if (testImage.isProprietaryImage) {
-      assertEquals(
-          1, traces.countSpansByName("GreetingServlet.withSpan"), "Span for the annotated method");
-    }
-
     assertEquals(
-        totalNumberOfSpansInWebappTrace(testImage),
+        totalNumberOfSpansInWebappTrace(),
         traces.countFilteredAttributes("otel.library.version", getCurrentAgentVersion()),
         "Number of spans tagged with current otel library version");
   }
@@ -106,12 +101,11 @@ public abstract class AppServerTest extends SmokeTest {
     return responseBody;
   }
 
-  private int totalNumberOfSpansInWebappTrace(TestImage testImage) {
+  private int totalNumberOfSpansInWebappTrace() {
     // 1) Incoming /greeting
     // 2) Outgoing /headers
     // 3) Incoming /headers
-    // 4) Splunk WAR in proprietary images adds a @WithSpan span
-    return 3 + (testImage.isProprietaryImage ? 1 : 0);
+    return 3;
   }
 
   protected void assertMiddlewareAttributesInWebAppTrace(

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/AppServerTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/AppServerTest.java
@@ -19,7 +19,6 @@ package com.splunk.opentelemetry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.splunk.opentelemetry.helper.TestImage;
 import io.opentelemetry.proto.trace.v1.Span;
 import java.io.IOException;
 import java.util.ArrayList;

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/GlassFishSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/GlassFishSmokeTest.java
@@ -73,7 +73,7 @@ public class GlassFishSmokeTest extends AppServerTest {
     startTargetOrSkipTest(image);
 
     assertServerHandler(expectedServerAttributes);
-    assertWebAppTrace(expectedServerAttributes, image);
+    assertWebAppTrace(expectedServerAttributes);
 
     stopTarget();
   }

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/JBossEapSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/JBossEapSmokeTest.java
@@ -16,7 +16,7 @@
 
 package com.splunk.opentelemetry;
 
-import static com.splunk.opentelemetry.helper.TestImage.linuxImage;
+import static com.splunk.opentelemetry.helper.TestImage.proprietaryLinuxImage;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.splunk.opentelemetry.helper.TestImage;
@@ -43,11 +43,11 @@ public class JBossEapSmokeTest extends AppServerTest {
   private static Stream<Arguments> jboss() {
     return Stream.of(
         arguments(
-            linuxImage("ghcr.io/signalfx/splunk-otel-jboss-eap:7.1.0-jdk8"), JBOSS_EAP_7_1_SERVER_ATTRIBUTES),
+            proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-jboss-eap:7.1.0-jdk8"), JBOSS_EAP_7_1_SERVER_ATTRIBUTES),
         arguments(
-            linuxImage("ghcr.io/signalfx/splunk-otel-jboss-eap:7.3.0-jdk8"), JBOSS_EAP_7_3_SERVER_ATTRIBUTES),
+            proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-jboss-eap:7.3.0-jdk8"), JBOSS_EAP_7_3_SERVER_ATTRIBUTES),
         arguments(
-            linuxImage("ghcr.io/signalfx/splunk-otel-jboss-eap:7.3.0-jdk11"),
+            proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-jboss-eap:7.3.0-jdk11"),
             JBOSS_EAP_7_3_SERVER_ATTRIBUTES));
   }
 

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/JBossEapSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/JBossEapSmokeTest.java
@@ -16,7 +16,7 @@
 
 package com.splunk.opentelemetry;
 
-import static com.splunk.opentelemetry.helper.TestImage.proprietaryLinuxImage;
+import static com.splunk.opentelemetry.helper.TestImage.linuxImage;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.splunk.opentelemetry.helper.TestImage;
@@ -43,11 +43,11 @@ public class JBossEapSmokeTest extends AppServerTest {
   private static Stream<Arguments> jboss() {
     return Stream.of(
         arguments(
-            proprietaryLinuxImage("splunk-jboss-eap:7.1.0-jdk8"), JBOSS_EAP_7_1_SERVER_ATTRIBUTES),
+            linuxImage("ghcr.io/signalfx/splunk-otel-jboss-eap:7.1.0-jdk8"), JBOSS_EAP_7_1_SERVER_ATTRIBUTES),
         arguments(
-            proprietaryLinuxImage("splunk-jboss-eap:7.3.0-jdk8"), JBOSS_EAP_7_3_SERVER_ATTRIBUTES),
+            linuxImage("ghcr.io/signalfx/splunk-otel-jboss-eap:7.3.0-jdk8"), JBOSS_EAP_7_3_SERVER_ATTRIBUTES),
         arguments(
-            proprietaryLinuxImage("splunk-jboss-eap:7.3.0-jdk11"),
+            linuxImage("ghcr.io/signalfx/splunk-otel-jboss-eap:7.3.0-jdk11"),
             JBOSS_EAP_7_3_SERVER_ATTRIBUTES));
   }
 
@@ -58,7 +58,7 @@ public class JBossEapSmokeTest extends AppServerTest {
     startTargetOrSkipTest(image);
 
     assertServerHandler(expectedServerAttributes);
-    assertWebAppTrace(expectedServerAttributes, image);
+    assertWebAppTrace(expectedServerAttributes);
 
     stopTarget();
   }

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/JBossEapSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/JBossEapSmokeTest.java
@@ -43,9 +43,11 @@ public class JBossEapSmokeTest extends AppServerTest {
   private static Stream<Arguments> jboss() {
     return Stream.of(
         arguments(
-            proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-jboss-eap:7.1.0-jdk8"), JBOSS_EAP_7_1_SERVER_ATTRIBUTES),
+            proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-jboss-eap:7.1.0-jdk8"),
+            JBOSS_EAP_7_1_SERVER_ATTRIBUTES),
         arguments(
-            proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-jboss-eap:7.3.0-jdk8"), JBOSS_EAP_7_3_SERVER_ATTRIBUTES),
+            proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-jboss-eap:7.3.0-jdk8"),
+            JBOSS_EAP_7_3_SERVER_ATTRIBUTES),
         arguments(
             proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-jboss-eap:7.3.0-jdk11"),
             JBOSS_EAP_7_3_SERVER_ATTRIBUTES));

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/JettySmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/JettySmokeTest.java
@@ -77,7 +77,7 @@ public class JettySmokeTest extends AppServerTest {
     startTargetOrSkipTest(image);
 
     assertServerHandler(expectedServerAttributes);
-    assertWebAppTrace(expectedServerAttributes, image);
+    assertWebAppTrace(expectedServerAttributes);
 
     stopTarget();
   }

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/LibertySmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/LibertySmokeTest.java
@@ -76,7 +76,7 @@ public class LibertySmokeTest extends AppServerTest {
     startTargetOrSkipTest(image);
 
     assertServerHandler(expectedServerAttributes);
-    assertWebAppTrace(expectedServerAttributes, image);
+    assertWebAppTrace(expectedServerAttributes);
 
     stopTarget();
   }

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/SmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/SmokeTest.java
@@ -73,6 +73,12 @@ public abstract class SmokeTest {
         containerManager.isImageCompatible(image),
         "Current Docker environment can run image " + image);
 
+    if (image.isProprietaryImage) {
+      // Proprietary images are private, therefore if they are not present, the test
+      // will be skipped as not everybody can pull them from a remote repository.
+      assumeTrue(containerManager.isImagePresent(image), "Proprietary image is present: " + image);
+    }
+
     containerManager.startTarget(image.imageName, agentPath, getExtraEnv(), getWaitStrategy());
   }
 

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/SmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/SmokeTest.java
@@ -73,12 +73,6 @@ public abstract class SmokeTest {
         containerManager.isImageCompatible(image),
         "Current Docker environment can run image " + image);
 
-    if (image.isProprietaryImage) {
-      // Proprietary images have to be built locally, therefore if they are not present, the test
-      // will be skipped as they are not expected to be found in a remote repository.
-      assumeTrue(containerManager.isImagePresent(image), "Proprietary image is present: " + image);
-    }
-
     containerManager.startTarget(image.imageName, agentPath, getExtraEnv(), getWaitStrategy());
   }
 

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/TomcatSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/TomcatSmokeTest.java
@@ -82,7 +82,7 @@ public class TomcatSmokeTest extends AppServerTest {
     startTargetOrSkipTest(image);
 
     assertServerHandler(expectedServerAttributes);
-    assertWebAppTrace(expectedServerAttributes, image);
+    assertWebAppTrace(expectedServerAttributes);
 
     stopTarget();
   }

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/WebLogicSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/WebLogicSmokeTest.java
@@ -43,11 +43,11 @@ class WebLogicSmokeTest extends AppServerTest {
 
   private static Stream<Arguments> supportedWlsConfigurations() {
     return Stream.of(
-        arguments(proprietaryLinuxImage("splunk-weblogic:12.1.3-jdkdeveloper"), V12_1_ATTRIBUTES),
-        arguments(proprietaryLinuxImage("splunk-weblogic:12.2.1.4-jdkdeveloper"), V12_2_ATTRIBUTES),
-        arguments(proprietaryLinuxImage("splunk-weblogic:14.1.1.0-jdkdeveloper-8"), V14_ATTRIBUTES),
+        arguments(proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-weblogic:12.1.3-jdkdeveloper"), V12_1_ATTRIBUTES),
+        arguments(proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-weblogic:12.2.1.4-jdkdeveloper"), V12_2_ATTRIBUTES),
+        arguments(proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-weblogic:14.1.1.0-jdkdeveloper-8"), V14_ATTRIBUTES),
         arguments(
-            proprietaryLinuxImage("splunk-weblogic:14.1.1.0-jdkdeveloper-11"), V14_ATTRIBUTES));
+            proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-weblogic:14.1.1.0-jdkdeveloper-11"), V14_ATTRIBUTES));
   }
 
   @ParameterizedTest

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/WebLogicSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/WebLogicSmokeTest.java
@@ -58,7 +58,7 @@ class WebLogicSmokeTest extends AppServerTest {
 
     // No assertServerHandler as there are no current plans to have a WebLogic server handler that
     // creates spans
-    assertWebAppTrace(serverAttributes, image);
+    assertWebAppTrace(serverAttributes);
 
     stopTarget();
   }

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/WebLogicSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/WebLogicSmokeTest.java
@@ -43,11 +43,18 @@ class WebLogicSmokeTest extends AppServerTest {
 
   private static Stream<Arguments> supportedWlsConfigurations() {
     return Stream.of(
-        arguments(proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-weblogic:12.1.3-jdkdeveloper"), V12_1_ATTRIBUTES),
-        arguments(proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-weblogic:12.2.1.4-jdkdeveloper"), V12_2_ATTRIBUTES),
-        arguments(proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-weblogic:14.1.1.0-jdkdeveloper-8"), V14_ATTRIBUTES),
         arguments(
-            proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-weblogic:14.1.1.0-jdkdeveloper-11"), V14_ATTRIBUTES));
+            proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-weblogic:12.1.3-jdkdeveloper"),
+            V12_1_ATTRIBUTES),
+        arguments(
+            proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-weblogic:12.2.1.4-jdkdeveloper"),
+            V12_2_ATTRIBUTES),
+        arguments(
+            proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-weblogic:14.1.1.0-jdkdeveloper-8"),
+            V14_ATTRIBUTES),
+        arguments(
+            proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-weblogic:14.1.1.0-jdkdeveloper-11"),
+            V14_ATTRIBUTES));
   }
 
   @ParameterizedTest

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/WildFlySmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/WildFlySmokeTest.java
@@ -85,7 +85,7 @@ public class WildFlySmokeTest extends AppServerTest {
     startTargetOrSkipTest(image);
 
     assertServerHandler(expectedServerAttributes);
-    assertWebAppTrace(expectedServerAttributes, image);
+    assertWebAppTrace(expectedServerAttributes);
 
     stopTarget();
   }


### PR DESCRIPTION
JBoss and WebLogic images are now pushed to private repositories in SignalFx GH org. Thus we now can test them in CI.