### PR TITLE
Add Jetty 11 and Tomcat 10 smoke tests

### DIFF
--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/AppServerTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/AppServerTest.java
@@ -181,7 +181,7 @@ public abstract class AppServerTest extends SmokeTest {
     }
   }
 
-  protected static final String OTEL_IMAGE_VERSION = "20210316.657616194";
+  protected static final String OTEL_IMAGE_VERSION = "20210406.721629261";
   protected static final String OTEL_REPO = "ghcr.io/open-telemetry/java-test-containers";
   protected static final String SPLUNK_REPO_PREFIX = "ghcr.io/signalfx/splunk-otel-";
 

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/JettySmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/JettySmokeTest.java
@@ -31,13 +31,17 @@ public class JettySmokeTest extends AppServerTest {
       new ExpectedServerAttributes("HTTP GET", "jetty", "10.0.0");
   public static final ExpectedServerAttributes JETTY10_BETA_SERVER_ATTRIBUTES =
       new ExpectedServerAttributes("HTTP GET", "jetty", "10.0.0.beta3");
+  public static final ExpectedServerAttributes JETTY11_SERVER_ATTRIBUTES =
+      new ExpectedServerAttributes("HTTP GET", "jetty", "11.0.1");
 
   private static Stream<Arguments> supportedConfigurations() {
     return configurations("jetty")
         .otelLinux("9.4.35", JETTY9_SERVER_ATTRIBUTES, VMS_ALL, "8", "11", "15")
         .otelLinux("10.0.0", JETTY10_SERVER_ATTRIBUTES, VMS_ALL, "11", "15")
+        .otelLinux("11.0.1", JETTY11_SERVER_ATTRIBUTES, VMS_ALL, "11", "15")
         .otelWindows("9.4.35", JETTY9_SERVER_ATTRIBUTES, VMS_ALL, "8", "11", "15")
         .otelWindows("10.0.0", JETTY10_BETA_SERVER_ATTRIBUTES, VMS_ALL, "11", "15")
+        .otelWindows("11.0.1", JETTY11_SERVER_ATTRIBUTES, VMS_ALL, "11", "15")
         .stream();
   }
 

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/TomcatSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/TomcatSmokeTest.java
@@ -31,15 +31,19 @@ public class TomcatSmokeTest extends AppServerTest {
       new TomcatAttributes("8.5.60.0");
   public static final ExpectedServerAttributes TOMCAT9_SERVER_ATTRIBUTES =
       new TomcatAttributes("9.0.40.0");
+  public static final ExpectedServerAttributes TOMCAT10_SERVER_ATTRIBUTES =
+      new TomcatAttributes("10.0.4.0");
 
   private static Stream<Arguments> supportedConfigurations() {
     return configurations("tomcat")
         .otelLinux("7.0.107", TOMCAT7_SERVER_ATTRIBUTES, VMS_ALL, "8")
         .otelLinux("8.5.60", TOMCAT8_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
         .otelLinux("9.0.40", TOMCAT9_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
+        .otelLinux("10.0.4", TOMCAT10_SERVER_ATTRIBUTES, VMS_ALL, "11", "15")
         .otelWindows("7.0.107", TOMCAT7_SERVER_ATTRIBUTES, VMS_ALL, "8")
         .otelWindows("8.5.60", TOMCAT8_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
         .otelWindows("9.0.40", TOMCAT9_SERVER_ATTRIBUTES, VMS_ALL, "8", "11")
+        .otelWindows("10.0.4", TOMCAT10_SERVER_ATTRIBUTES, VMS_ALL, "11", "15")
         .stream();
   }
 


### PR DESCRIPTION
As OpenTelemetry distribution supports Tomcat 10 and Jetty 11 from version 1.1.0, add their smoke tests. Unlike in OpenTelemetry, the Jetty/Tomcat specific instrumentations here did not reference Servlet API classes, therefore the use of Servlet API 5 in those versions did not require any instrumentation changes here.