### PR TITLE
Fix main branch test failures

### DIFF
--- a/custom/src/main/java/com/splunk/opentelemetry/micrometer/MicrometerInstaller.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/micrometer/MicrometerInstaller.java
@@ -32,13 +32,16 @@ public class MicrometerInstaller implements ComponentInstaller {
   @Override
   public void beforeByteBuddyAgent() {
     Resource resource = OpenTelemetrySdkAutoConfiguration.getResource();
-    GlobalMetricsTags.set(new GlobalTagsBuilder(resource).build());
-    Metrics.addRegistry(createSplunkMeterRegistry(resource));
+    SplunkMetricsConfig splunkMetricsConfig = new SplunkMetricsConfig(Config.get(), resource);
+
+    if (splunkMetricsConfig.enabled()) {
+      GlobalMetricsTags.set(new GlobalTagsBuilder(resource).build());
+      Metrics.addRegistry(createSplunkMeterRegistry(splunkMetricsConfig));
+    }
   }
 
-  private static SignalFxMeterRegistry createSplunkMeterRegistry(Resource resource) {
-    SignalFxMeterRegistry signalFxRegistry =
-        new SignalFxMeterRegistry(new SplunkMetricsConfig(Config.get(), resource), Clock.SYSTEM);
+  private static SignalFxMeterRegistry createSplunkMeterRegistry(SplunkMetricsConfig config) {
+    SignalFxMeterRegistry signalFxRegistry = new SignalFxMeterRegistry(config, Clock.SYSTEM);
     NamingConvention signalFxNamingConvention = signalFxRegistry.config().namingConvention();
     signalFxRegistry.config().namingConvention(new OtelNamingConvention(signalFxNamingConvention));
     return signalFxRegistry;

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/JBossEapSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/JBossEapSmokeTest.java
@@ -51,7 +51,7 @@ public class JBossEapSmokeTest extends AppServerTest {
   // AFAIK only openj9 (IBM) JDK 8 has this problem, all other JDKs don't use JUL in MBeans
   @Override
   protected Map<String, String> getExtraEnv() {
-    return Map.of("OTEL_INSTRUMENTATION_JVM_METRICS_ENABLED", "false");
+    return Map.of("SPLUNK_METRICS_ENABLED", "false");
   }
 
   @ParameterizedTest(name = "[{index}] {0}")

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/WildFlySmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/WildFlySmokeTest.java
@@ -52,7 +52,7 @@ public class WildFlySmokeTest extends AppServerTest {
   // AFAIK only openj9 (IBM) JDK 8 has this problem, all other JDKs don't use JUL in MBeans
   @Override
   protected Map<String, String> getExtraEnv() {
-    return Map.of("OTEL_INSTRUMENTATION_JVM_METRICS_ENABLED", "false");
+    return Map.of("SPLUNK_METRICS_ENABLED", "false");
   }
 
   @ParameterizedTest(name = "[{index}] {0}")


### PR DESCRIPTION
This should fix the condition 

```java
    boolean metricsRegistryPresent = !Metrics.globalRegistry.getRegistries().isEmpty();
```

in metrics instrumentation modules.