### PR TITLE
Don't use private docker registry in PR verification

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,10 +1,7 @@
 name: PR build
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
+  pull_request:
 
 jobs:
   build:
@@ -16,15 +13,8 @@ jobs:
         with:
           java-version: 11
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN }}
-
       - name: Build and test
-        run: ./gradlew pullProprietaryTestImages build --scan --no-daemon
+        run: ./gradlew build --scan --no-daemon
 
   build_windows:
     runs-on: windows-latest


### PR DESCRIPTION
We use private Docker container registry which requires authentication. But GitHub does not pass repository secrets to PRs from forks. Which in general means that we cannot use private registry during PR. Thus let's do it in builds on main branch only.