### PR TITLE
OpenJ9 smoke test Docker images

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,9 @@ boolean snapshot = getProperty("snapshot") == 'yes'
 def versions = [
     'opentelemetry'         : snapshot ? "0.17.0-SNAPSHOT"       : "0.16.0",
     'opentelemetryAlpha'    : snapshot ? "0.17.0-alpha-SNAPSHOT" : "0.16.0-alpha",
-    'opentelemetryJavaagent': snapshot ? "0.17.0-SNAPSHOT"       : '0.16.1'
+    'opentelemetryJavaagent': snapshot ? "0.17.0-SNAPSHOT"       : '0.16.1',
+    'mockito'               : '3.8.0',
+    'jupiter'               : '5.7.1'
 ]
 
 subprojects {
@@ -44,12 +46,12 @@ subprojects {
   }
 
   dependencies {
-    testImplementation("org.mockito:mockito-core:3.8.0")
-    testImplementation("org.mockito:mockito-junit-jupiter:3.8.0")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.1")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:5.7.1")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.1")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:5.7.1")
+    testImplementation("org.mockito:mockito-core:${versions.mockito}")
+    testImplementation("org.mockito:mockito-junit-jupiter:${versions.mockito}")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:${versions.jupiter}")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:${versions.jupiter}")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${versions.jupiter}")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:${versions.jupiter}")
   }
 
   tasks {

--- a/build.gradle
+++ b/build.gradle
@@ -44,12 +44,12 @@ subprojects {
   }
 
   dependencies {
-    testImplementation("org.mockito:mockito-core:3.5.15")
-    testImplementation("org.mockito:mockito-junit-jupiter:3.5.15")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:5.6.2")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.6.2")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:5.6.2")
+    testImplementation("org.mockito:mockito-core:3.8.0")
+    testImplementation("org.mockito:mockito-junit-jupiter:3.8.0")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.1")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.7.1")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.1")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.7.1")
   }
 
   tasks {

--- a/matrix/build.gradle
+++ b/matrix/build.gradle
@@ -31,8 +31,8 @@ def proprietaryTargets = [
         [version: ["14.1.1.0"], vm: ["hotspot"], jdk: ["11"], args: [tagSuffix: "developer-11"]]
     ],
     "jboss-eap": [
-        [version: ["7.1.0"], vm: ["hotspot"], jdk: ["8"]],
-        [version: ["7.3.0"], vm: ["hotspot"], jdk: ["8", "11"]]
+        [version: ["7.1.0"], vm: ["hotspot", "openj9"], jdk: ["8"]],
+        [version: ["7.3.0"], vm: ["hotspot", "openj9"], jdk: ["8", "11"]]
     ]
 ]
 

