### PR TITLE
Fix GitLab CI build: missing zip

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,7 @@ release:
     - /^v[0-9]+\.[0-9]+\.[0-9]+.*/
   script:
     # make sure zip is available
+    - apt-get update
     - apt-get -y install zip unzip
     # create release dir
     - mkdir -p dist

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,9 @@ release:
     - tags
     - /^v[0-9]+\.[0-9]+\.[0-9]+.*/
   script:
+    # make sure zip is available
+    - apt-get -y install zip unzip
+    # create release dir
     - mkdir -p dist
     # build the javaagent
     - ./gradlew -Prelease.useLastTag=true build final -x test --no-daemon

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,9 +19,9 @@ release:
     - tags
     - /^v[0-9]+\.[0-9]+\.[0-9]+.*/
   script:
-    # make sure zip is available
+    # make sure zip is available - it's necessary to execute the buildpack script
     - apt-get update
-    - apt-get -y install zip unzip
+    - apt-get -y install zip
     # create release dir
     - mkdir -p dist
     # build the javaagent

--- a/README.md
+++ b/README.md
@@ -42,10 +42,6 @@
 
 ---
 
-The documentation below refers to the in development version of this package. Docs for the latest version ([v0.11.0](https://github.com/signalfx/splunk-otel-java/releases/tag/v0.11.0)) can be found [here](https://github.com/signalfx/splunk-otel-java/blob/v0.11.0/README.md).
-
----
-
 # Splunk Distribution of OpenTelemetry Java
 
 The Splunk Distribution of [OpenTelemetry Instrumentation for


### PR DESCRIPTION
And remove the readme note about "development version docs" that I forgot to remove earlier. 