### PR TITLE
Profiling smoke test

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -20,9 +20,7 @@ configurations {
 dependencies {
     customShadow project(path: ":custom", configuration: "shadow")
     customShadow project(path: ":instrumentation", configuration: "shadow")
-    if(project.hasProperty('profiler')) {
-        customShadow project(path: ":profiler", configuration: "shadow")
-    }
+    customShadow project(path: ":profiler", configuration: "shadow")
     mainShadow "io.opentelemetry.javaagent:opentelemetry-javaagent:${versions.opentelemetryJavaagent}:all"
     customShadowInclude project(":bootstrap")
 }
@@ -52,9 +50,7 @@ task customShadow(type: ShadowJar) {
 
     dependsOn ':custom:shadowJar'
     dependsOn ':instrumentation:shadowJar'
-    if(project.hasProperty('profiler')){
-        dependsOn ':profiler:shadowJar'
-    }
+    dependsOn ':profiler:shadowJar'
     dependsOn ':bootstrap:jar'
     with isolateSpec()
 

--- a/profiler/README.md
+++ b/profiler/README.md
@@ -2,8 +2,3 @@
 The profiler is in its infancy and is disabled by default.
 
 It should be considered experimental and is completely unsupported.
-
-To compile with the profiler included:
-```
-./gradlew -Pprofiler=true assemble
-```

--- a/profiler/README.md
+++ b/profiler/README.md
@@ -2,3 +2,11 @@
 The profiler is in its infancy and is disabled by default.
 
 It should be considered experimental and is completely unsupported.
+
+# configuration
+
+| name                                | default | description                          |
+|-------------------------------------|---------|--------------------------------------|
+|`splunk.profiler.enabled`            | false   | set to true to enable the profiler   |
+|`splunk.profiler.directory`          | "."     | location of jfr files                |
+|`splunk.profiler.recording.duration` | 20      | number of seconds per recording unit |

--- a/profiler/build.gradle
+++ b/profiler/build.gradle
@@ -6,6 +6,11 @@ apply from: "$rootDir/gradle/shadow.gradle"
 
 def relocatePackages = ext.relocatePackages
 
+compileJava {
+    sourceCompatibility = 8
+    targetCompatibility = 8
+}
+
 dependencies {
     compileOnly("io.opentelemetry:opentelemetry-sdk:${versions.opentelemetry}")
     compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:${versions.opentelemetryAlpha}")

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
@@ -25,6 +25,7 @@ import java.util.Map;
 public class Configuration implements PropertySource {
 
   public static final String CONFIG_KEY_ENABLE_PROFILER = "splunk.profiler.enabled";
+  public static final String CONFIG_KEY_PROFILER_DIRECTORY = "splunk.profiler.directory";
   public static final String CONFIG_KEY_RECORDING_DURATION_SECONDS =
       "splunk.profiler.recording.duration";
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
@@ -23,7 +23,6 @@ import com.google.auto.service.AutoService;
 import com.splunk.opentelemetry.profiler.util.HelpfulExecutors;
 import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.javaagent.spi.ComponentInstaller;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
@@ -16,7 +16,9 @@
 
 package com.splunk.opentelemetry.profiler;
 
-import static com.splunk.opentelemetry.profiler.Configuration.*;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_ENABLE_PROFILER;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PROFILER_DIRECTORY;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_RECORDING_DURATION_SECONDS;
 import static com.splunk.opentelemetry.profiler.util.HelpfulExecutors.logUncaught;
 
 import com.google.auto.service.AutoService;

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
@@ -16,14 +16,16 @@
 
 package com.splunk.opentelemetry.profiler;
 
-import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_ENABLE_PROFILER;
-import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_RECORDING_DURATION_SECONDS;
+import static com.splunk.opentelemetry.profiler.Configuration.*;
 import static com.splunk.opentelemetry.profiler.util.HelpfulExecutors.logUncaught;
 
 import com.google.auto.service.AutoService;
 import com.splunk.opentelemetry.profiler.util.HelpfulExecutors;
 import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.javaagent.spi.ComponentInstaller;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import org.slf4j.Logger;
@@ -56,11 +58,13 @@ public class JfrActivator implements ComponentInstaller {
     Duration recordingDuration = Duration.ofSeconds(Integer.parseInt(recordingDurationStr));
     RecordingEscapeHatch recordingEscapeHatch = new RecordingEscapeHatch();
     JfrSettingsReader settingsReader = new JfrSettingsReader();
+    Path outputDir = Paths.get(config.getProperty(CONFIG_KEY_PROFILER_DIRECTORY, "."));
     JfrRecorder recorder =
         JfrRecorder.builder()
             .settingsReader(settingsReader)
             .maxAgeDuration(recordingDuration.multipliedBy(10))
             .jfr(JFR.instance)
+            .outputDir(outputDir)
             .build();
     RecordingSequencer sequencer =
         RecordingSequencer.builder()

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrRecorder.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrRecorder.java
@@ -23,7 +23,9 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
-import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import jdk.jfr.Recording;
 import jdk.jfr.RecordingState;
@@ -66,7 +68,10 @@ public class JfrRecorder {
 
   public void flushSnapshot() {
     try (Recording snap = jfr.takeSnapshot()) {
-      Path file = Paths.get(Instant.now().toString() + ".jfr");
+      String prefix =
+          DateTimeFormatter.ISO_DATE_TIME.format(
+              LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS));
+      Path file = Paths.get(prefix + ".jfr");
       Path path = outputDir.resolve(file);
       logger.debug("Flushing a JFR snapshot: {}", path);
       snap.dump(path);

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrRecorder.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrRecorder.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
@@ -36,12 +37,14 @@ public class JfrRecorder {
   private final JfrSettingsReader settingsReader;
   private final Duration maxAgeDuration;
   private final JFR jfr;
+  private final Path outputDir;
   private volatile Recording recording;
 
   JfrRecorder(Builder builder) {
     this.settingsReader = requireNonNull(builder.settingsReader);
     this.maxAgeDuration = requireNonNull(builder.maxAgeDuration);
     this.jfr = requireNonNull(builder.jfr);
+    this.outputDir = requireNonNull(builder.outputDir);
   }
 
   public void start() {
@@ -63,7 +66,8 @@ public class JfrRecorder {
 
   public void flushSnapshot() {
     try (Recording snap = jfr.takeSnapshot()) {
-      Path path = Path.of(Instant.now().toString() + ".jfr");
+      Path file = Paths.get(Instant.now().toString() + ".jfr");
+      Path path = outputDir.resolve(file);
       logger.debug("Flushing a JFR snapshot: {}", path);
       snap.dump(path);
     } catch (IOException e) {
@@ -85,6 +89,7 @@ public class JfrRecorder {
   }
 
   public static class Builder {
+    private Path outputDir;
     private JfrSettingsReader settingsReader;
     private Duration maxAgeDuration;
     private JFR jfr = JFR.instance;
@@ -101,6 +106,11 @@ public class JfrRecorder {
 
     public Builder jfr(JFR jfr) {
       this.jfr = jfr;
+      return this;
+    }
+
+    public Builder outputDir(Path outputDir){
+      this.outputDir = outputDir;
       return this;
     }
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrRecorder.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrRecorder.java
@@ -109,7 +109,7 @@ public class JfrRecorder {
       return this;
     }
 
-    public Builder outputDir(Path outputDir){
+    public Builder outputDir(Path outputDir) {
       this.outputDir = outputDir;
       return this;
     }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrRecorderTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrRecorderTest.java
@@ -115,10 +115,10 @@ class JfrRecorderTest {
   private JfrRecorder buildJfrRecorder(JFR jfr) {
     JfrRecorder.Builder builder =
         JfrRecorder.builder()
-                .maxAgeDuration(maxAge)
-                .settingsReader(settingsReader)
-                .outputDir(OUTDIR)
-                .jfr(jfr);
+            .maxAgeDuration(maxAge)
+            .settingsReader(settingsReader)
+            .outputDir(OUTDIR)
+            .jfr(jfr);
 
     return new JfrRecorder(builder) {
       @Override

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrRecorderTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrRecorderTest.java
@@ -31,12 +31,14 @@ import jdk.jfr.RecordingState;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class JfrRecorderTest {
 
+  static final Path OUTDIR = Path.of("/some/path");
   Duration maxAge = Duration.ofMinutes(13);
   Map<String, String> settings;
   @Mock JfrSettingsReader settingsReader;
@@ -65,10 +67,15 @@ class JfrRecorderTest {
   void testFlushSnapshot() throws Exception {
     JFR jfr = mock(JFR.class);
     Recording snap = mock(Recording.class);
+    ArgumentCaptor<Path> pathCaptor = ArgumentCaptor.forClass(Path.class);
+    doNothing().when(snap).dump(pathCaptor.capture());
     when(jfr.takeSnapshot()).thenReturn(snap);
     JfrRecorder jfrRecorder = buildJfrRecorder(jfr);
+
     jfrRecorder.flushSnapshot();
+
     verify(snap).dump(isA(Path.class));
+    assertTrue(pathCaptor.getValue().startsWith(OUTDIR));
     verify(snap).close();
   }
 
@@ -107,7 +114,11 @@ class JfrRecorderTest {
 
   private JfrRecorder buildJfrRecorder(JFR jfr) {
     JfrRecorder.Builder builder =
-        JfrRecorder.builder().maxAgeDuration(maxAge).settingsReader(settingsReader).jfr(jfr);
+        JfrRecorder.builder()
+                .maxAgeDuration(maxAge)
+                .settingsReader(settingsReader)
+                .outputDir(OUTDIR)
+                .jfr(jfr);
 
     return new JfrRecorder(builder) {
       @Override

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/RecordingSequencerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/RecordingSequencerTest.java
@@ -20,6 +20,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import org.junit.jupiter.api.Test;
@@ -145,7 +146,8 @@ class RecordingSequencerTest {
       super(
           new Builder()
               .settingsReader(mock(JfrSettingsReader.class))
-              .maxAgeDuration(Duration.ofSeconds(10)));
+              .maxAgeDuration(Duration.ofSeconds(10))
+              .outputDir(Paths.get(".")));
       this.flushLatch = flushLatch;
       started = false;
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -32,5 +32,6 @@ include("agent",
   "profiler",
   "smoke-tests",
   "testing:agent-for-testing",
+  "testing:profiler-tests",
   "testing:agent-metrics",
   "testing:common")

--- a/testing/profiler-tests/Dockerfile
+++ b/testing/profiler-tests/Dockerfile
@@ -1,0 +1,12 @@
+# Dockerfile for the application under test
+# Builds petclinic-rest in a java 8 container new enough to support JFR
+FROM adoptopenjdk:8
+
+RUN apt update && apt install -y git
+RUN git clone https://github.com/spring-petclinic/spring-petclinic-rest.git /src
+
+WORKDIR /src
+RUN ./mvnw package
+
+RUN mkdir /app && cp /src/target/spring-petclinic-rest*.jar /app/spring-petclinic-rest.jar
+WORKDIR /app

--- a/testing/profiler-tests/README.md
+++ b/testing/profiler-tests/README.md
@@ -1,0 +1,2 @@
+
+Integration and smoke tests related to the profiler.

--- a/testing/profiler-tests/build.gradle
+++ b/testing/profiler-tests/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+  id 'java'
+}
+
+dependencies {
+  testImplementation("org.testcontainers:testcontainers:1.15.3")
+}
+
+tasks.register('copyProfilingAgentJar', Copy) {
+  from "../../agent/build/libs/"
+  include "splunk-otel-javaagent-*-all.jar"
+  into "build"
+}
+
+copyProfilingAgentJar.dependsOn(':agent:assemble')
+test.dependsOn(copyProfilingAgentJar)
+
+jar {
+  enabled = false
+}

--- a/testing/profiler-tests/build.gradle
+++ b/testing/profiler-tests/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
   testImplementation("org.testcontainers:testcontainers:1.15.3")
+  testImplementation deps.awaitility
 }
 
 

--- a/testing/profiler-tests/build.gradle
+++ b/testing/profiler-tests/build.gradle
@@ -6,10 +6,20 @@ dependencies {
   testImplementation("org.testcontainers:testcontainers:1.15.3")
 }
 
+
 tasks.register('copyProfilingAgentJar', Copy) {
   from "../../agent/build/libs/"
   include "splunk-otel-javaagent-*-all.jar"
   into "build"
+}
+
+tasks.test {
+  def shadowTask = project(":agent").tasks.named("shadowJar").get()
+  inputs.files(layout.files(shadowTask))
+
+  doFirst {
+    jvmArgs("-Dio.opentelemetry.smoketest.agent.shadowJar.path=${shadowTask.archiveFile.get()}")
+  }
 }
 
 copyProfilingAgentJar.dependsOn(':agent:assemble')

--- a/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/ProfilerSmokeTest.java
+++ b/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/ProfilerSmokeTest.java
@@ -90,7 +90,7 @@ public class ProfilerSmokeTest {
       dirStream.forEach(
           item -> {
             System.out.println("Found " + item);
-            if (item.toFile().isFile() && item.getFileName().toString().endsWith(".jfr")) {
+            if (Files.isRegularFile(item) && item.getFileName().toString().endsWith(".jfr")) {
               done.set(true);
             }
           });

--- a/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/ProfilerSmokeTest.java
+++ b/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/ProfilerSmokeTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Spliterator;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.StreamSupport;
+import org.junit.ClassRule;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.utility.MountableFile;
+
+public class ProfilerSmokeTest {
+
+  @ClassRule public static GenericContainer<?> petclinic;
+
+  static {
+    MountableFile agentJar = MountableFile.forHostPath(findAgentJar());
+    petclinic =
+        new GenericContainer<>(new ImageFromDockerfile().withDockerfile(Path.of("./Dockerfile")))
+            .withExposedPorts(9966)
+            .withCopyFileToContainer(agentJar, "/app/javaagent.jar")
+            .withCreateContainerCmdModifier(cmd -> cmd.withEntrypoint("java"))
+            .withCommand(
+                "-javaagent:/app/javaagent.jar",
+                "-Dotel.javaagent.debug=true",
+                "-Dsplunk.profiler.enabled=true",
+                "-Dsplunk.profiler.directory=/app/jfr",
+                "-jar",
+                "/app/spring-petclinic-rest.jar")
+            .withFileSystemBind("build/test/output", "/app/jfr", BindMode.READ_WRITE)
+            .waitingFor(Wait.forHttp("/petclinic/api/vets"));
+  }
+
+  static Path findAgentJar() {
+    try {
+      Spliterator<Path> spliterator = Files.newDirectoryStream(Path.of("build/")).spliterator();
+      return StreamSupport.stream(spliterator, false)
+          .filter(path -> path.toFile().isFile())
+          .filter(path -> path.getFileName().toString().startsWith("splunk-otel-javaagent"))
+          .filter(path -> path.getFileName().toString().endsWith(".jar"))
+          .sorted()
+          .findFirst()
+          .orElseThrow();
+    } catch (Exception e) {
+      fail(e);
+      return null;
+    }
+  }
+
+  @Test
+  void ensureJfrFilesCreated() throws Exception {
+    Path outputDir = Path.of("build/test/output");
+    Files.createDirectories(outputDir);
+    petclinic.start();
+    Wait.forHttp("/petclinic/api/vets");
+    System.out.println("Petclinic has been started.");
+
+    Instant start = Instant.now();
+    AtomicBoolean done = new AtomicBoolean(false);
+    while (!done.get()) {
+
+      System.out.println("Opening dir to look for jfr files...");
+      DirectoryStream<Path> dirStream = Files.newDirectoryStream(outputDir);
+
+      dirStream.forEach(
+          item -> {
+            System.out.println("Found " + item);
+            if (item.toFile().isFile() && item.getFileName().toString().endsWith(".jfr")) {
+              done.set(true);
+            }
+          });
+      if (Duration.between(start, Instant.now()).toSeconds() > 60) {
+        petclinic.stop();
+        fail("No output within time.");
+      }
+      TimeUnit.SECONDS.sleep(1);
+    }
+  }
+}

--- a/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/ProfilerSmokeTest.java
+++ b/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/ProfilerSmokeTest.java
@@ -85,20 +85,21 @@ public class ProfilerSmokeTest {
     while (!done.get()) {
 
       System.out.println("Opening dir to look for jfr files...");
-      DirectoryStream<Path> dirStream = Files.newDirectoryStream(outputDir);
+      try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(outputDir)) {
 
-      dirStream.forEach(
-          item -> {
-            System.out.println("Found " + item);
-            if (Files.isRegularFile(item) && item.getFileName().toString().endsWith(".jfr")) {
-              done.set(true);
-            }
-          });
-      if (Duration.between(start, Instant.now()).toSeconds() > 60) {
-        petclinic.stop();
-        fail("No output within time.");
+        dirStream.forEach(
+            item -> {
+              System.out.println("Found " + item);
+              if (Files.isRegularFile(item) && item.getFileName().toString().endsWith(".jfr")) {
+                done.set(true);
+              }
+            });
+        if (Duration.between(start, Instant.now()).toSeconds() > 60) {
+          petclinic.stop();
+          fail("No output within time.");
+        }
+        TimeUnit.SECONDS.sleep(1);
       }
-      TimeUnit.SECONDS.sleep(1);
     }
   }
 }

--- a/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/ProfilerSmokeTest.java
+++ b/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/ProfilerSmokeTest.java
@@ -78,7 +78,6 @@ public class ProfilerSmokeTest {
     Path outputDir = Path.of("build/test/output");
     Files.createDirectories(outputDir);
     petclinic.start();
-    Wait.forHttp("/petclinic/api/vets");
     System.out.println("Petclinic has been started.");
 
     Instant start = Instant.now();


### PR DESCRIPTION
This builds on top of #273.

This makes a smoke test that fires up spring petclinic with the profiling agent enabled and ensures that JFR files are generated. It should be the foundational work for more thorough testing down the road.

In order to test, we also needed a way to configure the output directory for JFR files, so this changeset also includes that.

The smoketest has to build a spring petclinic rest image because the one in dockerhub is 2 years old and doesn't have a java 8 version with JFR.  Because of that, it's slower than I would prefer...so I'm inclined to file an issue to address that at a later time (maybe we can publish a base image like we do elsewhere).