### PR TITLE
Update migration.md to match github.com/signalfx/splunk-otel-java

### DIFF
--- a/migration.md
+++ b/migration.md
@@ -32,14 +32,14 @@ distribution of Splunk Distribution of OpenTelemetry Java Instrumentation:
    variable. This is how you can set it with an environment variable with a
    service name of `yourServiceName`:
    ```
-   $ EXPORT OTEL_EXPORTER_ZIPKIN_SERVICE_NAME="yourServiceName"
+   $ EXPORT OTEL_RESOURCE_ATTRIBUTES=service.name=my-java-app
    ```
 3. Specify the endpoint of the SignalFx Smart Agent or OpenTelemetry Collector
    you're exporting traces to. You can set the endpoint with a system property
    or environment variable. This is how you can set it with an environment
    variable with an endpoint of `http://yourEndpoint:9080/v1/trace`:
    ```
-   $ EXPORT OTEL_EXPORTER_ZIPKIN_ENDPOINT="http://yourEndpoint:9080/v1/trace"
+   $ EXPORT OTEL_EXPORTER_JAEGER_ENDPOINT="http://yourEndpoint:9080/v1/trace"
    ```
    The default value is `http://localhost:9080/v1/trace`. If you're exporting
    traces to a local Smart Agent, you don't have to modify this configuration
@@ -68,8 +68,8 @@ OpenTelemetry system properties:
 
 | SignalFx system property | OpenTelemetry system property |
 | ------------------------ | ----------------------------- |
-| `signalfx.service.name` | `otel.exporter.zipkin.service.name` |
-| `signalfx.endpoint.url` | `otel.exporter.zipkin.endpoint` |
+| `signalfx.service.name` | `otel.resource.attributes=service.name=my-java-app` |
+| `signalfx.endpoint.url` | `otel.exporter.jaeger.endpoint` |
 | `signalfx.tracing.enabled` | `otel.trace.enabled` |
 | `signalfx.span.tags` | `otel.resource.attributes` |
 | `signalfx.recorded.value.max.length` | `otel.config.max.attr.length` |
@@ -83,12 +83,11 @@ OpenTelemetry environment variables:
 
 | SignalFx environment variable | OpenTelemetry environment variable |
 | ----------------------------- | ---------------------------------- |
-| `SIGNALFX_SERVICE_NAME` | `OTEL_EXPORTER_ZIPKIN_SERVICE_NAME` |
-| `SIGNALFX_ENDPOINT_URL` |`OTEL_EXPORTER_ZIPKIN_ENDPOINT` |
+| `SIGNALFX_SERVICE_NAME` | `OTEL_RESOURCE_ATTRIBUTES=service.name=my-java-app` |
+| `SIGNALFX_ENDPOINT_URL` |`OTEL_EXPORTER_JAEGER_ENDPOINT` |
 | `SIGNALFX_TRACING_ENABLED` | `OTEL_TRACE_ENABLED` |
 | `SIGNALFX_SPAN_TAGS` | `OTEL_RESOURCE_ATTRIBUTES` |
 | `SIGNALFX_RECORDED_VALUE_MAX_LENGTH` | `OTEL_CONFIG_MAX_ATTR_LENGTH` |
-| `SIGNALFX_DB_STATEMENT_MAX_LENGTH` | `OTEL_CONFIG_MAX_ATTR_LENGTH` |
 | `SIGNALFX_TRACE_ANNOTATED_METHOD_BLACKLIST` | `OTEL_TRACE_ANNOTATED_METHODS_EXCLUDE` |
 | `SIGNALFX_TRACE_METHODS` | `OTEL_TRACE_METHODS` |
 


### PR DESCRIPTION
In looking at https://github.com/signalfx/splunk-otel-java, it has different environment variable names and system property names than the migration guide.
Updating the migration guide to match the latest version of the splunk-otel-java agent.