### PR TITLE
Correctly silence confusing signalfx metrics exporter INFO log

### DIFF
--- a/custom/src/main/java/com/splunk/opentelemetry/SplunkConfiguration.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/SplunkConfiguration.java
@@ -43,15 +43,6 @@ public class SplunkConfiguration implements PropertySource {
     config.put("otel.instrumentation.spring-batch.enabled", "true");
     config.put("otel.instrumentation.spring-batch.item.enabled", "true");
 
-    // metrics exporter sometimes logs "Broken pipe (Write failed)" at INFO; usually in docker-based
-    // environments
-    // most likely docker resets long-running connections and the exporter has to retry, and it
-    // always succeeds after
-    // retrying and metrics are exported correctly
-    config.put(
-        "io.opentelemetry.javaagent.slf4j.simpleLogger.log.com.signalfx.shaded.apache.http.impl.execchain.RetryExec",
-        "WARN");
-
     return config;
   }
 }


### PR DESCRIPTION
Fixes https://github.com/signalfx/splunk-otel-java/pull/262

This morning I realized that config is initialized after logging, so the previous solution couldn't function properly. This one does (I tested it).