### PR TITLE
Implement configuration changes required by GDI spec

### DIFF
--- a/custom/build.gradle
+++ b/custom/build.gradle
@@ -30,6 +30,7 @@ dependencies {
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing:${versions.opentelemetry}")
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:${versions.opentelemetryAlpha}")
   testImplementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:${versions.opentelemetryJavaagentAlpha}")
+  testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent-spi:${versions.opentelemetryJavaagentAlpha}")
   testImplementation("io.micrometer:micrometer-core:${versions.micrometer}")
 
   testImplementation(project(':testing:common'))

--- a/custom/src/main/java/com/splunk/opentelemetry/ServiceNameChecker.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/ServiceNameChecker.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.instrumentation.api.config.Config;
+import io.opentelemetry.javaagent.spi.ComponentInstaller;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@AutoService(ComponentInstaller.class)
+public class ServiceNameChecker implements ComponentInstaller {
+  private static final Logger log = LoggerFactory.getLogger(ServiceNameChecker.class);
+
+  @Override
+  public void beforeByteBuddyAgent(Config config) {
+    Map<String, String> resourceAttributes = config.getMapProperty("otel.resource.attributes");
+    if (!resourceAttributes.containsKey(ResourceAttributes.SERVICE_NAME.getKey())) {
+      log.warn(
+          "Resource attribute 'service.name' is not set: your service is unnamed and will be difficult to identify."
+              + " Please Set your service name using the 'OTEL_RESOURCE_ATTRIBUTES' environment variable"
+              + " or the 'otel.resource.attributes' system property."
+              + " E.g. 'export OTEL_RESOURCE_ATTRIBUTES=\"service.name=<YOUR_SERVICE_NAME_HERE>\"'");
+    }
+  }
+}

--- a/custom/src/main/java/com/splunk/opentelemetry/SplunkConfiguration.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/SplunkConfiguration.java
@@ -16,8 +16,6 @@
 
 package com.splunk.opentelemetry;
 
-import static com.splunk.opentelemetry.jaeger.JaegerThriftSpanExporterFactory.OTEL_EXPORTER_JAEGER_ENDPOINT;
-
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.spi.config.PropertySource;
 import java.util.HashMap;
@@ -25,6 +23,9 @@ import java.util.Map;
 
 @AutoService(PropertySource.class)
 public class SplunkConfiguration implements PropertySource {
+  public static final String SPLUNK_ACCESS_TOKEN = "splunk.access.token";
+  public static final String OTEL_EXPORTER_JAEGER_ENDPOINT = "otel.exporter.jaeger.endpoint";
+
   @Override
   public Map<String, String> getProperties() {
     Map<String, String> config = new HashMap<>();
@@ -34,11 +35,11 @@ public class SplunkConfiguration implements PropertySource {
     // disable otel runtime-metrics instrumentation; we use micrometer metrics instead
     config.put("otel.instrumentation.runtime-metrics.enabled", "false");
 
-    config.put("otel.traces.exporter", "jaeger-thrift-splunk");
+    config.put("otel.traces.exporter", "otlp");
     // http://localhost:9080/v1/trace is the default endpoint for SmartAgent
     // http://localhost:14268/api/traces is the default endpoint for otel-collector
     config.put(OTEL_EXPORTER_JAEGER_ENDPOINT, "http://localhost:9080/v1/trace");
-    config.put("otel.propagators", "b3multi");
+    config.put("otel.propagators", "tracecontext,baggage");
 
     // enable experimental instrumentation
     config.put("otel.instrumentation.spring-batch.enabled", "true");

--- a/custom/src/main/java/com/splunk/opentelemetry/jaeger/JaegerThriftSpanExporterFactory.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/jaeger/JaegerThriftSpanExporterFactory.java
@@ -16,6 +16,9 @@
 
 package com.splunk.opentelemetry.jaeger;
 
+import static com.splunk.opentelemetry.SplunkConfiguration.OTEL_EXPORTER_JAEGER_ENDPOINT;
+import static com.splunk.opentelemetry.SplunkConfiguration.SPLUNK_ACCESS_TOKEN;
+
 import com.google.auto.service.AutoService;
 import io.jaegertracing.thrift.internal.senders.HttpSender;
 import io.opentelemetry.exporter.jaeger.thrift.JaegerThriftSpanExporter;
@@ -30,9 +33,6 @@ import org.slf4j.LoggerFactory;
 @AutoService(ConfigurableSpanExporterProvider.class)
 public class JaegerThriftSpanExporterFactory implements ConfigurableSpanExporterProvider {
   private static final Logger log = LoggerFactory.getLogger(JaegerThriftSpanExporterFactory.class);
-
-  static final String SPLUNK_ACCESS_TOKEN = "splunk.access.token";
-  public static final String OTEL_EXPORTER_JAEGER_ENDPOINT = "otel.exporter.jaeger.endpoint";
 
   @Override
   public SpanExporter createExporter(ConfigProperties config) {

--- a/custom/src/main/java/com/splunk/opentelemetry/micrometer/SplunkMetricsConfig.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/micrometer/SplunkMetricsConfig.java
@@ -16,6 +16,8 @@
 
 package com.splunk.opentelemetry.micrometer;
 
+import static com.splunk.opentelemetry.SplunkConfiguration.SPLUNK_ACCESS_TOKEN;
+
 import io.micrometer.signalfx.SignalFxConfig;
 import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.sdk.resources.Resource;
@@ -24,7 +26,6 @@ import java.time.Duration;
 
 class SplunkMetricsConfig implements SignalFxConfig {
   static final String METRICS_ENABLED_PROPERTY = "splunk.metrics.enabled";
-  static final String ACCESS_TOKEN_PROPERTY = "splunk.access.token";
   static final String METRICS_ENDPOINT_PROPERTY = "splunk.metrics.endpoint";
   static final String METRICS_EXPORT_INTERVAL_PROPERTY = "splunk.metrics.export.interval";
 
@@ -43,7 +44,7 @@ class SplunkMetricsConfig implements SignalFxConfig {
 
     // non-empty token MUST be provided; we can just send anything because collector/SmartAgent will
     // use the real one
-    accessToken = config.getProperty(ACCESS_TOKEN_PROPERTY, "no-token");
+    accessToken = config.getProperty(SPLUNK_ACCESS_TOKEN, "no-token");
     source = resource.getAttributes().get(ResourceAttributes.SERVICE_NAME);
     step =
         Duration.ofMillis(

--- a/custom/src/test/java/com/splunk/opentelemetry/jaeger/JaegerThriftSpanExporterFactoryTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/jaeger/JaegerThriftSpanExporterFactoryTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.BDDMockito.given;
 
+import com.splunk.opentelemetry.SplunkConfiguration;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.sdk.autoconfigure.ConfigProperties;
@@ -78,9 +79,8 @@ class JaegerThriftSpanExporterFactoryTest {
   @Test
   void shouldCreateExporterWithSplunkAccessToken() {
     // given
-    given(config.getString(JaegerThriftSpanExporterFactory.SPLUNK_ACCESS_TOKEN))
-        .willReturn("token");
-    given(config.getString(JaegerThriftSpanExporterFactory.OTEL_EXPORTER_JAEGER_ENDPOINT))
+    given(config.getString(SplunkConfiguration.SPLUNK_ACCESS_TOKEN)).willReturn("token");
+    given(config.getString(SplunkConfiguration.OTEL_EXPORTER_JAEGER_ENDPOINT))
         .willReturn("http://localhost:" + port + "/v1/trace");
 
     // when
@@ -94,7 +94,7 @@ class JaegerThriftSpanExporterFactoryTest {
   @Test
   void shouldCreateExporterWithoutSplunkAccessToken() {
     // given
-    given(config.getString(JaegerThriftSpanExporterFactory.OTEL_EXPORTER_JAEGER_ENDPOINT))
+    given(config.getString(SplunkConfiguration.OTEL_EXPORTER_JAEGER_ENDPOINT))
         .willReturn("http://localhost:" + port + "/v1/trace");
 
     // when

--- a/custom/src/test/java/com/splunk/opentelemetry/micrometer/SplunkMetricsConfigTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/micrometer/SplunkMetricsConfigTest.java
@@ -16,7 +16,7 @@
 
 package com.splunk.opentelemetry.micrometer;
 
-import static com.splunk.opentelemetry.micrometer.SplunkMetricsConfig.ACCESS_TOKEN_PROPERTY;
+import static com.splunk.opentelemetry.SplunkConfiguration.SPLUNK_ACCESS_TOKEN;
 import static com.splunk.opentelemetry.micrometer.SplunkMetricsConfig.DEFAULT_METRICS_ENDPOINT;
 import static com.splunk.opentelemetry.micrometer.SplunkMetricsConfig.METRICS_ENABLED_PROPERTY;
 import static com.splunk.opentelemetry.micrometer.SplunkMetricsConfig.METRICS_ENDPOINT_PROPERTY;
@@ -55,10 +55,14 @@ class SplunkMetricsConfigTest {
     var javaagentConfig =
         Config.create(
             Map.of(
-                METRICS_ENABLED_PROPERTY, "false",
-                ACCESS_TOKEN_PROPERTY, "token",
-                METRICS_ENDPOINT_PROPERTY, "http://my-endpoint:42",
-                METRICS_EXPORT_INTERVAL_PROPERTY, "60000"));
+                METRICS_ENABLED_PROPERTY,
+                "false",
+                SPLUNK_ACCESS_TOKEN,
+                "token",
+                METRICS_ENDPOINT_PROPERTY,
+                "http://my-endpoint:42",
+                METRICS_EXPORT_INTERVAL_PROPERTY,
+                "60000"));
     var resource = Resource.create(Attributes.of(ResourceAttributes.SERVICE_NAME, "test-service"));
     var splunkMetricsConfig = new SplunkMetricsConfig(javaagentConfig, resource);
 

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/JaegerAndB3SpringBootSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/JaegerAndB3SpringBootSmokeTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class JaegerAndB3SpringBootSmokeTest extends SpringBootSmokeTest {
+  protected Map<String, String> getExtraEnv() {
+    return Map.of(
+        "OTEL_TRACES_EXPORTER", "jaeger-thrift-splunk",
+        "OTEL_PROPAGATORS", "b3multi");
+  }
+
+  protected void assertTraces(TraceInspector traces) throws IOException {
+    // verify spans are exported
+    assertEquals(1, traces.countSpansByName("/greeting"));
+    assertEquals(1, traces.countSpansByName("WebController.greeting"));
+    assertEquals(1, traces.countSpansByName("WebController.withSpan"));
+
+    // verify that correct agent version is set in the resource
+    String currentAgentVersion = getCurrentAgentVersion();
+    assertEquals(3, traces.countFilteredAttributes("otel.library.version", currentAgentVersion));
+
+    // verify that correct service name is set in the resource
+    assertTrue(traces.resourceExists("service.name", "smoke-test"));
+  }
+}

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/TraceInspector.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/TraceInspector.java
@@ -50,6 +50,14 @@ public class TraceInspector {
         .count();
   }
 
+  public Set<String> getInstrumentationLibraryVersions() {
+    return traces.stream()
+        .flatMap(it -> it.getResourceSpansList().stream())
+        .flatMap(it -> it.getInstrumentationLibrarySpansList().stream())
+        .map(it -> it.getInstrumentationLibrary().getVersion())
+        .collect(Collectors.toSet());
+  }
+
   protected int countSpansByName(String spanName) {
     return (int) getSpanStream().filter(it -> it.getName().equals(spanName)).count();
   }
@@ -64,10 +72,6 @@ public class TraceInspector {
         .map(ResourceSpans::getResource)
         .flatMap(resource -> resource.getAttributesList().stream())
         .anyMatch(kv -> kv.getKey().equals(key) && kv.getValue().getStringValue().equals(value));
-  }
-
-  public int size() {
-    return traces.size();
   }
 
   public int countTraceIds() {

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/AbstractTestContainerManager.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/AbstractTestContainerManager.java
@@ -35,6 +35,7 @@ public abstract class AbstractTestContainerManager implements TestContainerManag
     environment.put("OTEL_BSP_SCHEDULE_DELAY", "10ms");
     environment.put(
         "OTEL_EXPORTER_JAEGER_ENDPOINT", "http://" + COLLECTOR_ALIAS + ":14268/api/traces");
+    environment.put("OTEL_EXPORTER_OTLP_ENDPOINT", "http://" + COLLECTOR_ALIAS + ":4317");
     // export metrics every 1s
     environment.put("SPLUNK_METRICS_EXPORT_INTERVAL", "1000");
     environment.put("SPLUNK_METRICS_ENDPOINT", "http://" + COLLECTOR_ALIAS + ":9943/v2/datapoint");

--- a/smoke-tests/src/test/resources/otel.yaml
+++ b/smoke-tests/src/test/resources/otel.yaml
@@ -10,6 +10,9 @@ receivers:
     protocols:
       grpc:
       thrift_http:
+  otlp:
+    protocols:
+      grpc:
   signalfx:
 
 processors:
@@ -27,7 +30,7 @@ exporters:
 service:
   pipelines:
     traces:
-      receivers: [ jaeger ]
+      receivers: [ jaeger, otlp ]
       processors: [ batch ]
       exporters: [ logging/logging_debug, otlp ]
     metrics:

--- a/smoke-tests/src/test/resources/otelcol-windows.yaml
+++ b/smoke-tests/src/test/resources/otelcol-windows.yaml
@@ -10,6 +10,9 @@ receivers:
     protocols:
       grpc:
       thrift_http:
+  otlp:
+    protocols:
+      grpc:
 
 processors:
   batch:
@@ -24,7 +27,7 @@ exporters:
 service:
   pipelines:
     traces:
-      receivers: [ jaeger ]
+      receivers: [ jaeger, otlp ]
       processors: [ batch ]
       exporters: [ logging, otlp ]
 


### PR DESCRIPTION
* set default traces exporter to otlp
* support `SPLUNK_ACCESS_TOKEN` in otlp
* set default propagators to `tracecontext,baggage`
* log a warning if `service.name` resource attribute is missing