### PR TITLE
include profiling code in jar, even though disabled.

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -20,9 +20,7 @@ configurations {
 dependencies {
     customShadow project(path: ":custom", configuration: "shadow")
     customShadow project(path: ":instrumentation", configuration: "shadow")
-    if(project.hasProperty('profiler')) {
-        customShadow project(path: ":profiler", configuration: "shadow")
-    }
+    customShadow project(path: ":profiler", configuration: "shadow")
     mainShadow "io.opentelemetry.javaagent:opentelemetry-javaagent:${versions.opentelemetryJavaagent}:all"
     customShadowInclude project(":bootstrap")
 }
@@ -52,9 +50,7 @@ task customShadow(type: ShadowJar) {
 
     dependsOn ':custom:shadowJar'
     dependsOn ':instrumentation:shadowJar'
-    if(project.hasProperty('profiler')){
-        dependsOn ':profiler:shadowJar'
-    }
+    dependsOn ':profiler:shadowJar'
     dependsOn ':bootstrap:jar'
     with isolateSpec()
 

--- a/profiler/README.md
+++ b/profiler/README.md
@@ -2,8 +2,3 @@
 The profiler is in its infancy and is disabled by default.
 
 It should be considered experimental and is completely unsupported.
-
-To compile with the profiler included:
-```
-./gradlew -Pprofiler=true assemble
-```


### PR DESCRIPTION
Now that 1.0.0 is released, let's go ahead and include the profiling code. The activator will be invoked early in the lifecycle, but the config default is still false and it should return early with a message logged at debug.

(this helps with the testing effort as well)