### PR TITLE
Re-enable proprietary appserver (JBoss EAP) tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,6 +96,8 @@ jobs:
 
   smoke-test:
     runs-on: ${{ matrix.os }}
+    permissions:
+      packages: read
     strategy:
       matrix:
         os: [ windows-2019, ubuntu-20.04 ]
@@ -112,18 +114,17 @@ jobs:
           distribution: adopt
           java-version: 11.0.11+9
 
-# TODO: uncomment that once it's clear how we should deal with tokens
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v1
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.GHCR_TOKEN }}
-#        if: matrix.os == 'ubuntu-latest'
-#
-#      - name: Pull proprietary images
-#        run: ./gradlew pullProprietaryTestImages --scan --no-daemon
-#        if: startsWith(matrix.os, 'ubuntu')
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        if: startsWith(matrix.os, 'ubuntu')
+
+      - name: Pull proprietary images
+        run: ./gradlew pullProprietaryTestImages --scan --no-daemon
+        if: startsWith(matrix.os, 'ubuntu')
 
       - name: Test
         run: ./gradlew :smoke-tests:test -PsmokeTestSuite=${{ matrix.suite }} --scan --no-daemon

--- a/matrix/build.gradle.kts
+++ b/matrix/build.gradle.kts
@@ -32,11 +32,13 @@ data class Arguments(val versions: List<String>,
 data class AppServerTarget(val name: String, val args: List<Arguments>)
 
 val proprietaryTargets = listOf(
+    /* disable weblogic for now - it turns out we lost all weblogic images and we have to re-generate them
     AppServerTarget("weblogic", listOf(
         Arguments(versions = listOf("12.1.3", "12.2.1.4"), vms = listOf("hotspot"), jdks = listOf("8"), extraArgs = mapOf("tagSuffix" to "developer")),
         Arguments(versions = listOf("14.1.1.0"), vms = listOf("hotspot"), jdks = listOf("8"), extraArgs = mapOf("tagSuffix" to "developer-8")),
         Arguments(versions = listOf("14.1.1.0"), vms = listOf("hotspot"), jdks = listOf("11"), extraArgs = mapOf("tagSuffix" to "developer-11"))
     )),
+     */
     AppServerTarget("jboss-eap", listOf(
         Arguments(versions = listOf("7.1.0"), vms = listOf("hotspot", "openj9"), jdks = listOf("8")),
         Arguments(versions = listOf("7.3.0"), vms = listOf("hotspot", "openj9"), jdks = listOf("8", "11"))


### PR DESCRIPTION
It looks like Weblogic containers completely disappeared from GHCR, we'll have to generate them from scratch and upload them again. 