### PR TITLE
Don't merge. Enable more logging for smoke tests

### DIFF
--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -29,6 +29,8 @@ tasks.test {
     maxRetries = System.getenv("CI") != null ? 5 : 0
   }
 
+  testLogging.showStandardStreams = true
+
   reports {
     junitXml.outputPerTestCase = true
   }

--- a/smoke-tests/src/test/resources/logback.xml
+++ b/smoke-tests/src/test/resources/logback.xml
@@ -25,5 +25,9 @@
   <logger name="LoggerIntegrationTest" level="trace"/>
   <logger name="io.opentelemetry" level="debug"/>
   <logger name="com.splunk" level="debug"/>
+  <logger name="org.testcontainers" level="debug"/>
+  <logger name="org.testcontainers.shaded" level="warn"/>
+  <logger name="org.testcontainers.containers.output.WaitingConsumer" level="warn"/>
+  <logger name="com.github.dockerjava" level="debug"/>
 
 </configuration>


### PR DESCRIPTION
Add more debug logging to smoke tests. Perhaps this will help us understand why windows tests run slowly in otel.