### PR TITLE
Add splunk.distro.version resource attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Enhancements
+
+- The agent will now set a resource attribute `splunk.distro.version` with its own version.
+
 ## [v0.11.0] - 2021-05-17
 
 ### General Notes

--- a/custom/build.gradle
+++ b/custom/build.gradle
@@ -44,6 +44,12 @@ tasks {
     options.release.set(8)
   }
 
+  processResources {
+    expand([
+        'version': project.version
+    ])
+  }
+
   shadowJar {
     mergeServiceFiles()
 

--- a/custom/src/main/java/com/splunk/opentelemetry/SplunkDistroVersionResourceProvider.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/SplunkDistroVersionResourceProvider.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.autoconfigure.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+import io.opentelemetry.sdk.resources.Resource;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+@AutoService(ResourceProvider.class)
+public class SplunkDistroVersionResourceProvider implements ResourceProvider {
+  static final AttributeKey<String> SPLUNK_DISTRO_VERSION =
+      AttributeKey.stringKey("splunk.distro.version");
+
+  private static final Resource DISTRO_VERSION_RESOURCE = initialize();
+
+  private static Resource initialize() {
+    InputStream in =
+        Thread.currentThread().getContextClassLoader().getResourceAsStream("splunk.properties");
+    if (in == null) {
+      return Resource.empty();
+    }
+    try (InputStream ignored = in) {
+      Properties splunkProps = new Properties();
+      splunkProps.load(in);
+      return Resource.create(
+          Attributes.of(
+              SPLUNK_DISTRO_VERSION, splunkProps.getProperty(SPLUNK_DISTRO_VERSION.getKey())));
+    } catch (IOException e) {
+      return Resource.empty();
+    }
+  }
+
+  @Override
+  public Resource createResource(ConfigProperties config) {
+    return DISTRO_VERSION_RESOURCE;
+  }
+}

--- a/custom/src/main/java/com/splunk/opentelemetry/SplunkDistroVersionResourceProvider.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/SplunkDistroVersionResourceProvider.java
@@ -34,12 +34,12 @@ public class SplunkDistroVersionResourceProvider implements ResourceProvider {
   private static final Resource DISTRO_VERSION_RESOURCE = initialize();
 
   private static Resource initialize() {
-    InputStream in =
-        Thread.currentThread().getContextClassLoader().getResourceAsStream("splunk.properties");
-    if (in == null) {
-      return Resource.empty();
-    }
-    try (InputStream ignored = in) {
+    try (InputStream in =
+        Thread.currentThread().getContextClassLoader().getResourceAsStream("splunk.properties")) {
+      if (in == null) {
+        return Resource.empty();
+      }
+
       Properties splunkProps = new Properties();
       splunkProps.load(in);
       return Resource.create(

--- a/custom/src/main/resources/splunk.properties
+++ b/custom/src/main/resources/splunk.properties
@@ -1,0 +1,1 @@
+splunk.distro.version = ${version}

--- a/custom/src/test/java/com/splunk/opentelemetry/SplunkDistroVersionResourceProviderTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/SplunkDistroVersionResourceProviderTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class SplunkDistroVersionResourceProviderTest {
+  @Test
+  void shouldGetDistroVersionFromProperties() {
+    // given
+    var provider = new SplunkDistroVersionResourceProvider();
+
+    // when
+    var resource = provider.createResource(null);
+
+    // then
+    assertThat(resource.getAttributes().size()).isEqualTo(1);
+    assertThat(
+            resource.getAttributes().get(SplunkDistroVersionResourceProvider.SPLUNK_DISTRO_VERSION))
+        .isNotEmpty();
+  }
+}

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/SpringBootSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/SpringBootSmokeTest.java
@@ -72,6 +72,7 @@ public class SpringBootSmokeTest extends AppServerTest {
 
     // verify that correct service name is set in the resource
     assertTrue(traces.resourceExists("service.name", "smoke-test"));
+    assertTrue(traces.resourceExists("splunk.distro.version", v -> !v.isEmpty()));
   }
 
   protected void assertMetrics(MetricsInspector metrics) {

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/TraceInspector.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/TraceInspector.java
@@ -24,6 +24,7 @@ import io.opentelemetry.proto.trace.v1.Span;
 import java.util.Collection;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -67,11 +68,16 @@ public class TraceInspector {
   }
 
   public boolean resourceExists(String key, String value) {
+    return resourceExists(key, v -> v.equals(value));
+  }
+
+  public boolean resourceExists(String key, Predicate<String> valuePredicate) {
     return traces.stream()
         .flatMap(it -> it.getResourceSpansList().stream())
         .map(ResourceSpans::getResource)
         .flatMap(resource -> resource.getAttributesList().stream())
-        .anyMatch(kv -> kv.getKey().equals(key) && kv.getValue().getStringValue().equals(value));
+        .anyMatch(
+            kv -> kv.getKey().equals(key) && valuePredicate.test(kv.getValue().getStringValue()));
   }
 
   public int countTraceIds() {


### PR DESCRIPTION
Implements https://github.com/signalfx/gdi-specification/blob/main/specification/semantic_conventions.md#splunk-resource-attributes

I didn't touch the agent version (and `telemetry.auto.version`) in this PR, it's still

```groovy
attributes.put("Implementation-Version", "splunk-${project.version}-otel-${versions["opentelemetryJavaagent"]}")
```

I think that first the upstream agent has to stop using `Implementation-Version` to determine the agent version; any distro can (and probably will) override it.