### PR TITLE
Deployment environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ A couple other configuration options that may need to be changed or set are:
 - Endpoint if not sending to a locally running Smart Agent with default
   configuration. See the [Jaeger exporter](#jaeger-exporter) section for more information.
 - Environment resource attribute (example:
-  `-Dotel.resource.attributes=service.name=my-service,environment=production`) to specify what
+  `-Dotel.resource.attributes=service.name=my-service,deployment.environment=production`) to specify what
   environment the span originated from.
 
 ### Supported Java Versions
@@ -138,7 +138,7 @@ OpenTelemetry Instrumentation for Java version 1.0.0 and API version 1.0.0.
 To correlate traces with logs it is possible to add the following metadata from traces to logs:
 
  - Trace: `trace_id` and `span_id`
- - Resource: `service.name` and `environment`
+ - Resource: `service.name` and `deployment.environment`
 
 Documentation on how to inject trace context into logs is available
 [here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/logger-mdc-instrumentation.md).

--- a/custom/src/main/java/com/splunk/opentelemetry/micrometer/GlobalTagsBuilder.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/micrometer/GlobalTagsBuilder.java
@@ -33,15 +33,18 @@ class GlobalTagsBuilder {
   List<Tag> build() {
     List<Tag> globalTags = new ArrayList<>(4);
     // Use deployment.environment if it's there, otherwise fall back to environment
-    addTag(globalTags, "deployment.environment", AttributeKey.stringKey("deployment.environment"), AttributeKey.stringKey("environment"));
+    addTag(
+        globalTags,
+        "deployment.environment",
+        AttributeKey.stringKey("deployment.environment"),
+        AttributeKey.stringKey("environment"));
     addTag(globalTags, "service", ResourceAttributes.SERVICE_NAME);
     addTag(globalTags, "runtime", ResourceAttributes.PROCESS_RUNTIME_NAME);
     addTag(globalTags, "process.pid", ResourceAttributes.PROCESS_PID);
     return globalTags;
   }
 
-
-  private void addTag(List<Tag> tags, String tagName, AttributeKey<?> ... resourceAttributeKeys) {
+  private void addTag(List<Tag> tags, String tagName, AttributeKey<?>... resourceAttributeKeys) {
     for (AttributeKey<?> key : resourceAttributeKeys) {
       Object value = resource.getAttributes().get(key);
       if (value != null) {

--- a/custom/src/main/java/com/splunk/opentelemetry/micrometer/GlobalTagsBuilder.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/micrometer/GlobalTagsBuilder.java
@@ -32,17 +32,22 @@ class GlobalTagsBuilder {
 
   List<Tag> build() {
     List<Tag> globalTags = new ArrayList<>(4);
-    addTag(globalTags, "deployment.environment", AttributeKey.stringKey("environment"));
+    // Use deployment.environment if it's there, otherwise fall back to environment
+    addTag(globalTags, "deployment.environment", AttributeKey.stringKey("deployment.environment"), AttributeKey.stringKey("environment"));
     addTag(globalTags, "service", ResourceAttributes.SERVICE_NAME);
     addTag(globalTags, "runtime", ResourceAttributes.PROCESS_RUNTIME_NAME);
     addTag(globalTags, "process.pid", ResourceAttributes.PROCESS_PID);
     return globalTags;
   }
 
-  private void addTag(List<Tag> tags, String tagName, AttributeKey<?> resourceAttributeKey) {
-    Object value = resource.getAttributes().get(resourceAttributeKey);
-    if (value != null) {
-      tags.add(Tag.of(tagName, value.toString()));
+
+  private void addTag(List<Tag> tags, String tagName, AttributeKey<?> ... resourceAttributeKeys) {
+    for (AttributeKey<?> key : resourceAttributeKeys) {
+      Object value = resource.getAttributes().get(key);
+      if (value != null) {
+        tags.add(Tag.of(tagName, value.toString()));
+        return;
+      }
     }
   }
 }

--- a/custom/src/test/java/com/splunk/opentelemetry/micrometer/GlobalTagsBuilderTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/micrometer/GlobalTagsBuilderTest.java
@@ -73,9 +73,8 @@ class GlobalTagsBuilderTest {
             Attributes.of(
                 AttributeKey.stringKey("deployment.environment"),
                 "gauntlet",
-                  AttributeKey.stringKey("environment"),
-                "oldstyle"
-            ));
+                AttributeKey.stringKey("environment"),
+                "oldstyle"));
 
     // when
     var tags = new GlobalTagsBuilder(resource).build();

--- a/custom/src/test/java/com/splunk/opentelemetry/micrometer/GlobalTagsBuilderTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/micrometer/GlobalTagsBuilderTest.java
@@ -64,4 +64,24 @@ class GlobalTagsBuilderTest {
     assertEquals(Tag.of("runtime", "OpenJDK Runtime Environment"), tags.get(2));
     assertEquals(Tag.of("process.pid", "12345"), tags.get(3));
   }
+
+  @Test
+  void preferDeploymentEnvironment() {
+    // given
+    var resource =
+        Resource.create(
+            Attributes.of(
+                AttributeKey.stringKey("deployment.environment"),
+                "gauntlet",
+                  AttributeKey.stringKey("environment"),
+                "oldstyle"
+            ));
+
+    // when
+    var tags = new GlobalTagsBuilder(resource).build();
+
+    // then
+    assertEquals(1, tags.size());
+    assertEquals(Tag.of("deployment.environment", "gauntlet"), tags.get(0));
+  }
 }


### PR DESCRIPTION
We want to standardize on `deployment.environment` so this fixes up the README for this.  Since the micrometer tag builder was using `environment`, this creates a fallback/safeguard that prefers `deployment.environment`.