--- a/matrix/build.gradle
+++ b/matrix/build.gradle
@@ -25,14 +25,14 @@ def buildProprietaryTestImagesTask = tasks.create("buildProprietaryTestImages") 
 def pullProprietaryTestImagesTask = tasks.create("pullProprietaryTestImages")
 
 def proprietaryTargets = [
-    "weblogic" : [
-       "12.1.3" : ["developer"],
-       "12.2.1.4" : ["developer"],
-       "14.1.1.0" : ["developer-8", "developer-11"]
+    "weblogic": [
+        [version: ["12.1.3", "12.2.1.4"], vm: ["hotspot"], jdk: ["8"], args: [tagSuffix: "developer"]],
+        [version: ["14.1.1.0"], vm: ["hotspot"], jdk: ["8"], args: [tagSuffix: "developer-8"]],
+        [version: ["14.1.1.0"], vm: ["hotspot"], jdk: ["11"], args: [tagSuffix: "developer-11"]]
     ],
-    "jboss-eap" : [
-        "7.1.0" : ["8"],
-        "7.3.0" : ["8", "11"]
+    "jboss-eap": [
+        [version: ["7.1.0"], vm: ["hotspot"], jdk: ["8"]],
+        [version: ["7.3.0"], vm: ["hotspot"], jdk: ["8", "11"]]
     ]
 ]
 
@@ -45,79 +45,84 @@ def buildWindowsTestImagesTask = tasks.create("buildWindowsTestImages") {
 
 def windowsTargets = [
     "tomcat" : [
-        [version: "7.0.107", majorVersion: "7"]: ["8"],
-        [version: "8.5.60", majorVersion: "8"]: ["8", "11"],
-        [version: "9.0.40", majorVersion: "9"]: ["8", "11"]
+        [version: ["7.0.107"], vm: ["hotspot", "openj9"], jdk: ["8"], args: [majorVersion: "7"]],
+        [version: ["8.5.60"], vm: ["hotspot", "openj9"], jdk: ["8", "11"], args: [majorVersion: "8"]],
+        [version: ["9.0.40"], vm: ["hotspot", "openj9"], jdk: ["8", "11"], args: [majorVersion: "9"]]
     ],
     "tomee" : [
-        "7.0.0": ["8"],
-        "8.0.6": ["8", "11"]
+        [version: ["7.0.0"], vm: ["hotspot", "openj9"], jdk: ["8"]],
+        [version: ["8.0.6"], vm: ["hotspot", "openj9"], jdk: ["8", "11"]]
     ],
     "jetty" : [
-        [version: "9.4.35", sourceVersion: "9.4.35.v20201120"]: ["8", "11", "15"],
-        [version: "10.0.0", sourceVersion: "10.0.0.beta3", classifier: "split"]: ["11", "15"]
+        [version: ["9.4.35"], vm: ["hotspot", "openj9"], jdk: ["8", "11", "15"], args: [sourceVersion: "9.4.35.v20201120"]],
+        [version: ["10.0.0"], vm: ["hotspot", "openj9"], jdk: ["11", "15"], dockerfile: "jetty-split", args: [sourceVersion: "10.0.0.beta3"]]
     ],
     "payara": [
-        "5.2020.6": ["8", "11"]
+        [version: ["5.2020.6"], vm: ["hotspot", "openj9"], jdk: ["8", "11"]]
     ],
     "wildfly" : [
-        "13.0.0.Final": ["8"],
-        "17.0.1.Final": ["8", "11"],
-        "21.0.0.Final": ["8", "11"]
+        [version: ["13.0.0.Final"], vm: ["hotspot", "openj9"], jdk: ["8"]],
+        [version: ["17.0.1.Final", "21.0.0.Final"], vm: ["hotspot", "openj9"], jdk: ["8", "11"]]
     ],
     "openliberty" : [
-        [version: "20.0.0.12", release: "2020-11-11_0736"]: ["8", "11", "15"]
+        [version: ["20.0.0.12"], vm: ["hotspot", "openj9"], jdk: ["8", "11", "15"], args: [release: "2020-11-11_0736"]]
     ]
 ]
 
 createDockerTasks(buildWindowsTestImagesTask, null, windowsTargets, true)
 
-def createDockerTasks(parentTask, Task parentPullTask, targets, isWindows) {
+def configureImage(Task parentTask, Task parentPullTask, server, dockerfile, version, vm, jdk, Map<String, String> extraArgs, isWindows) {
   def dockerWorkingDir = new File(project.buildDir, "docker")
+  def dockerFileName = isWindows ? "${dockerfile}.windows.dockerfile" : "${dockerfile}.dockerfile"
+  def platformSuffix = isWindows ? "-windows" : ""
 
-  targets.forEach { server, data ->
-    data.forEach { versionKey, jdks ->
-      jdks.forEach { jdk ->
-        def versionInfo = versionKey instanceof Map ? versionKey : [version: versionKey.toString()]
-        def version = versionInfo["version"]
+  def prepareTask = tasks.register("${server}ImagePrepare-$version-jdk$jdk-$vm$platformSuffix", Copy) {
+    def warTask = project.tasks.named("war").get()
+    it.dependsOn(warTask)
+    it.into(dockerWorkingDir)
+    it.from("src/$dockerFileName")
+    it.from("src/main/docker/$server")
+    it.from(warTask.archiveFile) {
+      rename { _ -> "app.war" }
+    }
+  }
 
-        def classifier = versionInfo["classifier"] ? "-" + versionInfo["classifier"] : ""
-        def dockerFileName = isWindows ? "${server}${classifier}.windows.dockerfile" : "${server}${classifier}.dockerfile"
+  def vmSuffix = vm == "hotspot" ? "" : "-$vm"
+  def fullDockerImageName = "ghcr.io/signalfx/splunk-otel-$server:$version-jdk$jdk$vmSuffix$platformSuffix"
 
-        def prepareTask = tasks.register("${server}ImagePrepare-$version-jdk$jdk", Copy) {
-          def warTask = project.tasks.named("war").get()
-          it.dependsOn(warTask)
-          it.into(dockerWorkingDir)
-          it.from("src/${dockerFileName}")
-          it.from("src/main/docker/${server}")
-          it.from(warTask.archiveFile) {
-            rename { _ -> "app.war" }
+  def buildTask = tasks.register("${server}Image-$version-jdk$jdk-$vm$platformSuffix", DockerBuildImage) {
+    it.dependsOn(prepareTask)
+    group = "build"
+    description = "Builds Docker image with $server $version on JDK $jdk-$vm"
+
+    it.inputDir.set(dockerWorkingDir)
+    it.images.add(fullDockerImageName)
+    it.dockerFile.set(new File(dockerWorkingDir, dockerFileName))
+    it.buildArgs.set(extraArgs + [jdk: jdk, vm: vm, version: version])
+  }
+
+  parentTask.dependsOn(buildTask)
+
+  if(parentPullTask != null){
+    def pullTask = tasks.register("${server}ImagePull-$version-jdk$jdk-$vm$platformSuffix", DockerPullImage) {
+      it.image.set(fullDockerImageName)
+    }
+
+    parentPullTask.dependsOn(pullTask)
+  }
+}
+
+def createDockerTasks(Task parentTask, Task parentPullTask, targets, isWindows) {
+  targets.each { server, matrices ->
+    matrices.forEach { entry ->
+      def dockerfile = entry["dockerfile"]?.toString() ?: server
+      def extraArgs = (entry["args"] ?: [:]) as Map<String, String>
+
+      entry.version.forEach { version ->
+        entry.vm.forEach { vm ->
+          entry.jdk.forEach { jdk ->
+            configureImage(parentTask, parentPullTask, server, dockerfile, version, vm, jdk, extraArgs, isWindows)
           }
-        }
-
-        def fullDockerImageName = "ghcr.io/signalfx/splunk-otel-$server:$version-jdk$jdk" + (isWindows ? "-windows" : "")
-
-        def buildTask = tasks.register("${server}Image-$version-jdk$jdk", DockerBuildImage) {
-          it.dependsOn(prepareTask)
-          group = "build"
-          description = "Builds Docker image with $server $version on JDK $jdk"
-
-          it.inputDir.set(dockerWorkingDir)
-          it.images.add(fullDockerImageName)
-
-          it.buildArgs.set(["jdk": jdk] + versionInfo)
-
-          it.dockerFile.set(new File(dockerWorkingDir, dockerFileName))
-        }
-
-        parentTask.dependsOn(buildTask)
-
-        if(parentPullTask != null){
-          def pullTask = tasks.register("${server}ImagePull-$version-jdk$jdk", DockerPullImage) {
-            it.image.set(fullDockerImageName)
-          }
-
-          parentPullTask.dependsOn(pullTask)
         }
       }
     }

--- a/matrix/src/jboss-eap.dockerfile
+++ b/matrix/src/jboss-eap.dockerfile
@@ -1,5 +1,6 @@
 ARG jdk
-FROM adoptopenjdk:${jdk}-hotspot-focal
+ARG vm
+FROM adoptopenjdk:${jdk}-${vm}-focal
 
 # Create a user and group used to launch processes
 # The user ID 1000 is the default for the first "regular" user on Fedora/RHEL,

--- a/matrix/src/jetty-split.windows.dockerfile
+++ b/matrix/src/jetty-split.windows.dockerfile
@@ -1,4 +1,5 @@
 ARG jdk
+ARG vm
 ARG sourceVersion
 
 # Unzip in a separate container so that zip file layer is not part of final image
@@ -7,7 +8,7 @@ ARG sourceVersion
 ADD https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/${sourceVersion}/jetty-home-${sourceVersion}.zip /server.zip
 RUN ["powershell", "-Command", "expand-archive -Path /server.zip -DestinationPath /server"]
 
-FROM winamd64/openjdk:${jdk}-jdk-windowsservercore-1809
+FROM adoptopenjdk:${jdk}-jdk-${vm}-windowsservercore-1809
 ARG sourceVersion
 # Make /server the base directory to simplify all further paths
 COPY --from=builder /server/jetty-home-${sourceVersion} /server

--- a/matrix/src/jetty.windows.dockerfile
+++ b/matrix/src/jetty.windows.dockerfile
@@ -1,4 +1,5 @@
 ARG jdk
+ARG vm
 ARG sourceVersion
 
 # Unzip in a separate container so that zip file layer is not part of final image
@@ -7,7 +8,7 @@ ARG sourceVersion
 ADD https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/${sourceVersion}/jetty-distribution-${sourceVersion}.zip /server.zip
 RUN ["powershell", "-Command", "expand-archive -Path /server.zip -DestinationPath /server"]
 
-FROM winamd64/openjdk:${jdk}-jdk-windowsservercore-1809
+FROM adoptopenjdk:${jdk}-jdk-${vm}-windowsservercore-1809
 ARG sourceVersion
 # Make /server the base directory to simplify all further paths
 COPY --from=builder /server/jetty-distribution-${sourceVersion} /server

--- a/matrix/src/openliberty.windows.dockerfile
+++ b/matrix/src/openliberty.windows.dockerfile
@@ -1,4 +1,5 @@
 ARG jdk
+ARG vm
 ARG version
 ARG release
 
@@ -9,7 +10,7 @@ ARG release
 ADD https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/${release}/openliberty-${version}.zip /server.zip
 RUN ["powershell", "-Command", "expand-archive -Path /server.zip -DestinationPath /server"]
 
-FROM winamd64/openjdk:${jdk}-jdk-windowsservercore-1809
+FROM adoptopenjdk:${jdk}-jdk-${vm}-windowsservercore-1809
 ARG version
 # Make /server the base directory to simplify all further paths
 COPY --from=builder /server/wlp /server

--- a/matrix/src/payara.windows.dockerfile
+++ b/matrix/src/payara.windows.dockerfile
@@ -1,4 +1,5 @@
 ARG jdk
+ARG vm
 ARG version
 
 # Unzip in a separate container so that zip file layer is not part of final image
@@ -8,7 +9,7 @@ ADD https://s3-eu-west-1.amazonaws.com/payara.fish/Payara+Downloads/${version}/p
 RUN ["powershell", "-Command", "expand-archive -Path /server.zip -DestinationPath /server"]
 RUN ["powershell", "-Command", "remove-item -Path /server/payara5/glassfish/modules/phonehome-bootstrap.jar"]
 
-FROM winamd64/openjdk:${jdk}-jdk-windowsservercore-1809
+FROM adoptopenjdk:${jdk}-jdk-${vm}-windowsservercore-1809
 ARG version
 # Make /server the base directory to simplify all further paths
 COPY --from=builder /server/payara5 /server

--- a/matrix/src/tomcat.windows.dockerfile
+++ b/matrix/src/tomcat.windows.dockerfile
@@ -1,4 +1,5 @@
 ARG jdk
+ARG vm
 ARG majorVersion
 ARG version
 
@@ -9,7 +10,7 @@ ARG version
 ADD https://archive.apache.org/dist/tomcat/tomcat-${majorVersion}/v${version}/bin/apache-tomcat-${version}-windows-x64.zip /server.zip
 RUN ["powershell", "-Command", "expand-archive -Path /server.zip -DestinationPath /server"]
 
-FROM winamd64/openjdk:${jdk}-jdk-windowsservercore-1809
+FROM adoptopenjdk:${jdk}-jdk-${vm}-windowsservercore-1809
 ARG version
 # Make /server the base directory to simplify all further paths
 COPY --from=builder /server/apache-tomcat-${version} /server

--- a/matrix/src/tomee.windows.dockerfile
+++ b/matrix/src/tomee.windows.dockerfile
@@ -1,4 +1,5 @@
 ARG jdk
+ARG vm
 ARG version
 
 # Unzip in a separate container so that zip file layer is not part of final image
@@ -8,7 +9,7 @@ ARG version
 ADD https://archive.apache.org/dist/tomee/tomee-${version}/apache-tomee-${version}-webprofile.zip /server.zip
 RUN ["powershell", "-Command", "expand-archive -Path /server.zip -DestinationPath /server"]
 
-FROM winamd64/openjdk:${jdk}-jdk-windowsservercore-1809
+FROM adoptopenjdk:${jdk}-jdk-${vm}-windowsservercore-1809
 ARG version
 # Make /server the base directory to simplify all further paths
 COPY --from=builder /server/apache-tomee-webprofile-${version} /server

--- a/matrix/src/weblogic.dockerfile
+++ b/matrix/src/weblogic.dockerfile
@@ -1,6 +1,6 @@
-ARG jdk
+ARG tagSuffix
 ARG version
-FROM oracle/weblogic:$version-$jdk
+FROM oracle/weblogic:$version-$tagSuffix
 
 ARG APPLICATION_NAME
 ARG APPLICATION_FILE

--- a/matrix/src/wildfly.windows.dockerfile
+++ b/matrix/src/wildfly.windows.dockerfile
@@ -1,4 +1,5 @@
 ARG jdk
+ARG vm
 ARG version
 
 # Unzip in a separate container so that zip file layer is not part of final image
@@ -7,7 +8,7 @@ ARG version
 ADD http://download.jboss.org/wildfly/${version}/wildfly-${version}.zip /server.zip
 RUN ["powershell", "-Command", "expand-archive -Path /server.zip -DestinationPath /server"]
 
-FROM winamd64/openjdk:${jdk}-jdk-windowsservercore-1809
+FROM adoptopenjdk:${jdk}-jdk-${vm}-windowsservercore-1809
 ARG version
 # Make /server the base directory to simplify all further paths
 COPY --from=builder /server/wildfly-${version} /server

--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -14,7 +14,7 @@ dependencies {
   testImplementation("io.opentelemetry:opentelemetry-api:0.16.0")
 
   testImplementation("ch.qos.logback:logback-classic:1.2.3")
-  testImplementation("org.junit.jupiter:junit-jupiter-params:5.7.0")
+  testImplementation("org.junit.jupiter:junit-jupiter-params:5.7.1")
 
   testImplementation("com.github.docker-java:docker-java-core:$dockerJavaVersion")
   testImplementation("com.github.docker-java:docker-java-transport-httpclient5:$dockerJavaVersion")

--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -3,6 +3,7 @@ plugins {
   id "org.gradle.test-retry" version "1.2.0"
 }
 
+def versions = ext['versions']
 def dockerJavaVersion = "3.2.5"
 
 dependencies {
@@ -14,7 +15,7 @@ dependencies {
   testImplementation("io.opentelemetry:opentelemetry-api:0.16.0")
 
   testImplementation("ch.qos.logback:logback-classic:1.2.3")
-  testImplementation("org.junit.jupiter:junit-jupiter-params:5.7.1")
+  testImplementation("org.junit.jupiter:junit-jupiter-params:${versions.jupiter}")
 
   testImplementation("com.github.docker-java:docker-java-core:$dockerJavaVersion")
   testImplementation("com.github.docker-java:docker-java-transport-httpclient5:$dockerJavaVersion")

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/GlassFishSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/GlassFishSmokeTest.java
@@ -37,7 +37,7 @@ public class GlassFishSmokeTest extends AppServerTest {
   private static Stream<Arguments> supportedConfigurations() {
     return configurations("payara")
         .otelLinux("5.2020.6", PAYARA_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
-        .splunkWindows("5.2020.6", PAYARA_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8", "11")
+        .splunkWindows("5.2020.6", PAYARA_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
         .stream();
   }
 

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/GlassFishSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/GlassFishSmokeTest.java
@@ -37,8 +37,7 @@ public class GlassFishSmokeTest extends AppServerTest {
   private static Stream<Arguments> supportedConfigurations() {
     return configurations("payara")
         .otelLinux("5.2020.6", PAYARA_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
-        .splunkWindows("5.2020.6", PAYARA_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
-        .stream();
+        .splunkWindows("5.2020.6", PAYARA_SERVER_ATTRIBUTES, VMS_ALL, "8", "11").stream();
   }
 
   @Override
@@ -48,7 +47,8 @@ public class GlassFishSmokeTest extends AppServerTest {
 
   @Override
   protected TargetWaitStrategy getWaitStrategy() {
-    return new TargetWaitStrategy.Log(Duration.ofMinutes(5), ".*(app was successfully deployed|deployed with name app).*");
+    return new TargetWaitStrategy.Log(
+        Duration.ofMinutes(5), ".*(app was successfully deployed|deployed with name app).*");
   }
 
   @ParameterizedTest

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/GlassFishSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/GlassFishSmokeTest.java
@@ -16,10 +16,6 @@
 
 package com.splunk.opentelemetry;
 
-import static com.splunk.opentelemetry.helper.TestImage.linuxImage;
-import static com.splunk.opentelemetry.helper.TestImage.proprietaryWindowsImage;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
-
 import com.splunk.opentelemetry.helper.TargetWaitStrategy;
 import com.splunk.opentelemetry.helper.TestImage;
 import java.io.IOException;
@@ -39,21 +35,10 @@ public class GlassFishSmokeTest extends AppServerTest {
           "5.2020.6");
 
   private static Stream<Arguments> supportedConfigurations() {
-    return Stream.of(
-        arguments(
-            linuxImage(
-                "ghcr.io/open-telemetry/java-test-containers:payara-5.2020.6-jdk11-jdk11-20201207.405832649"),
-            PAYARA_SERVER_ATTRIBUTES),
-        arguments(
-            linuxImage(
-                "ghcr.io/open-telemetry/java-test-containers:payara-5.2020.6-jdk8-20201207.405832649"),
-            PAYARA_SERVER_ATTRIBUTES),
-        arguments(
-            proprietaryWindowsImage("splunk-payara:5.2020.6-jdk8-windows"),
-            PAYARA_SERVER_ATTRIBUTES),
-        arguments(
-            proprietaryWindowsImage("splunk-payara:5.2020.6-jdk11-windows"),
-            PAYARA_SERVER_ATTRIBUTES));
+    return configurations("payara")
+        .otelLinux("5.2020.6", PAYARA_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
+        .splunkWindows("5.2020.6", PAYARA_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8", "11")
+        .stream();
   }
 
   @Override
@@ -63,7 +48,7 @@ public class GlassFishSmokeTest extends AppServerTest {
 
   @Override
   protected TargetWaitStrategy getWaitStrategy() {
-    return new TargetWaitStrategy.Log(Duration.ofMinutes(5), ".*app was successfully deployed.*");
+    return new TargetWaitStrategy.Log(Duration.ofMinutes(5), ".*(app was successfully deployed|deployed with name app).*");
   }
 
   @ParameterizedTest

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/JBossEapSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/JBossEapSmokeTest.java
@@ -41,16 +41,10 @@ public class JBossEapSmokeTest extends AppServerTest {
           "DisallowedMethodsHandler.handleRequest", "JBoss EAP", "7.3.0.GA");
 
   private static Stream<Arguments> jboss() {
-    return Stream.of(
-        arguments(
-            proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-jboss-eap:7.1.0-jdk8"),
-            JBOSS_EAP_7_1_SERVER_ATTRIBUTES),
-        arguments(
-            proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-jboss-eap:7.3.0-jdk8"),
-            JBOSS_EAP_7_3_SERVER_ATTRIBUTES),
-        arguments(
-            proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-jboss-eap:7.3.0-jdk11"),
-            JBOSS_EAP_7_3_SERVER_ATTRIBUTES));
+    return configurations("jboss")
+        .splunkLinux("7.1.0", JBOSS_EAP_7_1_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8")
+        .splunkLinux("7.3.0", JBOSS_EAP_7_3_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8", "11")
+        .stream();
   }
 
   @ParameterizedTest(name = "[{index}] {0}")

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/JBossEapSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/JBossEapSmokeTest.java
@@ -16,9 +16,6 @@
 
 package com.splunk.opentelemetry;
 
-import static com.splunk.opentelemetry.helper.TestImage.proprietaryLinuxImage;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
-
 import com.splunk.opentelemetry.helper.TestImage;
 import java.io.IOException;
 import java.util.stream.Stream;
@@ -42,8 +39,8 @@ public class JBossEapSmokeTest extends AppServerTest {
 
   private static Stream<Arguments> jboss() {
     return configurations("jboss")
-        .splunkLinux("7.1.0", JBOSS_EAP_7_1_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8")
-        .splunkLinux("7.3.0", JBOSS_EAP_7_3_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8", "11")
+        .splunkLinux("7.1.0", JBOSS_EAP_7_1_SERVER_ATTRIBUTES, VMS_ALL, "8")
+        .splunkLinux("7.3.0", JBOSS_EAP_7_3_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
         .stream();
   }
 

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/JBossEapSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/JBossEapSmokeTest.java
@@ -40,8 +40,7 @@ public class JBossEapSmokeTest extends AppServerTest {
   private static Stream<Arguments> jboss() {
     return configurations("jboss")
         .splunkLinux("7.1.0", JBOSS_EAP_7_1_SERVER_ATTRIBUTES, VMS_ALL, "8")
-        .splunkLinux("7.3.0", JBOSS_EAP_7_3_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
-        .stream();
+        .splunkLinux("7.3.0", JBOSS_EAP_7_3_SERVER_ATTRIBUTES, VMS_ALL, "8", "11").stream();
   }
 
   @ParameterizedTest(name = "[{index}] {0}")

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/JettySmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/JettySmokeTest.java
@@ -37,8 +37,7 @@ public class JettySmokeTest extends AppServerTest {
         .otelLinux("9.4.35", JETTY9_SERVER_ATTRIBUTES, VMS_ALL, "8", "11", "15")
         .otelLinux("10.0.0", JETTY10_SERVER_ATTRIBUTES, VMS_ALL, "11", "15")
         .splunkWindows("9.4.35", JETTY9_SERVER_ATTRIBUTES, VMS_ALL, "8", "11", "15")
-        .splunkWindows("10.0.0", JETTY10_BETA_SERVER_ATTRIBUTES, VMS_ALL, "11", "15")
-        .stream();
+        .splunkWindows("10.0.0", JETTY10_BETA_SERVER_ATTRIBUTES, VMS_ALL, "11", "15").stream();
   }
 
   @ParameterizedTest(name = "[{index}] {0}")

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/JettySmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/JettySmokeTest.java
@@ -16,10 +16,6 @@
 
 package com.splunk.opentelemetry;
 
-import static com.splunk.opentelemetry.helper.TestImage.linuxImage;
-import static com.splunk.opentelemetry.helper.TestImage.proprietaryWindowsImage;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
-
 import com.splunk.opentelemetry.helper.TestImage;
 import java.io.IOException;
 import java.util.stream.Stream;
@@ -32,42 +28,17 @@ public class JettySmokeTest extends AppServerTest {
   public static final ExpectedServerAttributes JETTY9_SERVER_ATTRIBUTES =
       new ExpectedServerAttributes("HandlerCollection.handle", "jetty", "9.4.35.v20201120");
   public static final ExpectedServerAttributes JETTY10_SERVER_ATTRIBUTES =
+      new ExpectedServerAttributes("HandlerList.handle", "jetty", "10.0.0");
+  public static final ExpectedServerAttributes JETTY10_BETA_SERVER_ATTRIBUTES =
       new ExpectedServerAttributes("HandlerList.handle", "jetty", "10.0.0.beta3");
 
   private static Stream<Arguments> supportedConfigurations() {
-    return Stream.of(
-        arguments(
-            linuxImage(
-                "ghcr.io/open-telemetry/java-test-containers:jetty-9.4.35-jdk8-20201207.405832649"),
-            JETTY9_SERVER_ATTRIBUTES),
-        arguments(
-            linuxImage(
-                "ghcr.io/open-telemetry/java-test-containers:jetty-9.4.35-jdk11-20201207.405832649"),
-            JETTY9_SERVER_ATTRIBUTES),
-        arguments(
-            linuxImage(
-                "ghcr.io/open-telemetry/java-test-containers:jetty-9.4.35-jdk15-20201207.405832649"),
-            JETTY9_SERVER_ATTRIBUTES),
-        arguments(
-            linuxImage(
-                "ghcr.io/open-telemetry/java-test-containers:jetty-10.0.0.beta3-jdk11-20201207.405832649"),
-            JETTY10_SERVER_ATTRIBUTES),
-        arguments(
-            linuxImage(
-                "ghcr.io/open-telemetry/java-test-containers:jetty-10.0.0.beta3-jdk15-20201207.405832649"),
-            JETTY10_SERVER_ATTRIBUTES),
-        arguments(
-            proprietaryWindowsImage("splunk-jetty:9.4.35-jdk8-windows"), JETTY9_SERVER_ATTRIBUTES),
-        arguments(
-            proprietaryWindowsImage("splunk-jetty:9.4.35-jdk11-windows"), JETTY9_SERVER_ATTRIBUTES),
-        arguments(
-            proprietaryWindowsImage("splunk-jetty:9.4.35-jdk15-windows"), JETTY9_SERVER_ATTRIBUTES),
-        arguments(
-            proprietaryWindowsImage("splunk-jetty:10.0.0-jdk11-windows"),
-            JETTY10_SERVER_ATTRIBUTES),
-        arguments(
-            proprietaryWindowsImage("splunk-jetty:10.0.0-jdk15-windows"),
-            JETTY10_SERVER_ATTRIBUTES));
+    return configurations("jetty")
+        .otelLinux("9.4.35", JETTY9_SERVER_ATTRIBUTES, VMS_ALL, "8", "11", "15")
+        .otelLinux("10.0.0", JETTY10_SERVER_ATTRIBUTES, VMS_ALL, "11", "15")
+        .splunkWindows("9.4.35", JETTY9_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8", "11", "15")
+        .splunkWindows("10.0.0", JETTY10_BETA_SERVER_ATTRIBUTES, VMS_HOTSPOT, "11", "15")
+        .stream();
   }
 
   @ParameterizedTest(name = "[{index}] {0}")

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/JettySmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/JettySmokeTest.java
@@ -36,8 +36,8 @@ public class JettySmokeTest extends AppServerTest {
     return configurations("jetty")
         .otelLinux("9.4.35", JETTY9_SERVER_ATTRIBUTES, VMS_ALL, "8", "11", "15")
         .otelLinux("10.0.0", JETTY10_SERVER_ATTRIBUTES, VMS_ALL, "11", "15")
-        .splunkWindows("9.4.35", JETTY9_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8", "11", "15")
-        .splunkWindows("10.0.0", JETTY10_BETA_SERVER_ATTRIBUTES, VMS_HOTSPOT, "11", "15")
+        .splunkWindows("9.4.35", JETTY9_SERVER_ATTRIBUTES, VMS_ALL, "8", "11", "15")
+        .splunkWindows("10.0.0", JETTY10_BETA_SERVER_ATTRIBUTES, VMS_ALL, "11", "15")
         .stream();
   }
 

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/LibertySmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/LibertySmokeTest.java
@@ -31,8 +31,7 @@ public class LibertySmokeTest extends AppServerTest {
   private static Stream<Arguments> supportedConfigurations() {
     return configurations("liberty")
         .otelLinux("20.0.0.12", LIBERTY20_SERVER_ATTRIBUTES, VMS_ALL, "8", "11", "15")
-        .splunkWindows("20.0.0.12", LIBERTY20_SERVER_ATTRIBUTES, VMS_ALL, "8", "11", "15")
-        .stream();
+        .splunkWindows("20.0.0.12", LIBERTY20_SERVER_ATTRIBUTES, VMS_ALL, "8", "11", "15").stream();
   }
 
   @ParameterizedTest(name = "[{index}] {0}")

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/LibertySmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/LibertySmokeTest.java
@@ -31,7 +31,7 @@ public class LibertySmokeTest extends AppServerTest {
   private static Stream<Arguments> supportedConfigurations() {
     return configurations("liberty")
         .otelLinux("20.0.0.12", LIBERTY20_SERVER_ATTRIBUTES, VMS_ALL, "8", "11", "15")
-        .splunkWindows("20.0.0.12", LIBERTY20_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8", "11", "15")
+        .splunkWindows("20.0.0.12", LIBERTY20_SERVER_ATTRIBUTES, VMS_ALL, "8", "11", "15")
         .stream();
   }
 

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/LibertySmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/LibertySmokeTest.java
@@ -16,10 +16,6 @@
 
 package com.splunk.opentelemetry;
 
-import static com.splunk.opentelemetry.helper.TestImage.linuxImage;
-import static com.splunk.opentelemetry.helper.TestImage.proprietaryWindowsImage;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
-
 import com.splunk.opentelemetry.helper.TestImage;
 import java.io.IOException;
 import java.util.stream.Stream;
@@ -33,40 +29,10 @@ public class LibertySmokeTest extends AppServerTest {
       new LibertyAttributes("20.0.0.12");
 
   private static Stream<Arguments> supportedConfigurations() {
-    return Stream.of(
-        arguments(
-            linuxImage(
-                "ghcr.io/open-telemetry/java-test-containers:liberty-20.0.0.12-jdk8-20201209.410207048"),
-            LIBERTY20_SERVER_ATTRIBUTES),
-        arguments(
-            linuxImage(
-                "ghcr.io/open-telemetry/java-test-containers:liberty-20.0.0.12-jdk11-20201209.410207048"),
-            LIBERTY20_SERVER_ATTRIBUTES),
-        arguments(
-            linuxImage(
-                "ghcr.io/open-telemetry/java-test-containers:liberty-20.0.0.12-jdk15-20201209.410207048"),
-            LIBERTY20_SERVER_ATTRIBUTES),
-        arguments(
-            linuxImage(
-                "ghcr.io/open-telemetry/java-test-containers:liberty-20.0.0.12-jdk8-jdk-openj9-20201209.410207048"),
-            LIBERTY20_SERVER_ATTRIBUTES),
-        arguments(
-            linuxImage(
-                "ghcr.io/open-telemetry/java-test-containers:liberty-20.0.0.12-jdk11-jdk-openj9-20201209.410207048"),
-            LIBERTY20_SERVER_ATTRIBUTES),
-        arguments(
-            linuxImage(
-                "ghcr.io/open-telemetry/java-test-containers:liberty-20.0.0.12-jdk15-jdk-openj9-20201209.410207048"),
-            LIBERTY20_SERVER_ATTRIBUTES),
-        arguments(
-            proprietaryWindowsImage("splunk-openliberty:20.0.0.12-jdk8-windows"),
-            LIBERTY20_SERVER_ATTRIBUTES),
-        arguments(
-            proprietaryWindowsImage("splunk-openliberty:20.0.0.12-jdk11-windows"),
-            LIBERTY20_SERVER_ATTRIBUTES),
-        arguments(
-            proprietaryWindowsImage("splunk-openliberty:20.0.0.12-jdk15-windows"),
-            LIBERTY20_SERVER_ATTRIBUTES));
+    return configurations("liberty")
+        .otelLinux("20.0.0.12", LIBERTY20_SERVER_ATTRIBUTES, VMS_ALL, "8", "11", "15")
+        .splunkWindows("20.0.0.12", LIBERTY20_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8", "11", "15")
+        .stream();
   }
 
   @ParameterizedTest(name = "[{index}] {0}")

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/TomcatSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/TomcatSmokeTest.java
@@ -16,10 +16,6 @@
 
 package com.splunk.opentelemetry;
 
-import static com.splunk.opentelemetry.helper.TestImage.linuxImage;
-import static com.splunk.opentelemetry.helper.TestImage.proprietaryWindowsImage;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
-
 import com.splunk.opentelemetry.helper.TestImage;
 import java.io.IOException;
 import java.util.stream.Stream;
@@ -37,42 +33,14 @@ public class TomcatSmokeTest extends AppServerTest {
       new TomcatAttributes("9.0.40.0");
 
   private static Stream<Arguments> supportedConfigurations() {
-    return Stream.of(
-        arguments(
-            linuxImage(
-                "ghcr.io/open-telemetry/java-test-containers:tomcat-7.0.107-jdk8-20201207.405832649"),
-            TOMCAT7_SERVER_ATTRIBUTES),
-        arguments(
-            linuxImage(
-                "ghcr.io/open-telemetry/java-test-containers:tomcat-8.5.60-jdk8-20201207.405832649"),
-            TOMCAT8_SERVER_ATTRIBUTES),
-        arguments(
-            linuxImage(
-                "ghcr.io/open-telemetry/java-test-containers:tomcat-8.5.60-jdk11-20201207.405832649"),
-            TOMCAT8_SERVER_ATTRIBUTES),
-        arguments(
-            linuxImage(
-                "ghcr.io/open-telemetry/java-test-containers:tomcat-9.0.40-jdk8-20201207.405832649"),
-            TOMCAT9_SERVER_ATTRIBUTES),
-        arguments(
-            linuxImage(
-                "ghcr.io/open-telemetry/java-test-containers:tomcat-9.0.40-jdk11-20201207.405832649"),
-            TOMCAT9_SERVER_ATTRIBUTES),
-        arguments(
-            proprietaryWindowsImage("splunk-tomcat:7.0.107-jdk8-windows"),
-            TOMCAT7_SERVER_ATTRIBUTES),
-        arguments(
-            proprietaryWindowsImage("splunk-tomcat:8.5.60-jdk8-windows"),
-            TOMCAT8_SERVER_ATTRIBUTES),
-        arguments(
-            proprietaryWindowsImage("splunk-tomcat:8.5.60-jdk11-windows"),
-            TOMCAT8_SERVER_ATTRIBUTES),
-        arguments(
-            proprietaryWindowsImage("splunk-tomcat:9.0.40-jdk8-windows"),
-            TOMCAT9_SERVER_ATTRIBUTES),
-        arguments(
-            proprietaryWindowsImage("splunk-tomcat:9.0.40-jdk11-windows"),
-            TOMCAT9_SERVER_ATTRIBUTES));
+    return configurations("tomcat")
+        .otelLinux("7.0.107", TOMCAT7_SERVER_ATTRIBUTES, VMS_ALL, "8")
+        .otelLinux("8.5.60", TOMCAT8_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
+        .otelLinux("9.0.40", TOMCAT9_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
+        .splunkWindows("7.0.107", TOMCAT7_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8")
+        .splunkWindows("8.5.60", TOMCAT8_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8", "11")
+        .splunkWindows("9.0.40", TOMCAT9_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8", "11")
+        .stream();
   }
 
   @ParameterizedTest(name = "[{index}] {0}")

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/TomcatSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/TomcatSmokeTest.java
@@ -33,14 +33,12 @@ public class TomcatSmokeTest extends AppServerTest {
       new TomcatAttributes("9.0.40.0");
 
   private static Stream<Arguments> supportedConfigurations() {
-    return configurations("tomcat")
-        .otelLinux("7.0.107", TOMCAT7_SERVER_ATTRIBUTES, VMS_ALL, "8")
+    return configurations("tomcat").otelLinux("7.0.107", TOMCAT7_SERVER_ATTRIBUTES, VMS_ALL, "8")
         .otelLinux("8.5.60", TOMCAT8_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
         .otelLinux("9.0.40", TOMCAT9_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
         .splunkWindows("7.0.107", TOMCAT7_SERVER_ATTRIBUTES, VMS_ALL, "8")
         .splunkWindows("8.5.60", TOMCAT8_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
-        .splunkWindows("9.0.40", TOMCAT9_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
-        .stream();
+        .splunkWindows("9.0.40", TOMCAT9_SERVER_ATTRIBUTES, VMS_ALL, "8", "11").stream();
   }
 
   @ParameterizedTest(name = "[{index}] {0}")

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/TomcatSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/TomcatSmokeTest.java
@@ -37,9 +37,9 @@ public class TomcatSmokeTest extends AppServerTest {
         .otelLinux("7.0.107", TOMCAT7_SERVER_ATTRIBUTES, VMS_ALL, "8")
         .otelLinux("8.5.60", TOMCAT8_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
         .otelLinux("9.0.40", TOMCAT9_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
-        .splunkWindows("7.0.107", TOMCAT7_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8")
-        .splunkWindows("8.5.60", TOMCAT8_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8", "11")
-        .splunkWindows("9.0.40", TOMCAT9_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8", "11")
+        .splunkWindows("7.0.107", TOMCAT7_SERVER_ATTRIBUTES, VMS_ALL, "8")
+        .splunkWindows("8.5.60", TOMCAT8_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
+        .splunkWindows("9.0.40", TOMCAT9_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
         .stream();
   }
 

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/TomeeSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/TomeeSmokeTest.java
@@ -31,12 +31,10 @@ public class TomeeSmokeTest extends AppServerTest {
       new TomeeAttributes("8.0.6");
 
   private static Stream<Arguments> supportedConfigurations() {
-    return configurations("tomee")
-        .otelLinux("7.0.0", TOMEE7_SERVER_ATTRIBUTES, VMS_ALL, "8")
+    return configurations("tomee").otelLinux("7.0.0", TOMEE7_SERVER_ATTRIBUTES, VMS_ALL, "8")
         .otelLinux("8.0.6", TOMEE8_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
         .splunkWindows("7.0.0", TOMEE7_SERVER_ATTRIBUTES, VMS_ALL, "8")
-        .splunkWindows("8.0.6", TOMEE8_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
-        .stream();
+        .splunkWindows("8.0.6", TOMEE8_SERVER_ATTRIBUTES, VMS_ALL, "8", "11").stream();
   }
 
   @ParameterizedTest(name = "[{index}] {0}")

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/TomeeSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/TomeeSmokeTest.java
@@ -34,8 +34,8 @@ public class TomeeSmokeTest extends AppServerTest {
     return configurations("tomee")
         .otelLinux("7.0.0", TOMEE7_SERVER_ATTRIBUTES, VMS_ALL, "8")
         .otelLinux("8.0.6", TOMEE8_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
-        .splunkWindows("7.0.0", TOMEE7_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8")
-        .splunkWindows("8.0.6", TOMEE8_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8", "11")
+        .splunkWindows("7.0.0", TOMEE7_SERVER_ATTRIBUTES, VMS_ALL, "8")
+        .splunkWindows("8.0.6", TOMEE8_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
         .stream();
   }
 

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/TomeeSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/TomeeSmokeTest.java
@@ -16,10 +16,6 @@
 
 package com.splunk.opentelemetry;
 
-import static com.splunk.opentelemetry.helper.TestImage.linuxImage;
-import static com.splunk.opentelemetry.helper.TestImage.proprietaryWindowsImage;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
-
 import com.splunk.opentelemetry.helper.TestImage;
 import java.io.IOException;
 import java.util.stream.Stream;
@@ -35,24 +31,12 @@ public class TomeeSmokeTest extends AppServerTest {
       new TomeeAttributes("8.0.6");
 
   private static Stream<Arguments> supportedConfigurations() {
-    return Stream.of(
-        arguments(
-            linuxImage(
-                "ghcr.io/open-telemetry/java-test-containers:tomee-7.0.0-jdk8-20210202.531569197"),
-            TOMEE7_SERVER_ATTRIBUTES),
-        arguments(
-            linuxImage(
-                "ghcr.io/open-telemetry/java-test-containers:tomee-8.0.6-jdk8-20210202.531569197"),
-            TOMEE8_SERVER_ATTRIBUTES),
-        arguments(
-            proprietaryWindowsImage("ghcr.io/signalfx/splunk-otel-tomee:7.0.0-jdk8-windows"),
-            TOMEE7_SERVER_ATTRIBUTES),
-        arguments(
-            proprietaryWindowsImage("ghcr.io/signalfx/splunk-otel-tomee:8.0.6-jdk8-windows"),
-            TOMEE8_SERVER_ATTRIBUTES),
-        arguments(
-            proprietaryWindowsImage("ghcr.io/signalfx/splunk-otel-tomee:8.0.6-jdk11-windows"),
-            TOMEE8_SERVER_ATTRIBUTES));
+    return configurations("tomee")
+        .otelLinux("7.0.0", TOMEE7_SERVER_ATTRIBUTES, VMS_ALL, "8")
+        .otelLinux("8.0.6", TOMEE8_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
+        .splunkWindows("7.0.0", TOMEE7_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8")
+        .splunkWindows("8.0.6", TOMEE8_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8", "11")
+        .stream();
   }
 
   @ParameterizedTest(name = "[{index}] {0}")

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/WebLogicSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/WebLogicSmokeTest.java
@@ -16,9 +16,6 @@
 
 package com.splunk.opentelemetry;
 
-import static com.splunk.opentelemetry.helper.TestImage.proprietaryLinuxImage;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
-
 import com.splunk.opentelemetry.helper.TestImage;
 import java.io.IOException;
 import java.util.stream.Stream;
@@ -42,19 +39,10 @@ class WebLogicSmokeTest extends AppServerTest {
       new AppServerTest.ExpectedServerAttributes("", "WebLogic Server", "14.1.1.0.0");
 
   private static Stream<Arguments> supportedWlsConfigurations() {
-    return Stream.of(
-        arguments(
-            proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-weblogic:12.1.3-jdkdeveloper"),
-            V12_1_ATTRIBUTES),
-        arguments(
-            proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-weblogic:12.2.1.4-jdkdeveloper"),
-            V12_2_ATTRIBUTES),
-        arguments(
-            proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-weblogic:14.1.1.0-jdkdeveloper-8"),
-            V14_ATTRIBUTES),
-        arguments(
-            proprietaryLinuxImage("ghcr.io/signalfx/splunk-otel-weblogic:14.1.1.0-jdkdeveloper-11"),
-            V14_ATTRIBUTES));
+    return configurations("weblogic")
+        .splunkLinux("12.1.3", V12_1_ATTRIBUTES, VMS_HOTSPOT, "8")
+        .splunkLinux("12.2.1.4", V12_2_ATTRIBUTES, VMS_HOTSPOT, "8")
+        .splunkLinux("14.1.1.0", V14_ATTRIBUTES, VMS_HOTSPOT, "8", "11").stream();
   }
 
   @ParameterizedTest

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/WebLogicSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/WebLogicSmokeTest.java
@@ -39,8 +39,7 @@ class WebLogicSmokeTest extends AppServerTest {
       new AppServerTest.ExpectedServerAttributes("", "WebLogic Server", "14.1.1.0.0");
 
   private static Stream<Arguments> supportedWlsConfigurations() {
-    return configurations("weblogic")
-        .splunkLinux("12.1.3", V12_1_ATTRIBUTES, VMS_HOTSPOT, "8")
+    return configurations("weblogic").splunkLinux("12.1.3", V12_1_ATTRIBUTES, VMS_HOTSPOT, "8")
         .splunkLinux("12.2.1.4", V12_2_ATTRIBUTES, VMS_HOTSPOT, "8")
         .splunkLinux("14.1.1.0", V14_ATTRIBUTES, VMS_HOTSPOT, "8", "11").stream();
   }

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/WildFlySmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/WildFlySmokeTest.java
@@ -42,8 +42,7 @@ public class WildFlySmokeTest extends AppServerTest {
         .otelLinux("21.0.0.Final", WILDFLY_21_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
         .splunkWindows("13.0.0.Final", WILDFLY_13_SERVER_ATTRIBUTES, VMS_ALL, "8")
         .splunkWindows("17.0.1.Final", WILDFLY_17_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
-        .splunkWindows("21.0.0.Final", WILDFLY_21_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
-        .stream();
+        .splunkWindows("21.0.0.Final", WILDFLY_21_SERVER_ATTRIBUTES, VMS_ALL, "8", "11").stream();
   }
 
   @ParameterizedTest(name = "[{index}] {0}")

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/WildFlySmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/WildFlySmokeTest.java
@@ -16,10 +16,6 @@
 
 package com.splunk.opentelemetry;
 
-import static com.splunk.opentelemetry.helper.TestImage.linuxImage;
-import static com.splunk.opentelemetry.helper.TestImage.proprietaryWindowsImage;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
-
 import com.splunk.opentelemetry.helper.TestImage;
 import java.io.IOException;
 import java.util.stream.Stream;
@@ -40,42 +36,14 @@ public class WildFlySmokeTest extends AppServerTest {
           "DisallowedMethodsHandler.handleRequest", "WildFly Full", "21.0.0.Final");
 
   private static Stream<Arguments> supportedConfigurations() {
-    return Stream.of(
-        arguments(
-            linuxImage(
-                "ghcr.io/open-telemetry/java-test-containers:wildfly-13.0.0.Final-jdk8-20201207.405832649"),
-            WILDFLY_13_SERVER_ATTRIBUTES),
-        arguments(
-            linuxImage(
-                "ghcr.io/open-telemetry/java-test-containers:wildfly-17.0.1.Final-jdk8-20201207.405832649"),
-            WILDFLY_17_SERVER_ATTRIBUTES),
-        arguments(
-            linuxImage(
-                "ghcr.io/open-telemetry/java-test-containers:wildfly-17.0.1.Final-jdk11-20201207.405832649"),
-            WILDFLY_17_SERVER_ATTRIBUTES),
-        arguments(
-            linuxImage(
-                "ghcr.io/open-telemetry/java-test-containers:wildfly-21.0.0.Final-jdk8-20201207.405832649"),
-            WILDFLY_21_SERVER_ATTRIBUTES),
-        arguments(
-            linuxImage(
-                "ghcr.io/open-telemetry/java-test-containers:wildfly-21.0.0.Final-jdk11-20201207.405832649"),
-            WILDFLY_21_SERVER_ATTRIBUTES),
-        arguments(
-            proprietaryWindowsImage("splunk-wildfly:13.0.0.Final-jdk8-windows"),
-            WILDFLY_13_SERVER_ATTRIBUTES),
-        arguments(
-            proprietaryWindowsImage("splunk-wildfly:17.0.1.Final-jdk8-windows"),
-            WILDFLY_17_SERVER_ATTRIBUTES),
-        arguments(
-            proprietaryWindowsImage("splunk-wildfly:17.0.1.Final-jdk11-windows"),
-            WILDFLY_17_SERVER_ATTRIBUTES),
-        arguments(
-            proprietaryWindowsImage("splunk-wildfly:21.0.0.Final-jdk8-windows"),
-            WILDFLY_21_SERVER_ATTRIBUTES),
-        arguments(
-            proprietaryWindowsImage("splunk-wildfly:21.0.0.Final-jdk11-windows"),
-            WILDFLY_21_SERVER_ATTRIBUTES));
+    return configurations("wildfly")
+        .otelLinux("13.0.0.Final", WILDFLY_13_SERVER_ATTRIBUTES, VMS_ALL, "8")
+        .otelLinux("17.0.1.Final", WILDFLY_17_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
+        .otelLinux("21.0.0.Final", WILDFLY_21_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
+        .splunkWindows("13.0.0.Final", WILDFLY_13_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8")
+        .splunkWindows("17.0.1.Final", WILDFLY_17_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8", "11")
+        .splunkWindows("21.0.0.Final", WILDFLY_21_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8", "11")
+        .stream();
   }
 
   @ParameterizedTest(name = "[{index}] {0}")

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/WildFlySmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/WildFlySmokeTest.java
@@ -40,9 +40,9 @@ public class WildFlySmokeTest extends AppServerTest {
         .otelLinux("13.0.0.Final", WILDFLY_13_SERVER_ATTRIBUTES, VMS_ALL, "8")
         .otelLinux("17.0.1.Final", WILDFLY_17_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
         .otelLinux("21.0.0.Final", WILDFLY_21_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
-        .splunkWindows("13.0.0.Final", WILDFLY_13_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8")
-        .splunkWindows("17.0.1.Final", WILDFLY_17_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8", "11")
-        .splunkWindows("21.0.0.Final", WILDFLY_21_SERVER_ATTRIBUTES, VMS_HOTSPOT, "8", "11")
+        .splunkWindows("13.0.0.Final", WILDFLY_13_SERVER_ATTRIBUTES, VMS_ALL, "8")
+        .splunkWindows("17.0.1.Final", WILDFLY_17_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
+        .splunkWindows("21.0.0.Final", WILDFLY_21_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
         .stream();
   }
 


### PR DESCRIPTION
* Adds OpenJ9 images for Windows images and JBoss images.
* The logic to define images to create in `matrix/build.gradle` has been changed to be as close as possible to the logic in OpenTelemetry - only difference currently is that this one has logic to make Windows images, add pull tasks, and can be called for multiple sets of targets as it is wrapped in a function with targets as a parameter.
* Added a more concise way to list test configurations in smoke tests now to remove duplication and to merge adding multiple JDKs and VMs of the same version into one line.
* Updated `junit-jupiter` and `mockito` dependency versions to the latest which also makes them all depend on exactly the same jupiter version. This was done because for some reason after `jcenter` removal, without redownloading dependencies it tried to use a mix of `5.7.0` and `5.6.2` packages which caused an `AbstractMethodError` during build. Did not investigate the root cause further as making sure everything requires the same version was an easy fix.