### PR TITLE
Remove jfrog oss-snapshot-local repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,9 +37,6 @@ subprojects {
     maven {
       url = uri("https://dl.bintray.com/open-telemetry/maven")
     }
-    maven {
-      url = uri("https://oss.jfrog.org/artifactory/oss-snapshot-local")
-    }
     mavenCentral()
     maven {
       url = uri("https://oss.sonatype.org/content/repositories/snapshots")


### PR DESCRIPTION
According to @iNikem it shouldn't be needed anymore. For some reason having it before `mavenCentral` slows down build by quite a bit.