### PR TITLE
Build splunk-otel-collector Windows docker image for tests

### DIFF
--- a/.github/workflows/publish-otel-collector-contrib-windows.yaml
+++ b/.github/workflows/publish-otel-collector-contrib-windows.yaml
@@ -1,0 +1,37 @@
+name: Build splunk-otel-collector Windows docker image
+
+on:
+  push:
+    paths:
+      - 'smoke-tests/otel-collector-contrib-windows/**'
+      - '.github/workflows/publish-otel-collector-contrib-windows.yaml'
+    branches: [ 'main' ]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Support longpaths
+        run: git config --system core.longpaths true
+
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Login to GitHub Package Registry
+        uses: azure/docker-login@v1
+        with:
+          login-server: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push docker image
+        run: ./build.sh "$GITHUB_RUN_ID"
+        working-directory: smoke-tests/otel-collector-contrib-windows

--- a/smoke-tests/otel-collector-contrib-windows/Dockerfile
+++ b/smoke-tests/otel-collector-contrib-windows/Dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+ADD https://github.com/signalfx/splunk-otel-collector/releases/latest/download/otelcol_windows_amd64.exe otelcol_windows_amd64.exe
+ENV NO_WINDOWS_SERVICE=1
+ENTRYPOINT /otelcol_windows_amd64.exe

--- a/smoke-tests/otel-collector-contrib-windows/Dockerfile
+++ b/smoke-tests/otel-collector-contrib-windows/Dockerfile
@@ -1,4 +1,4 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
-ADD https://github.com/signalfx/splunk-otel-collector/releases/latest/download/otelcol_windows_amd64.exe otelcol_windows_amd64.exe
+ADD https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/latest/download/otelcontribcol_windows_amd64.exe otelcol_windows_amd64.exe
 ENV NO_WINDOWS_SERVICE=1
 ENTRYPOINT /otelcol_windows_amd64.exe

--- a/smoke-tests/otel-collector-contrib-windows/build.sh
+++ b/smoke-tests/otel-collector-contrib-windows/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+EXTRA_TAG=$1
+IMAGE_NAME="ghcr.io/signalfx/splunk-otel-java/otel-collector-contrib-windows:$(date '+%Y%m%d').${EXTRA_TAG}"
+
+echo "Building image ${IMAGE_NAME} ..."
+
+docker build -t "$IMAGE_NAME" .
+docker push "$IMAGE_NAME"


### PR DESCRIPTION
Resolves https://github.com/signalfx/splunk-otel-java/issues/137

Ideally we should use splunk-otel-collector everywhere, but that needs to wait until splunk-otel-collector has a Windows docker image.