### PR TITLE
Verify in smoke tests that JVM metrics are exported

### DIFF
--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -11,8 +11,8 @@ dependencies {
   testImplementation("com.fasterxml.jackson.core:jackson-databind:2.11.2")
   testImplementation("com.google.protobuf:protobuf-java-util:3.12.4")
   testImplementation("com.squareup.okhttp3:okhttp:3.12.12")
-  testImplementation("io.opentelemetry:opentelemetry-proto:0.16.0")
-  testImplementation("io.opentelemetry:opentelemetry-api:0.16.0")
+  testImplementation("io.opentelemetry:opentelemetry-proto:${versions.opentelemetryAlpha}")
+  testImplementation("io.opentelemetry:opentelemetry-api:${versions.opentelemetry}")
 
   testImplementation("ch.qos.logback:logback-classic:1.2.3")
   testImplementation("org.junit.jupiter:junit-jupiter-params:${versions.jupiter}")

--- a/smoke-tests/fake-backend/build.gradle
+++ b/smoke-tests/fake-backend/build.gradle
@@ -57,7 +57,10 @@ task windowsCollectorBinaryDownload(type: Download) {
     collectorDockerBuildDir.mkdirs()
   }
 
-  src("https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/download/v0.22.0/otelcontribcol_windows_amd64.exe")
+  // TODO: the contrib image does not have https://github.com/open-telemetry/opentelemetry-collector/pull/2272
+  // and it cannot start properly on windows because of this
+  // src("https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/download/v0.22.0/otelcontribcol_windows_amd64.exe")
+  src("https://github.com/open-telemetry/opentelemetry-collector/releases/download/v0.18.0/otelcol_windows_amd64.exe")
   dest(collectorDockerBuildDir)
 }
 

--- a/smoke-tests/fake-backend/build.gradle
+++ b/smoke-tests/fake-backend/build.gradle
@@ -21,7 +21,7 @@ compileJava {
 
 dependencies {
   implementation("com.linecorp.armeria:armeria-grpc:1.0.0")
-  implementation("io.opentelemetry:opentelemetry-proto:0.10.0")
+  implementation("io.opentelemetry:opentelemetry-proto:1.0.0-alpha")
   implementation("org.slf4j:slf4j-simple:1.7.30")
 }
 

--- a/smoke-tests/fake-backend/build.gradle
+++ b/smoke-tests/fake-backend/build.gradle
@@ -57,7 +57,7 @@ task windowsCollectorBinaryDownload(type: Download) {
     collectorDockerBuildDir.mkdirs()
   }
 
-  src("https://github.com/open-telemetry/opentelemetry-collector/releases/download/v0.18.0/otelcol_windows_amd64.exe")
+  src("https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/download/v0.22.0/otelcontribcol_windows_amd64.exe")
   dest(collectorDockerBuildDir)
 }
 

--- a/smoke-tests/fake-backend/src/docker/collector/windows.dockerfile
+++ b/smoke-tests/fake-backend/src/docker/collector/windows.dockerfile
@@ -1,4 +1,4 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
-COPY otelcol_windows_amd64.exe /otelcol_windows_amd64.exe
+COPY otelcontribcol_windows_amd64.exe /otelcontribcol_windows_amd64.exe
 ENV NO_WINDOWS_SERVICE=1
-ENTRYPOINT /otelcol_windows_amd64.exe
+ENTRYPOINT /otelcontribcol_windows_amd64.exe

--- a/smoke-tests/fake-backend/src/docker/collector/windows.dockerfile
+++ b/smoke-tests/fake-backend/src/docker/collector/windows.dockerfile
@@ -1,4 +1,4 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
-COPY otelcontribcol_windows_amd64.exe /otelcontribcol_windows_amd64.exe
+COPY otelcol_windows_amd64.exe /otelcol_windows_amd64.exe
 ENV NO_WINDOWS_SERVICE=1
-ENTRYPOINT /otelcontribcol_windows_amd64.exe
+ENTRYPOINT /otelcol_windows_amd64.exe

