### PR TITLE
Use same otel collector config as the upstream repo

### DIFF
--- a/smoke-tests/src/test/resources/otel.yaml
+++ b/smoke-tests/src/test/resources/otel.yaml
@@ -16,8 +16,10 @@ processors:
   batch:
 
 exporters:
-  logging:
+  logging/logging_debug:
     loglevel: debug
+  logging/logging_info:
+    loglevel: info
   otlp:
     endpoint: backend:8080
     insecure: true
@@ -27,10 +29,10 @@ service:
     traces:
       receivers: [ jaeger ]
       processors: [ batch ]
-      exporters: [ logging, otlp ]
+      exporters: [ logging/logging_debug, otlp ]
     metrics:
       receivers: [ signalfx ]
       processors: [ batch ]
-      exporters: [ otlp ]
+      exporters: [ logging/logging_info, otlp ]
 
   extensions: [ health_check, pprof, zpages ]


### PR DESCRIPTION
Almost the same actually: we have the signalfx receiver