### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @iNikem @mateuszrzeszutek
-* @signalfx/gdi-instrumentation-java
+* @iNikem @mateuszrzeszutek @signalfx/gdi-instrumentation-java


### PR DESCRIPTION
It seems that we should group all codeowners that have the same pattern:

```
# Order is important; the last matching pattern takes the most
# precedence.
```