--- a/smoke-tests/fake-backend/src/main/java/com/splunk/opentelemetry/smoketest/fakebackend/FakeBackendMain.java
+++ b/smoke-tests/fake-backend/src/main/java/com/splunk/opentelemetry/smoketest/fakebackend/FakeBackendMain.java
@@ -30,6 +30,7 @@ import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.grpc.GrpcService;
 import com.linecorp.armeria.server.healthcheck.HealthCheckService;
 import io.netty.buffer.ByteBufOutputStream;
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -43,6 +44,7 @@ public class FakeBackendMain {
     var marshaller =
         MessageMarshaller.builder()
             .register(ExportTraceServiceRequest.getDefaultInstance())
+            .register(ExportMetricsServiceRequest.getDefaultInstance())
             .build();
 
     var mapper = JsonMapper.builder();
@@ -57,27 +59,50 @@ public class FakeBackendMain {
             marshaller.writeValue(value, gen);
           }
         });
+    serializers.addSerializer(
+        new StdSerializer<>(ExportMetricsServiceRequest.class) {
+          @Override
+          public void serialize(
+              ExportMetricsServiceRequest value, JsonGenerator gen, SerializerProvider provider)
+              throws IOException {
+            marshaller.writeValue(value, gen);
+          }
+        });
     module.setSerializers(serializers);
     mapper.addModule(module);
     OBJECT_MAPPER = mapper.build();
   }
 
   public static void main(String[] args) {
-    var collector = new FakeCollectorService();
+    var traceCollector = new FakeTraceCollectorService();
+    var metricsCollector = new FakeMetricsCollectorService();
     var server =
         Server.builder()
             .http(8080)
-            .service(GrpcService.builder().addService(collector).build())
+            .service(GrpcService.builder()
+                .addService(traceCollector)
+                .addService(metricsCollector)
+                .build())
             .service(
-                "/clear-requests",
+                "/clear",
                 (ctx, req) -> {
-                  collector.clearRequests();
+                  traceCollector.clearRequests();
+                  metricsCollector.clearRequests();
                   return HttpResponse.of(HttpStatus.OK);
                 })
             .service(
-                "/get-requests",
+                "/get-traces",
                 (ctx, req) -> {
-                  var requests = collector.getRequests();
+                  var requests = traceCollector.getRequests();
+                  var buf = new ByteBufOutputStream(ctx.alloc().buffer());
+                  OBJECT_MAPPER.writeValue((OutputStream) buf, requests);
+                  return HttpResponse.of(
+                      HttpStatus.OK, MediaType.JSON, HttpData.wrap(buf.buffer()));
+                })
+            .service(
+                "/get-metrics",
+                (ctx, req) -> {
+                  var requests = metricsCollector.getRequests();
                   var buf = new ByteBufOutputStream(ctx.alloc().buffer());
                   OBJECT_MAPPER.writeValue((OutputStream) buf, requests);
                   return HttpResponse.of(

--- a/smoke-tests/fake-backend/src/main/java/com/splunk/opentelemetry/smoketest/fakebackend/FakeMetricsCollectorService.java
+++ b/smoke-tests/fake-backend/src/main/java/com/splunk/opentelemetry/smoketest/fakebackend/FakeMetricsCollectorService.java
@@ -1,0 +1,33 @@
+package com.splunk.opentelemetry.smoketest.fakebackend;
+
+import com.google.common.collect.ImmutableList;
+import io.grpc.stub.StreamObserver;
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
+import io.opentelemetry.proto.collector.metrics.v1.MetricsServiceGrpc;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+
+class FakeMetricsCollectorService extends MetricsServiceGrpc.MetricsServiceImplBase {
+
+  private final BlockingQueue<ExportMetricsServiceRequest> exportRequests =
+      new LinkedBlockingDeque<>();
+
+  List<ExportMetricsServiceRequest> getRequests() {
+    return ImmutableList.copyOf(exportRequests);
+  }
+
+  void clearRequests() {
+    exportRequests.clear();
+  }
+
+  @Override
+  public void export(
+      ExportMetricsServiceRequest request,
+      StreamObserver<ExportMetricsServiceResponse> responseObserver) {
+    exportRequests.add(request);
+    responseObserver.onNext(ExportMetricsServiceResponse.getDefaultInstance());
+    responseObserver.onCompleted();
+  }
+}

--- a/smoke-tests/fake-backend/src/main/java/com/splunk/opentelemetry/smoketest/fakebackend/FakeTraceCollectorService.java
+++ b/smoke-tests/fake-backend/src/main/java/com/splunk/opentelemetry/smoketest/fakebackend/FakeTraceCollectorService.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 
-class FakeCollectorService extends TraceServiceGrpc.TraceServiceImplBase {
+class FakeTraceCollectorService extends TraceServiceGrpc.TraceServiceImplBase {
 
   private final BlockingQueue<ExportTraceServiceRequest> exportRequests =
       new LinkedBlockingDeque<>();

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/AppServerTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/AppServerTest.java
@@ -160,7 +160,7 @@ public abstract class AppServerTest extends SmokeTest {
         traces.getServerSpanAttribute("middleware.version"),
         "Middleware version tag on server span");
 
-    resetBackend();
+    clearTelemetry();
   }
 
   protected String getUrl(String path, boolean originalPort) {

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/MetricsInspector.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/MetricsInspector.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry;
+
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
+import java.util.Collection;
+import java.util.Objects;
+
+class MetricsInspector {
+  private final Collection<ExportMetricsServiceRequest> requests;
+
+  MetricsInspector(Collection<ExportMetricsServiceRequest> requests) {
+    this.requests = requests;
+  }
+
+  boolean hasMetricsNamed(String metricName) {
+    return requests.stream()
+        .flatMap(list -> list.getResourceMetricsList().stream())
+        .flatMap(list -> list.getInstrumentationLibraryMetricsList().stream())
+        .flatMap(list -> list.getMetricsList().stream())
+        .anyMatch(metric -> Objects.equals(metric.getName(), metricName));
+  }
+}

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/TelemetryRetriever.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/TelemetryRetriever.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.GeneratedMessageV3;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.ResponseBody;
+
+class TelemetryRetriever {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private final OkHttpClient client;
+  private final int backendPort;
+
+  TelemetryRetriever(OkHttpClient client, int backendPort) {
+    this.client = client;
+    this.backendPort = backendPort;
+  }
+
+  void clearTelemetry() throws IOException {
+    client
+        .newCall(
+            new Request.Builder()
+                .url(String.format("http://localhost:%d/clear", backendPort))
+                .build())
+        .execute()
+        .close();
+  }
+
+  TraceInspector waitForTraces() throws IOException, InterruptedException {
+    Stream<JsonNode> content = waitForContent("get-traces");
+
+    return new TraceInspector(
+        content.map(this::deserializeTraceRequest).collect(Collectors.toList()));
+  }
+
+  MetricsInspector waitForMetrics() throws IOException, InterruptedException {
+    Stream<JsonNode> content = waitForContent("get-metrics");
+
+    return new MetricsInspector(
+        content.map(this::deserializeMetricsRequest).collect(Collectors.toList()));
+  }
+
+  private ExportTraceServiceRequest deserializeTraceRequest(JsonNode it) {
+    var builder = ExportTraceServiceRequest.newBuilder();
+    deserializeIntoBuilder(it, builder);
+    return builder.build();
+  }
+
+  private ExportMetricsServiceRequest deserializeMetricsRequest(JsonNode it) {
+    var builder = ExportMetricsServiceRequest.newBuilder();
+    deserializeIntoBuilder(it, builder);
+    return builder.build();
+  }
+
+  private void deserializeIntoBuilder(JsonNode it, GeneratedMessageV3.Builder<?> builder) {
+    // TODO(anuraaga): Register parser into object mapper to avoid de -> re ->
+    // deserialize.
+    try {
+      JsonFormat.parser().merge(OBJECT_MAPPER.writeValueAsString(it), builder);
+    } catch (InvalidProtocolBufferException | JsonProcessingException e) {
+      throw new IllegalArgumentException("Invalid telemetry data", e);
+    }
+  }
+
+  private Stream<JsonNode> waitForContent(String path) throws IOException, InterruptedException {
+    long previousSize = 0;
+    long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
+    String content = "[]";
+    while (System.currentTimeMillis() < deadline) {
+
+      Request request =
+          new Request.Builder()
+              .url(String.format("http://localhost:%d/%s", backendPort, path))
+              .build();
+
+      try (ResponseBody body = client.newCall(request).execute().body()) {
+        content = body.string();
+      }
+
+      if (content.length() > 2 && content.length() == previousSize) {
+        break;
+      }
+      previousSize = content.length();
+      System.out.printf("Current content size %d%n", previousSize);
+      TimeUnit.MILLISECONDS.sleep(500);
+    }
+
+    return StreamSupport.stream(OBJECT_MAPPER.readTree(content).spliterator(), false);
+  }
+}

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/TelemetryRetriever.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/TelemetryRetriever.java
@@ -35,6 +35,7 @@ import okhttp3.ResponseBody;
 
 class TelemetryRetriever {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final String EMPTY_CONTENT = "[]";
 
   private final OkHttpClient client;
   private final int backendPort;
@@ -81,8 +82,6 @@ class TelemetryRetriever {
   }
 
   private void deserializeIntoBuilder(JsonNode it, GeneratedMessageV3.Builder<?> builder) {
-    // TODO(anuraaga): Register parser into object mapper to avoid de -> re ->
-    // deserialize.
     try {
       JsonFormat.parser().merge(OBJECT_MAPPER.writeValueAsString(it), builder);
     } catch (InvalidProtocolBufferException | JsonProcessingException e) {
@@ -93,7 +92,7 @@ class TelemetryRetriever {
   private Stream<JsonNode> waitForContent(String path) throws IOException, InterruptedException {
     long previousSize = 0;
     long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
-    String content = "[]";
+    String content = EMPTY_CONTENT;
     while (System.currentTimeMillis() < deadline) {
 
       Request request =
@@ -105,7 +104,7 @@ class TelemetryRetriever {
         content = body.string();
       }
 
-      if (content.length() > 2 && content.length() == previousSize) {
+      if (content.length() > EMPTY_CONTENT.length() && content.length() == previousSize) {
         break;
       }
       previousSize = content.length();

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/WildFlySmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/WildFlySmokeTest.java
@@ -43,6 +43,7 @@ public class WildFlySmokeTest extends AppServerTest {
         .splunkWindows("21.0.0.Final", WILDFLY_21_SERVER_ATTRIBUTES, VMS_ALL, "8", "11").stream();
   }
 
+  // TODO: this method can be removed after upstream javaagent 1.1.0 release
   // openj9 JDK8 does not have JFR classes, which causes all ComponentInstallers to run
   // synchronously, not after LogManager is loaded - see
   // AgentInstaller#installComponentsAfterByteBuddy()

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/AbstractTestContainerManager.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/AbstractTestContainerManager.java
@@ -32,10 +32,12 @@ public abstract class AbstractTestContainerManager implements TestContainerManag
     Map<String, String> environment = new HashMap<>();
     environment.put("JAVA_TOOL_OPTIONS", "-javaagent:/" + TARGET_AGENT_FILENAME);
     environment.put("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "1");
-    environment.put("OTEL_BSP_SCHEDULE_DELAY", "10");
-    environment.put("OTEL_IMR_EXPORT_INTERVAL", "1000");
+    environment.put("OTEL_BSP_SCHEDULE_DELAY", "10ms");
     environment.put(
         "OTEL_EXPORTER_JAEGER_ENDPOINT", "http://" + COLLECTOR_ALIAS + ":14268/api/traces");
+    // export metrics every 1s
+    environment.put("SPLUNK_METRICS_EXPORT_INTERVAL", "1000");
+    environment.put("SPLUNK_METRICS_ENDPOINT", "http://" + COLLECTOR_ALIAS + ":9943/v2/datapoint");
     environment.put("OTEL_RESOURCE_ATTRIBUTES", "service.name=smoke-test");
     return environment;
   }

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/LinuxTestContainerManager.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/LinuxTestContainerManager.java
@@ -50,7 +50,7 @@ public class LinuxTestContainerManager extends AbstractTestContainerManager {
     backend.start();
 
     collector =
-        new GenericContainer<>(DockerImageName.parse("otel/opentelemetry-collector-contrib:0.19.0"))
+        new GenericContainer<>(DockerImageName.parse("otel/opentelemetry-collector-contrib:0.22.0"))
             .dependsOn(backend)
             .withNetwork(network)
             .withNetworkAliases(COLLECTOR_ALIAS)

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/LinuxTestContainerManager.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/LinuxTestContainerManager.java
@@ -41,7 +41,7 @@ public class LinuxTestContainerManager extends AbstractTestContainerManager {
     backend =
         new GenericContainer<>(
                 DockerImageName.parse(
-                    "ghcr.io/open-telemetry/java-test-containers:smoke-fake-backend-20210126.1126194"))
+                    "ghcr.io/open-telemetry/java-test-containers:smoke-fake-backend-20210319.060589"))
             .withExposedPorts(BACKEND_PORT)
             .waitingFor(Wait.forHttp("/health").forPort(BACKEND_PORT))
             .withNetwork(network)

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/windows/WindowsTestContainerManager.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/windows/WindowsTestContainerManager.java
@@ -65,6 +65,8 @@ public class WindowsTestContainerManager extends AbstractTestContainerManager {
 
   private static final String NPIPE_URI = "npipe:////./pipe/docker_engine";
   private static final String COLLECTOR_CONFIG_FILE_PATH = "/collector-config.yml";
+  // TODO: Windows has to have a separate config file for the time being
+  private static final String WINDOWS_COLLECTOR_CONFIG_RESOURCE = "/otelcol-windows.yaml";
 
   private final DockerClient client =
       DockerClientImpl.getInstance(
@@ -117,7 +119,7 @@ public class WindowsTestContainerManager extends AbstractTestContainerManager {
             },
             containerId -> {
               try (InputStream configFileStream =
-                  this.getClass().getResourceAsStream(COLLECTOR_CONFIG_RESOURCE)) {
+                  this.getClass().getResourceAsStream(WINDOWS_COLLECTOR_CONFIG_RESOURCE)) {
                 copyFileToContainer(
                     containerId, IOUtils.toByteArray(configFileStream), COLLECTOR_CONFIG_FILE_PATH);
               } catch (IOException e) {
@@ -183,6 +185,8 @@ public class WindowsTestContainerManager extends AbstractTestContainerManager {
     List<String> environment = new ArrayList<>();
     getAgentEnvironment().forEach((key, value) -> environment.add(key + "=" + value));
     extraEnv.forEach((key, value) -> environment.add(key + "=" + value));
+    // TODO: Windows collector image cannot accept signalfx metrics right now, turning them off
+    environment.add("SPLUNK_METRICS_ENABLED=false");
 
     target =
         startContainer(

--- a/smoke-tests/src/test/resources/otel.yaml
+++ b/smoke-tests/src/test/resources/otel.yaml
@@ -10,6 +10,7 @@ receivers:
     protocols:
       grpc:
       thrift_http:
+  signalfx:
 
 processors:
   batch:
@@ -24,8 +25,12 @@ exporters:
 service:
   pipelines:
     traces:
-      receivers: [jaeger]
-      processors: [batch]
-      exporters: [logging, otlp]
+      receivers: [ jaeger ]
+      processors: [ batch ]
+      exporters: [ logging, otlp ]
+    metrics:
+      receivers: [ signalfx ]
+      processors: [ batch ]
+      exporters: [ logging, otlp ]
 
-  extensions: [health_check, pprof, zpages]
+  extensions: [ health_check, pprof, zpages ]

--- a/smoke-tests/src/test/resources/otel.yaml
+++ b/smoke-tests/src/test/resources/otel.yaml
@@ -31,6 +31,6 @@ service:
     metrics:
       receivers: [ signalfx ]
       processors: [ batch ]
-      exporters: [ logging, otlp ]
+      exporters: [ otlp ]
 
   extensions: [ health_check, pprof, zpages ]

--- a/smoke-tests/src/test/resources/otelcol-windows.yaml
+++ b/smoke-tests/src/test/resources/otelcol-windows.yaml
@@ -1,0 +1,31 @@
+extensions:
+  health_check:
+  pprof:
+    endpoint: 0.0.0.0:1777
+  zpages:
+    endpoint: 0.0.0.0:55679
+
+receivers:
+  jaeger:
+    protocols:
+      grpc:
+      thrift_http:
+
+processors:
+  batch:
+
+exporters:
+  logging:
+    loglevel: debug
+  otlp:
+    endpoint: backend:8080
+    insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [ jaeger ]
+      processors: [ batch ]
+      exporters: [ logging, otlp ]
+
+  extensions: [ health_check, pprof, zpages ]


### PR DESCRIPTION
This PR implements smoke tests verifying that our micrometer metrics get consumed by the collector correctly (and `runtime.` is added).

* Applied same fake-backend changes as in the upstream javaagent project
* Bumped otel-collector version
* Changed windows otel-collector image to contrib (has signalfx receiver)