### PR TITLE
Fix jboss eap image name

### DIFF
--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/JBossEapSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/JBossEapSmokeTest.java
@@ -36,7 +36,7 @@ public class JBossEapSmokeTest extends AppServerTest {
       new ExpectedServerAttributes("HTTP GET", "JBoss EAP", "7.3.0.GA");
 
   private static Stream<Arguments> jboss() {
-    return configurations("jboss")
+    return configurations("jboss-eap")
         .splunkLinux("7.1.0", JBOSS_EAP_7_1_SERVER_ATTRIBUTES, VMS_ALL, "8")
         .splunkLinux("7.3.0", JBOSS_EAP_7_3_SERVER_ATTRIBUTES, VMS_ALL, "8", "11").stream();
   }


### PR DESCRIPTION
We skip tests for proprietary images that are not found, as the image name is wrong jboss eap tests are currently skipped.