### PR TITLE
Add Windows TomEE image and test

### DIFF
--- a/matrix/build.gradle
+++ b/matrix/build.gradle
@@ -49,6 +49,10 @@ def windowsTargets = [
         [version: "8.5.60", majorVersion: "8"]: ["8", "11"],
         [version: "9.0.40", majorVersion: "9"]: ["8", "11"]
     ],
+    "tomee" : [
+        "7.0.0": ["8"],
+        "8.0.6": ["8", "11"]
+    ],
     "jetty" : [
         [version: "9.4.35", sourceVersion: "9.4.35.v20201120"]: ["8", "11", "15"],
         [version: "10.0.0", sourceVersion: "10.0.0.beta3", classifier: "split"]: ["11", "15"]

--- a/matrix/src/tomee.windows.dockerfile
+++ b/matrix/src/tomee.windows.dockerfile
@@ -1,0 +1,17 @@
+ARG jdk
+ARG version
+
+# Unzip in a separate container so that zip file layer is not part of final image
+FROM mcr.microsoft.com/windows/servercore:1809 as builder
+ARG majorVersion
+ARG version
+ADD https://archive.apache.org/dist/tomee/tomee-${version}/apache-tomee-${version}-webprofile.zip /server.zip
+RUN ["powershell", "-Command", "expand-archive -Path /server.zip -DestinationPath /server"]
+
+FROM winamd64/openjdk:${jdk}-jdk-windowsservercore-1809
+ARG version
+# Make /server the base directory to simplify all further paths
+COPY --from=builder /server/apache-tomee-webprofile-${version} /server
+COPY app.war /server/webapps/
+WORKDIR /server/bin
+CMD /server/bin/catalina.bat run

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/TomeeSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/TomeeSmokeTest.java
@@ -17,6 +17,7 @@
 package com.splunk.opentelemetry;
 
 import static com.splunk.opentelemetry.helper.TestImage.linuxImage;
+import static com.splunk.opentelemetry.helper.TestImage.proprietaryWindowsImage;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.splunk.opentelemetry.helper.TestImage;
@@ -42,6 +43,15 @@ public class TomeeSmokeTest extends AppServerTest {
         arguments(
             linuxImage(
                 "ghcr.io/open-telemetry/java-test-containers:tomee-8.0.6-jdk8-20210202.531569197"),
+            TOMEE8_SERVER_ATTRIBUTES),
+        arguments(
+            proprietaryWindowsImage("ghcr.io/signalfx/splunk-otel-tomee:7.0.0-jdk8-windows"),
+            TOMEE7_SERVER_ATTRIBUTES),
+        arguments(
+            proprietaryWindowsImage("ghcr.io/signalfx/splunk-otel-tomee:8.0.6-jdk8-windows"),
+            TOMEE8_SERVER_ATTRIBUTES),
+        arguments(
+            proprietaryWindowsImage("ghcr.io/signalfx/splunk-otel-tomee:8.0.6-jdk11-windows"),
             TOMEE8_SERVER_ATTRIBUTES));
   }
 
@@ -59,7 +69,7 @@ public class TomeeSmokeTest extends AppServerTest {
 
   public static class TomeeAttributes extends ExpectedServerAttributes {
     public TomeeAttributes(String version) {
-      // This handler span name is only received if default webapps are removed
+      // This handler span name is only received if default webapps are present
       super(
           "/this-is-definitely-not-there-but-there-should-be-a-trace-nevertheless",
           "tomee",


### PR DESCRIPTION
Adds Windows Docker images for the same versions of TomEE that already exist for Linux and adds them as test cases for smoke test.