### PR TITLE
Introduce JfrPathHandler and clean up files

### DIFF
--- a/profiler/README.md
+++ b/profiler/README.md
@@ -10,3 +10,4 @@ It should be considered experimental and is completely unsupported.
 |`splunk.profiler.enabled`            | false   | set to true to enable the profiler   |
 |`splunk.profiler.directory`          | "."     | location of jfr files                |
 |`splunk.profiler.recording.duration` | 20      | number of seconds per recording unit |
+|`splunk.profiler.keepfiles`          | false   | leave JFR files on disk id `true`    |

--- a/profiler/README.md
+++ b/profiler/README.md
@@ -10,4 +10,4 @@ It should be considered experimental and is completely unsupported.
 |`splunk.profiler.enabled`            | false   | set to true to enable the profiler   |
 |`splunk.profiler.directory`          | "."     | location of jfr files                |
 |`splunk.profiler.recording.duration` | 20      | number of seconds per recording unit |
-|`splunk.profiler.keepfiles`          | false   | leave JFR files on disk id `true`    |
+|`splunk.profiler.keep-files`         | false   | leave JFR files on disk id `true`    |

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/BasicJfrRecordingFile.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/BasicJfrRecordingFile.java
@@ -26,7 +26,7 @@ import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordingFile;
 
 /** Simple/basic abstraction around a recording file. Can open and get a stream of events. */
-public class BasicJfrRecordingFile implements RecordedEventStream {
+class BasicJfrRecordingFile implements RecordedEventStream {
 
   private final JFR jfr;
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/BasicJfrRecordingFile.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/BasicJfrRecordingFile.java
@@ -1,7 +1,20 @@
-package com.splunk.opentelemetry.profiler;
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import jdk.jfr.consumer.RecordedEvent;
-import jdk.jfr.consumer.RecordingFile;
+package com.splunk.opentelemetry.profiler;
 
 import java.nio.file.Path;
 import java.util.Spliterator;
@@ -9,37 +22,37 @@ import java.util.Spliterators;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
 
-/**
- * Simple/basic abstraction around a recording file.  Can open and
- * get a stream of events.
- */
+/** Simple/basic abstraction around a recording file. Can open and get a stream of events. */
 public class BasicJfrRecordingFile implements RecordedEventStream {
 
-    private final JFR jfr;
+  private final JFR jfr;
 
-    public BasicJfrRecordingFile(JFR jfr) {
-        this.jfr = jfr;
-    }
+  public BasicJfrRecordingFile(JFR jfr) {
+    this.jfr = jfr;
+  }
 
-    @Override
-    public Stream<RecordedEvent> open(Path path) {
-        RecordingFile file = jfr.openRecordingFile(path);
-        return StreamSupport.stream(
-                new Spliterators.AbstractSpliterator<RecordedEvent>(Long.MAX_VALUE, Spliterator.ORDERED) {
-                    public boolean tryAdvance(Consumer<? super RecordedEvent> action) {
-                        if (file.hasMoreEvents()) {
-                            action.accept(jfr.readEvent(file, path));
-                            return true;
-                        }
-                        return false;
-                    }
+  @Override
+  public Stream<RecordedEvent> open(Path path) {
+    RecordingFile file = jfr.openRecordingFile(path);
+    return StreamSupport.stream(
+        new Spliterators.AbstractSpliterator<RecordedEvent>(Long.MAX_VALUE, Spliterator.ORDERED) {
+          public boolean tryAdvance(Consumer<? super RecordedEvent> action) {
+            if (file.hasMoreEvents()) {
+              action.accept(jfr.readEvent(file, path));
+              return true;
+            }
+            return false;
+          }
 
-                    public void forEachRemaining(Consumer<? super RecordedEvent> action) {
-                        while (file.hasMoreEvents()) {
-                            action.accept(jfr.readEvent(file, path));
-                        }
-                    }
-                }, false);
-    }
+          public void forEachRemaining(Consumer<? super RecordedEvent> action) {
+            while (file.hasMoreEvents()) {
+              action.accept(jfr.readEvent(file, path));
+            }
+          }
+        },
+        false);
+  }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/BasicJfrRecordingFile.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/BasicJfrRecordingFile.java
@@ -1,0 +1,45 @@
+package com.splunk.opentelemetry.profiler;
+
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+
+import java.nio.file.Path;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * Simple/basic abstraction around a recording file.  Can open and
+ * get a stream of events.
+ */
+public class BasicJfrRecordingFile implements RecordedEventStream {
+
+    private final JFR jfr;
+
+    public BasicJfrRecordingFile(JFR jfr) {
+        this.jfr = jfr;
+    }
+
+    @Override
+    public Stream<RecordedEvent> open(Path path) {
+        RecordingFile file = jfr.openRecordingFile(path);
+        return StreamSupport.stream(
+                new Spliterators.AbstractSpliterator<RecordedEvent>(Long.MAX_VALUE, Spliterator.ORDERED) {
+                    public boolean tryAdvance(Consumer<? super RecordedEvent> action) {
+                        if (file.hasMoreEvents()) {
+                            action.accept(jfr.readEvent(file, path));
+                            return true;
+                        }
+                        return false;
+                    }
+
+                    public void forEachRemaining(Consumer<? super RecordedEvent> action) {
+                        while (file.hasMoreEvents()) {
+                            action.accept(jfr.readEvent(file, path));
+                        }
+                    }
+                }, false);
+    }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
@@ -28,7 +28,7 @@ public class Configuration implements PropertySource {
   public static final String CONFIG_KEY_PROFILER_DIRECTORY = "splunk.profiler.directory";
   public static final String CONFIG_KEY_RECORDING_DURATION_SECONDS =
       "splunk.profiler.recording.duration";
-  public static final String CONFIG_KEY_KEEP_FILES = "splunk.profiler.keepfiles";
+  public static final String CONFIG_KEY_KEEP_FILES = "splunk.profiler.keep-files";
 
   @Override
   public Map<String, String> getProperties() {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
@@ -28,11 +28,13 @@ public class Configuration implements PropertySource {
   public static final String CONFIG_KEY_PROFILER_DIRECTORY = "splunk.profiler.directory";
   public static final String CONFIG_KEY_RECORDING_DURATION_SECONDS =
       "splunk.profiler.recording.duration";
+  public static final String CONFIG_KEY_KEEP_FILES = "splunk.profiler.keepfiles";
 
   @Override
   public Map<String, String> getProperties() {
     HashMap<String, String> config = new HashMap<>();
     config.put(CONFIG_KEY_ENABLE_PROFILER, "false");
+    config.put(CONFIG_KEY_KEEP_FILES, "false");
     return config;
   }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/EventProcessingChain.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/EventProcessingChain.java
@@ -1,12 +1,27 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.opentelemetry.profiler;
 
-import jdk.jfr.consumer.RecordedEvent;
-
 import java.nio.file.Path;
+import jdk.jfr.consumer.RecordedEvent;
 
 public class EventProcessingChain {
 
-    public void accept(Path path, RecordedEvent event) {
-        //NO-OP for now....
-    }
+  public void accept(Path path, RecordedEvent event) {
+    // NO-OP for now....
+  }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/EventProcessingChain.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/EventProcessingChain.java
@@ -1,0 +1,12 @@
+package com.splunk.opentelemetry.profiler;
+
+import jdk.jfr.consumer.RecordedEvent;
+
+import java.nio.file.Path;
+
+public class EventProcessingChain {
+
+    public void accept(Path path, RecordedEvent event) {
+        //NO-OP for now....
+    }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/EventProcessingChain.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/EventProcessingChain.java
@@ -19,7 +19,7 @@ package com.splunk.opentelemetry.profiler;
 import java.nio.file.Path;
 import jdk.jfr.consumer.RecordedEvent;
 
-public class EventProcessingChain {
+class EventProcessingChain {
 
   public void accept(Path path, RecordedEvent event) {
     // NO-OP for now....

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JFR.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JFR.java
@@ -24,7 +24,7 @@ import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordingFile;
 
 /** Abstraction around the Java Flight Recorder subsystem. */
-public class JFR {
+class JFR {
 
   public static final JFR instance = new JFR();
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JFR.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JFR.java
@@ -18,17 +18,40 @@ package com.splunk.opentelemetry.profiler;
 
 import jdk.jfr.FlightRecorder;
 import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
 
-/** Abstraction around the Java Flight Recorder subsystem. */
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Abstraction around the Java Flight Recorder subsystem.
+ */
 public class JFR {
 
-  public static final JFR instance = new JFR();
+    public static final JFR instance = new JFR();
 
-  public boolean isAvailable() {
-    return FlightRecorder.isAvailable();
-  }
+    public boolean isAvailable() {
+        return FlightRecorder.isAvailable();
+    }
 
-  public Recording takeSnapshot() {
-    return FlightRecorder.getFlightRecorder().takeSnapshot();
-  }
+    public Recording takeSnapshot() {
+        return FlightRecorder.getFlightRecorder().takeSnapshot();
+    }
+
+    public RecordingFile openRecordingFile(Path path) {
+        try {
+            return new RecordingFile(path);
+        } catch (IOException e) {
+            throw new JfrException("Error opening recording file", e);
+        }
+    }
+
+    public RecordedEvent readEvent(RecordingFile file, Path path) {
+        try {
+            return file.readEvent();
+        } catch (IOException e) {
+            throw new JfrException("Error reading events from " + path, e);
+        }
+    }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JFR.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JFR.java
@@ -16,42 +16,39 @@
 
 package com.splunk.opentelemetry.profiler;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import jdk.jfr.FlightRecorder;
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordingFile;
 
-import java.io.IOException;
-import java.nio.file.Path;
-
-/**
- * Abstraction around the Java Flight Recorder subsystem.
- */
+/** Abstraction around the Java Flight Recorder subsystem. */
 public class JFR {
 
-    public static final JFR instance = new JFR();
+  public static final JFR instance = new JFR();
 
-    public boolean isAvailable() {
-        return FlightRecorder.isAvailable();
-    }
+  public boolean isAvailable() {
+    return FlightRecorder.isAvailable();
+  }
 
-    public Recording takeSnapshot() {
-        return FlightRecorder.getFlightRecorder().takeSnapshot();
-    }
+  public Recording takeSnapshot() {
+    return FlightRecorder.getFlightRecorder().takeSnapshot();
+  }
 
-    public RecordingFile openRecordingFile(Path path) {
-        try {
-            return new RecordingFile(path);
-        } catch (IOException e) {
-            throw new JfrException("Error opening recording file", e);
-        }
+  public RecordingFile openRecordingFile(Path path) {
+    try {
+      return new RecordingFile(path);
+    } catch (IOException e) {
+      throw new JfrException("Error opening recording file", e);
     }
+  }
 
-    public RecordedEvent readEvent(RecordingFile file, Path path) {
-        try {
-            return file.readEvent();
-        } catch (IOException e) {
-            throw new JfrException("Error reading events from " + path, e);
-        }
+  public RecordedEvent readEvent(RecordingFile file, Path path) {
+    try {
+      return file.readEvent();
+    } catch (IOException e) {
+      throw new JfrException("Error reading events from " + path, e);
     }
+  }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
@@ -17,11 +17,15 @@
 package com.splunk.opentelemetry.profiler;
 
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_ENABLE_PROFILER;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_KEEP_FILES;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PROFILER_DIRECTORY;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_RECORDING_DURATION_SECONDS;
+import static com.splunk.opentelemetry.profiler.JfrFileLifecycleEvents.buildOnFileFinished;
+import static com.splunk.opentelemetry.profiler.JfrFileLifecycleEvents.buildOnNewRecording;
 import static com.splunk.opentelemetry.profiler.util.HelpfulExecutors.logUncaught;
 
 import com.google.auto.service.AutoService;
+import com.splunk.opentelemetry.profiler.util.FileDeleter;
 import com.splunk.opentelemetry.profiler.util.HelpfulExecutors;
 import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.javaagent.spi.ComponentInstaller;
@@ -30,7 +34,6 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,24 +66,30 @@ public class JfrActivator implements ComponentInstaller {
     JfrSettingsReader settingsReader = new JfrSettingsReader();
     Path outputDir = Paths.get(config.getProperty(CONFIG_KEY_PROFILER_DIRECTORY, "."));
 
-      RecordedEventStream.Factory recordedEventStreamFactory = () -> new BasicJfrRecordingFile(JFR.instance);
-      EventProcessingChain eventProcessingChain = new EventProcessingChain();
-      Consumer<Path> onFileFinished = path -> {
+    RecordedEventStream.Factory recordedEventStreamFactory =
+        () -> new BasicJfrRecordingFile(JFR.instance);
+    EventProcessingChain eventProcessingChain = new EventProcessingChain();
+    Consumer<Path> deleter = buildFileDeleter(config);
+    JfrDirCleanup dirCleanup = new JfrDirCleanup(deleter);
 
-      };
-      JfrPathHandler jfrPathHandler = JfrPathHandler.builder()
+    Consumer<Path> onFileFinished = buildOnFileFinished(deleter, dirCleanup);
+
+    JfrPathHandler jfrPathHandler =
+        JfrPathHandler.builder()
             .recordedEventStreamFactory(recordedEventStreamFactory)
             .eventProcessingChain(eventProcessingChain)
             .onFileFinished(onFileFinished)
             .build();
 
-      JfrRecorder recorder =
+    Consumer<Path> onNewRecording = buildOnNewRecording(jfrPathHandler, dirCleanup);
+
+    JfrRecorder recorder =
         JfrRecorder.builder()
             .settingsReader(settingsReader)
             .maxAgeDuration(recordingDuration.multipliedBy(10))
             .jfr(JFR.instance)
             .outputDir(outputDir)
-            .onNewRecordingFile(jfrPathHandler)
+            .onNewRecordingFile(onNewRecording)
             .build();
 
     RecordingSequencer sequencer =
@@ -91,5 +100,14 @@ public class JfrActivator implements ComponentInstaller {
             .build();
 
     sequencer.start();
+    dirCleanup.registerShutdownHook();
+  }
+
+  private Consumer<Path> buildFileDeleter(Config config) {
+    if (config.getBooleanProperty(CONFIG_KEY_KEEP_FILES, false)) {
+      logger.warn("{} is enabled, leaving JFR files on disk.", CONFIG_KEY_KEEP_FILES);
+      return FileDeleter.noopFileDeleter();
+    }
+    return FileDeleter.newDeleter();
   }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrDirCleanup.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrDirCleanup.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * This class is responsible for cleaning up jfr files that might not have otherwise been cleaned
  * up. It can register a VM shutdown hook to remove its list of pending files at shutdown.
  */
-public class JfrDirCleanup {
+class JfrDirCleanup {
 
   private static final Logger logger = LoggerFactory.getLogger(JfrDirCleanup.class);
   private final Consumer<Path> fileDeleter;

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrDirCleanup.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrDirCleanup.java
@@ -53,14 +53,13 @@ public class JfrDirCleanup {
         .keySet()
         .forEach(
             path -> {
-              logger.warn("Shutdown :: JfrDirCleanup deleting " + path);
+              logger.warn("Shutdown :: JfrDirCleanup deleting {}", path);
               fileDeleter.accept(path);
             });
   }
 
   public void registerShutdownHook() {
     getRuntime().addShutdownHook(new Thread(logUncaught(this::cleanUp)));
-    ;
   }
 
   @VisibleForTesting

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrDirCleanup.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrDirCleanup.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import static com.splunk.opentelemetry.profiler.util.HelpfulExecutors.logUncaught;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is responsible for cleaning up jfr files that might not have otherwise been cleaned
+ * up. It can register a VM shutdown hook to remove its list of pending files at shutdown.
+ */
+public class JfrDirCleanup {
+
+  private static final Logger logger = LoggerFactory.getLogger(JfrDirCleanup.class);
+  private final Consumer<Path> fileDeleter;
+  private final Map<Path, Integer> pending = new ConcurrentHashMap<>();
+
+  public JfrDirCleanup(Consumer<Path> fileDeleter) {
+    this.fileDeleter = fileDeleter;
+  }
+
+  public void recordingCreated(Path path) {
+    pending.put(path, 0);
+  }
+
+  public void recordingDeleted(Path path) {
+    pending.remove(path);
+  }
+
+  public void cleanUp() {
+    pending
+        .keySet()
+        .forEach(
+            path -> {
+              logger.warn("Shutdown :: JfrDirCleanup deleting " + path);
+              fileDeleter.accept(path);
+            });
+  }
+
+  public void registerShutdownHook() {
+    getRuntime().addShutdownHook(new Thread(logUncaught(this::cleanUp)));
+    ;
+  }
+
+  @VisibleForTesting
+  protected Runtime getRuntime() {
+    return Runtime.getRuntime();
+  }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrException.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrException.java
@@ -16,7 +16,7 @@
 
 package com.splunk.opentelemetry.profiler;
 
-public class JfrException extends RuntimeException {
+class JfrException extends RuntimeException {
 
   public JfrException(String message, Exception e) {
     super(message, e);

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrException.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrException.java
@@ -1,0 +1,8 @@
+package com.splunk.opentelemetry.profiler;
+
+public class JfrException extends RuntimeException {
+
+    public JfrException(String message, Exception e) {
+        super(message, e);
+    }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrFileLifecycleEvents.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrFileLifecycleEvents.java
@@ -16,9 +16,24 @@
 
 package com.splunk.opentelemetry.profiler;
 
-public class JfrException extends RuntimeException {
+import java.nio.file.Path;
+import java.util.function.Consumer;
 
-  public JfrException(String message, Exception e) {
-    super(message, e);
+public class JfrFileLifecycleEvents {
+
+  public static Consumer<Path> buildOnNewRecording(
+      Consumer<Path> jfrPathHandler, JfrDirCleanup dirCleanup) {
+    return path -> {
+      dirCleanup.recordingCreated(path);
+      jfrPathHandler.accept(path);
+    };
+  }
+
+  public static Consumer<Path> buildOnFileFinished(
+      Consumer<Path> deleter, JfrDirCleanup dirCleanup) {
+    return path -> {
+      deleter.accept(path);
+      dirCleanup.recordingDeleted(path);
+    };
   }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrFileLifecycleEvents.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrFileLifecycleEvents.java
@@ -19,7 +19,7 @@ package com.splunk.opentelemetry.profiler;
 import java.nio.file.Path;
 import java.util.function.Consumer;
 
-public class JfrFileLifecycleEvents {
+class JfrFileLifecycleEvents {
 
   public static Consumer<Path> buildOnNewRecording(
       Consumer<Path> jfrPathHandler, JfrDirCleanup dirCleanup) {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrPathHandler.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrPathHandler.java
@@ -1,0 +1,67 @@
+package com.splunk.opentelemetry.profiler;
+
+import com.splunk.opentelemetry.profiler.util.FileDeleter;
+import jdk.jfr.consumer.RecordedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+/**
+ * Responsible for processing a single jfr file snapshot.
+ * It streams events from the RecordedEventStream into the processing
+ * chain and, once complete, calls the onComplete callback.
+ */
+public class JfrPathHandler implements Consumer<Path> {
+
+    private final static Logger logger = LoggerFactory.getLogger(JfrPathHandler.class);
+    private final EventProcessingChain eventProcessingChain;
+    private final Consumer<Path> onFileFinished;
+    private final RecordedEventStream.Factory recordedEventStreamFactory;
+
+    public JfrPathHandler(Builder builder) {
+        this.eventProcessingChain = builder.eventProcessingChain;
+        this.onFileFinished = builder.onFileFinished;
+        this.recordedEventStreamFactory = builder.recordedEventStreamFactory;
+    }
+
+    @Override
+    public void accept(Path path) {
+        logger.info("New jfr file detected: " + path);
+        RecordedEventStream recordingFile = recordedEventStreamFactory.get();
+        Stream<RecordedEvent> events = recordingFile.open(path);
+        events.forEach(event -> eventProcessingChain.accept(path, event));
+        onFileFinished.accept(path);
+    }
+
+    public static Builder builder(){
+        return new Builder();
+    }
+
+    public static class Builder {
+        private EventProcessingChain eventProcessingChain;
+        private Consumer<Path> onFileFinished;
+        private RecordedEventStream.Factory recordedEventStreamFactory;
+
+        public Builder eventProcessingChain(EventProcessingChain eventProcessingChain) {
+            this.eventProcessingChain = eventProcessingChain;
+            return this;
+        }
+
+        public Builder onFileFinished(Consumer<Path> onFileFinished) {
+            this.onFileFinished = onFileFinished;
+            return this;
+        }
+
+        public Builder recordedEventStreamFactory(RecordedEventStream.Factory recordedEventStreamFactory) {
+            this.recordedEventStreamFactory = recordedEventStreamFactory;
+            return this;
+        }
+
+        public JfrPathHandler build() {
+            return new JfrPathHandler(this);
+        }
+    }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrPathHandler.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrPathHandler.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  * Responsible for processing a single jfr file snapshot. It streams events from the
  * RecordedEventStream into the processing chain and, once complete, calls the onComplete callback.
  */
-public class JfrPathHandler implements Consumer<Path> {
+class JfrPathHandler implements Consumer<Path> {
 
   private static final Logger logger = LoggerFactory.getLogger(JfrPathHandler.class);
   private final EventProcessingChain eventProcessingChain;

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrPathHandler.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrPathHandler.java
@@ -42,7 +42,7 @@ public class JfrPathHandler implements Consumer<Path> {
 
   @Override
   public void accept(Path path) {
-    logger.info("New jfr file detected: " + path);
+    logger.info("New jfr file detected: {}", path);
     RecordedEventStream recordingFile = recordedEventStreamFactory.get();
     Stream<RecordedEvent> events = recordingFile.open(path);
     events.forEach(event -> eventProcessingChain.accept(path, event));

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrPathHandler.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrPathHandler.java
@@ -25,7 +25,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Responsible for processing a single jfr file snapshot. It streams events from the
- * RecordedEventStream into the processing chain and, once complete, calls the onComplete callback.
+ * RecordedEventStream into the processing chain and, once complete, calls the onFileFinished
+ * callback.
  */
 class JfrPathHandler implements Consumer<Path> {
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrPathHandler.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrPathHandler.java
@@ -1,67 +1,81 @@
-package com.splunk.opentelemetry.profiler;
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import com.splunk.opentelemetry.profiler.util.FileDeleter;
-import jdk.jfr.consumer.RecordedEvent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+package com.splunk.opentelemetry.profiler;
 
 import java.nio.file.Path;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+import jdk.jfr.consumer.RecordedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * Responsible for processing a single jfr file snapshot.
- * It streams events from the RecordedEventStream into the processing
- * chain and, once complete, calls the onComplete callback.
+ * Responsible for processing a single jfr file snapshot. It streams events from the
+ * RecordedEventStream into the processing chain and, once complete, calls the onComplete callback.
  */
 public class JfrPathHandler implements Consumer<Path> {
 
-    private final static Logger logger = LoggerFactory.getLogger(JfrPathHandler.class);
-    private final EventProcessingChain eventProcessingChain;
-    private final Consumer<Path> onFileFinished;
-    private final RecordedEventStream.Factory recordedEventStreamFactory;
+  private static final Logger logger = LoggerFactory.getLogger(JfrPathHandler.class);
+  private final EventProcessingChain eventProcessingChain;
+  private final Consumer<Path> onFileFinished;
+  private final RecordedEventStream.Factory recordedEventStreamFactory;
 
-    public JfrPathHandler(Builder builder) {
-        this.eventProcessingChain = builder.eventProcessingChain;
-        this.onFileFinished = builder.onFileFinished;
-        this.recordedEventStreamFactory = builder.recordedEventStreamFactory;
+  public JfrPathHandler(Builder builder) {
+    this.eventProcessingChain = builder.eventProcessingChain;
+    this.onFileFinished = builder.onFileFinished;
+    this.recordedEventStreamFactory = builder.recordedEventStreamFactory;
+  }
+
+  @Override
+  public void accept(Path path) {
+    logger.info("New jfr file detected: " + path);
+    RecordedEventStream recordingFile = recordedEventStreamFactory.get();
+    Stream<RecordedEvent> events = recordingFile.open(path);
+    events.forEach(event -> eventProcessingChain.accept(path, event));
+    onFileFinished.accept(path);
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private EventProcessingChain eventProcessingChain;
+    private Consumer<Path> onFileFinished;
+    private RecordedEventStream.Factory recordedEventStreamFactory;
+
+    public Builder eventProcessingChain(EventProcessingChain eventProcessingChain) {
+      this.eventProcessingChain = eventProcessingChain;
+      return this;
     }
 
-    @Override
-    public void accept(Path path) {
-        logger.info("New jfr file detected: " + path);
-        RecordedEventStream recordingFile = recordedEventStreamFactory.get();
-        Stream<RecordedEvent> events = recordingFile.open(path);
-        events.forEach(event -> eventProcessingChain.accept(path, event));
-        onFileFinished.accept(path);
+    public Builder onFileFinished(Consumer<Path> onFileFinished) {
+      this.onFileFinished = onFileFinished;
+      return this;
     }
 
-    public static Builder builder(){
-        return new Builder();
+    public Builder recordedEventStreamFactory(
+        RecordedEventStream.Factory recordedEventStreamFactory) {
+      this.recordedEventStreamFactory = recordedEventStreamFactory;
+      return this;
     }
 
-    public static class Builder {
-        private EventProcessingChain eventProcessingChain;
-        private Consumer<Path> onFileFinished;
-        private RecordedEventStream.Factory recordedEventStreamFactory;
-
-        public Builder eventProcessingChain(EventProcessingChain eventProcessingChain) {
-            this.eventProcessingChain = eventProcessingChain;
-            return this;
-        }
-
-        public Builder onFileFinished(Consumer<Path> onFileFinished) {
-            this.onFileFinished = onFileFinished;
-            return this;
-        }
-
-        public Builder recordedEventStreamFactory(RecordedEventStream.Factory recordedEventStreamFactory) {
-            this.recordedEventStreamFactory = recordedEventStreamFactory;
-            return this;
-        }
-
-        public JfrPathHandler build() {
-            return new JfrPathHandler(this);
-        }
+    public JfrPathHandler build() {
+      return new JfrPathHandler(this);
     }
+  }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrRecorder.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrRecorder.java
@@ -28,7 +28,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.function.Consumer;
-
 import jdk.jfr.Recording;
 import jdk.jfr.RecordingState;
 import org.slf4j.Logger;
@@ -125,7 +124,7 @@ public class JfrRecorder {
       return this;
     }
 
-    public Builder onNewRecordingFile(Consumer<Path> onNewRecordingFile){
+    public Builder onNewRecordingFile(Consumer<Path> onNewRecordingFile) {
       this.onNewRecordingFile = onNewRecordingFile;
       return this;
     }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrRecorder.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrRecorder.java
@@ -34,7 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Responsible for starting a single JFR recording. */
-public class JfrRecorder {
+class JfrRecorder {
   private static final Logger logger = LoggerFactory.getLogger(JfrRecorder.class.getName());
   static final String RECORDING_NAME = "otel_agent_jfr_profiler";
   private final JfrSettingsReader settingsReader;

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrSettingsReader.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrSettingsReader.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class JfrSettingsReader {
+class JfrSettingsReader {
 
   private static final Logger logger = LoggerFactory.getLogger(JfrSettingsReader.class);
   private static final String DEFAULT_JFR_SETTINGS = "jfr.settings";

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordedEventStream.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordedEventStream.java
@@ -1,17 +1,29 @@
-package com.splunk.opentelemetry.profiler;
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import jdk.jfr.consumer.RecordedEvent;
+package com.splunk.opentelemetry.profiler;
 
 import java.nio.file.Path;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+import jdk.jfr.consumer.RecordedEvent;
 
-/**
- * Tag interface for turning a file path into a stream of JFR RecordedEvent instances.
- */
+/** Tag interface for turning a file path into a stream of JFR RecordedEvent instances. */
 public interface RecordedEventStream {
-    Stream<RecordedEvent> open(Path path);
-    interface Factory extends Supplier<RecordedEventStream> {
+  Stream<RecordedEvent> open(Path path);
 
-    }
+  interface Factory extends Supplier<RecordedEventStream> {}
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordedEventStream.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordedEventStream.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
 import jdk.jfr.consumer.RecordedEvent;
 
 /** Tag interface for turning a file path into a stream of JFR RecordedEvent instances. */
-public interface RecordedEventStream {
+interface RecordedEventStream {
   Stream<RecordedEvent> open(Path path);
 
   interface Factory extends Supplier<RecordedEventStream> {}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordedEventStream.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordedEventStream.java
@@ -1,0 +1,17 @@
+package com.splunk.opentelemetry.profiler;
+
+import jdk.jfr.consumer.RecordedEvent;
+
+import java.nio.file.Path;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+/**
+ * Tag interface for turning a file path into a stream of JFR RecordedEvent instances.
+ */
+public interface RecordedEventStream {
+    Stream<RecordedEvent> open(Path path);
+    interface Factory extends Supplier<RecordedEventStream> {
+
+    }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordingEscapeHatch.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordingEscapeHatch.java
@@ -16,7 +16,7 @@
 
 package com.splunk.opentelemetry.profiler;
 
-public class RecordingEscapeHatch {
+class RecordingEscapeHatch {
 
   public boolean jfrCanContinue() {
     return true;

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordingSequencer.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordingSequencer.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  * Responsible for periodically generating a sequence of JFR recording files. Prior to starting a
  * recording, it consults with a RecordingEscapeHatch to make sure that it is safe/relevant to do.
  */
-public class RecordingSequencer {
+class RecordingSequencer {
   private static final Logger logger = LoggerFactory.getLogger(RecordingSequencer.class.getName());
   // The overlap factor causes recordings to be shorter than the requested duration.
   // This forces overlap between recordings and ensures data is continuous when deduplicated.

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/util/FileDeleter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/util/FileDeleter.java
@@ -1,0 +1,31 @@
+package com.splunk.opentelemetry.profiler.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Consumer;
+
+public interface FileDeleter extends Consumer<Path> {
+
+    Logger logger = LoggerFactory.getLogger(FileDeleter.class);
+
+    static FileDeleter newDeleter(){
+        return path -> {
+            try {
+                Files.delete(path);
+            } catch (IOException e) {
+                logger.warn("Could not delete: " + path, e);
+            }
+        };
+    }
+
+    static FileDeleter noopFileDeleter(){
+        return path -> {
+            logger.warn("Leaving " + path + " on disk.");
+        };
+    }
+
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/util/FileDeleter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/util/FileDeleter.java
@@ -32,14 +32,14 @@ public interface FileDeleter extends Consumer<Path> {
       try {
         Files.delete(path);
       } catch (IOException e) {
-        logger.warn("Could not delete: " + path, e);
+        logger.warn("Could not delete: {}", path, e);
       }
     };
   }
 
   static FileDeleter noopFileDeleter() {
     return path -> {
-      logger.warn("Leaving " + path + " on disk.");
+      logger.warn("Leaving {} on disk.", path);
     };
   }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/util/FileDeleter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/util/FileDeleter.java
@@ -1,31 +1,45 @@
-package com.splunk.opentelemetry.profiler.util;
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+package com.splunk.opentelemetry.profiler.util;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public interface FileDeleter extends Consumer<Path> {
 
-    Logger logger = LoggerFactory.getLogger(FileDeleter.class);
+  Logger logger = LoggerFactory.getLogger(FileDeleter.class);
 
-    static FileDeleter newDeleter(){
-        return path -> {
-            try {
-                Files.delete(path);
-            } catch (IOException e) {
-                logger.warn("Could not delete: " + path, e);
-            }
-        };
-    }
+  static FileDeleter newDeleter() {
+    return path -> {
+      try {
+        Files.delete(path);
+      } catch (IOException e) {
+        logger.warn("Could not delete: " + path, e);
+      }
+    };
+  }
 
-    static FileDeleter noopFileDeleter(){
-        return path -> {
-            logger.warn("Leaving " + path + " on disk.");
-        };
-    }
-
+  static FileDeleter noopFileDeleter() {
+    return path -> {
+      logger.warn("Leaving " + path + " on disk.");
+    };
+  }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/BasicJfrRecordingFileTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/BasicJfrRecordingFileTest.java
@@ -16,7 +16,7 @@
 
 package com.splunk.opentelemetry.profiler;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/BasicJfrRecordingFileTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/BasicJfrRecordingFileTest.java
@@ -1,0 +1,47 @@
+package com.splunk.opentelemetry.profiler;
+
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BasicJfrRecordingFileTest {
+
+    @Mock
+    JFR jfr;
+    @Mock
+    RecordingFile recordingFile;
+    Path path = Paths.get("/path/to/file.jfr");
+
+    @Test
+    void testOpen() {
+        RecordedEvent e1 = mock(RecordedEvent.class);
+        RecordedEvent e2 = mock(RecordedEvent.class);
+        RecordedEvent e3 = mock(RecordedEvent.class);
+
+        when(recordingFile.hasMoreEvents()).thenReturn(true, true, true, false);
+        when(jfr.openRecordingFile(path)).thenReturn(recordingFile);
+        when(jfr.readEvent(recordingFile, path)).thenReturn(e1, e2, e3);
+        BasicJfrRecordingFile recordingFile = new BasicJfrRecordingFile(jfr);
+
+        Stream<RecordedEvent> stream = recordingFile.open(path);
+        List<RecordedEvent> result = stream.collect(Collectors.toList());
+        List<RecordedEvent> expected = Arrays.asList(e1, e2, e3);
+        assertEquals(expected, result);
+    }
+
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/BasicJfrRecordingFileTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/BasicJfrRecordingFileTest.java
@@ -1,11 +1,24 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.opentelemetry.profiler;
 
-import jdk.jfr.consumer.RecordedEvent;
-import jdk.jfr.consumer.RecordingFile;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -13,35 +26,34 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class BasicJfrRecordingFileTest {
 
-    @Mock
-    JFR jfr;
-    @Mock
-    RecordingFile recordingFile;
-    Path path = Paths.get("/path/to/file.jfr");
+  @Mock JFR jfr;
+  @Mock RecordingFile recordingFile;
+  Path path = Paths.get("/path/to/file.jfr");
 
-    @Test
-    void testOpen() {
-        RecordedEvent e1 = mock(RecordedEvent.class);
-        RecordedEvent e2 = mock(RecordedEvent.class);
-        RecordedEvent e3 = mock(RecordedEvent.class);
+  @Test
+  void testOpen() {
+    RecordedEvent e1 = mock(RecordedEvent.class);
+    RecordedEvent e2 = mock(RecordedEvent.class);
+    RecordedEvent e3 = mock(RecordedEvent.class);
 
-        when(recordingFile.hasMoreEvents()).thenReturn(true, true, true, false);
-        when(jfr.openRecordingFile(path)).thenReturn(recordingFile);
-        when(jfr.readEvent(recordingFile, path)).thenReturn(e1, e2, e3);
-        BasicJfrRecordingFile recordingFile = new BasicJfrRecordingFile(jfr);
+    when(recordingFile.hasMoreEvents()).thenReturn(true, true, true, false);
+    when(jfr.openRecordingFile(path)).thenReturn(recordingFile);
+    when(jfr.readEvent(recordingFile, path)).thenReturn(e1, e2, e3);
+    BasicJfrRecordingFile recordingFile = new BasicJfrRecordingFile(jfr);
 
-        Stream<RecordedEvent> stream = recordingFile.open(path);
-        List<RecordedEvent> result = stream.collect(Collectors.toList());
-        List<RecordedEvent> expected = Arrays.asList(e1, e2, e3);
-        assertEquals(expected, result);
-    }
-
+    Stream<RecordedEvent> stream = recordingFile.open(path);
+    List<RecordedEvent> result = stream.collect(Collectors.toList());
+    List<RecordedEvent> expected = Arrays.asList(e1, e2, e3);
+    assertEquals(expected, result);
+  }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrDirCleanupTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrDirCleanupTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class JfrDirCleanupTest {
+
+  @Test
+  void testLifecycle() {
+    Path path1 = Paths.get("/some/path/to/file1.jfr");
+    Path path2 = Paths.get("/some/path/to/file1.jfr");
+    Path path3 = Paths.get("/some/path/to/file1.jfr");
+
+    Consumer<Path> fileDeleter = mock(Consumer.class);
+    Runtime runtime = mock(Runtime.class);
+    ArgumentCaptor<Thread> threadCaptor = ArgumentCaptor.forClass(Thread.class);
+    doNothing().when(runtime).addShutdownHook(threadCaptor.capture());
+
+    JfrDirCleanup jfrDirCleanup =
+        new JfrDirCleanup(fileDeleter) {
+          @Override
+          protected Runtime getRuntime() {
+            return runtime;
+          }
+        };
+    jfrDirCleanup.registerShutdownHook();
+
+    jfrDirCleanup.recordingCreated(path1);
+    jfrDirCleanup.recordingCreated(path2);
+    jfrDirCleanup.recordingDeleted(path1);
+    jfrDirCleanup.recordingCreated(path3);
+
+    threadCaptor.getValue().run(); // not start, just runs inline
+
+    verify(fileDeleter).accept(path2);
+    verify(fileDeleter).accept(path3);
+    verifyNoMoreInteractions(fileDeleter);
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrFileLifecycleEventsTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrFileLifecycleEventsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class JfrFileLifecycleEventsTest {
+
+  @Mock JfrDirCleanup cleanup;
+  Path path = Paths.get("/path/to/some/file.jfr");
+
+  @Test
+  void testOnNewRecording() {
+    Consumer<Path> pathHandler = mock(Consumer.class);
+    Consumer<Path> callback = JfrFileLifecycleEvents.buildOnNewRecording(pathHandler, cleanup);
+    callback.accept(path);
+    verify(pathHandler).accept(path);
+    verify(cleanup).recordingCreated(path);
+  }
+
+  @Test
+  void testOnFileFinished() {
+    Consumer<Path> deleter = mock(Consumer.class);
+    Consumer<Path> callback = JfrFileLifecycleEvents.buildOnFileFinished(deleter, cleanup);
+    callback.accept(path);
+    verify(deleter).accept(path);
+    verify(cleanup).recordingDeleted(path);
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrPathHandlerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrPathHandlerTest.java
@@ -1,50 +1,63 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.opentelemetry.profiler;
 
-import jdk.jfr.consumer.RecordedEvent;
-import org.junit.jupiter.api.Test;
-
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.function.Consumer;
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import jdk.jfr.consumer.RecordedEvent;
+import org.junit.jupiter.api.Test;
+
 class JfrPathHandlerTest {
 
-    @Test
-    void testAccept() {
-        Path path = Paths.get("/path/to/something.jfr");
+  @Test
+  void testAccept() {
+    Path path = Paths.get("/path/to/something.jfr");
 
-        EventProcessingChain chain = mock(EventProcessingChain.class);
-        Consumer<Path> onFileFinished = mock(Consumer.class);
-        RecordedEventStream.Factory eventStreamFactory = mock(RecordedEventStream.Factory.class);
-        RecordedEventStream recordedEventStream = mock(RecordedEventStream.class);
-        RecordedEvent e1 = mock(RecordedEvent.class);
-        RecordedEvent e2 = mock(RecordedEvent.class);
-        RecordedEvent e3 = mock(RecordedEvent.class);
+    EventProcessingChain chain = mock(EventProcessingChain.class);
+    Consumer<Path> onFileFinished = mock(Consumer.class);
+    RecordedEventStream.Factory eventStreamFactory = mock(RecordedEventStream.Factory.class);
+    RecordedEventStream recordedEventStream = mock(RecordedEventStream.class);
+    RecordedEvent e1 = mock(RecordedEvent.class);
+    RecordedEvent e2 = mock(RecordedEvent.class);
+    RecordedEvent e3 = mock(RecordedEvent.class);
 
-        when(eventStreamFactory.get()).thenReturn(recordedEventStream);
-        when(recordedEventStream.open(path)).thenReturn(Stream.of(e1, e2, e3));
+    when(eventStreamFactory.get()).thenReturn(recordedEventStream);
+    when(recordedEventStream.open(path)).thenReturn(Stream.of(e1, e2, e3));
 
-        JfrPathHandler jfrPathHandler = JfrPathHandler.builder()
-                .eventProcessingChain(chain)
-                .onFileFinished(onFileFinished)
-                .recordedEventStreamFactory(eventStreamFactory)
-                .build();
+    JfrPathHandler jfrPathHandler =
+        JfrPathHandler.builder()
+            .eventProcessingChain(chain)
+            .onFileFinished(onFileFinished)
+            .recordedEventStreamFactory(eventStreamFactory)
+            .build();
 
-        jfrPathHandler.accept(path);
+    jfrPathHandler.accept(path);
 
-        verify(chain).accept(path, e1);
-        verify(chain).accept(path, e2);
-        verify(chain).accept(path, e3);
-        verifyNoMoreInteractions(chain);
-        verify(onFileFinished).accept(path);
-
-    }
-
+    verify(chain).accept(path, e1);
+    verify(chain).accept(path, e2);
+    verify(chain).accept(path, e3);
+    verifyNoMoreInteractions(chain);
+    verify(onFileFinished).accept(path);
+  }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrPathHandlerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrPathHandlerTest.java
@@ -1,0 +1,50 @@
+package com.splunk.opentelemetry.profiler;
+
+import jdk.jfr.consumer.RecordedEvent;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+class JfrPathHandlerTest {
+
+    @Test
+    void testAccept() {
+        Path path = Paths.get("/path/to/something.jfr");
+
+        EventProcessingChain chain = mock(EventProcessingChain.class);
+        Consumer<Path> onFileFinished = mock(Consumer.class);
+        RecordedEventStream.Factory eventStreamFactory = mock(RecordedEventStream.Factory.class);
+        RecordedEventStream recordedEventStream = mock(RecordedEventStream.class);
+        RecordedEvent e1 = mock(RecordedEvent.class);
+        RecordedEvent e2 = mock(RecordedEvent.class);
+        RecordedEvent e3 = mock(RecordedEvent.class);
+
+        when(eventStreamFactory.get()).thenReturn(recordedEventStream);
+        when(recordedEventStream.open(path)).thenReturn(Stream.of(e1, e2, e3));
+
+        JfrPathHandler jfrPathHandler = JfrPathHandler.builder()
+                .eventProcessingChain(chain)
+                .onFileFinished(onFileFinished)
+                .recordedEventStreamFactory(eventStreamFactory)
+                .build();
+
+        jfrPathHandler.accept(path);
+
+        verify(chain).accept(path, e1);
+        verify(chain).accept(path, e2);
+        verify(chain).accept(path, e3);
+        verifyNoMoreInteractions(chain);
+        verify(onFileFinished).accept(path);
+
+    }
+
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrRecorderTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrRecorderTest.java
@@ -26,6 +26,8 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
+
 import jdk.jfr.Recording;
 import jdk.jfr.RecordingState;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,6 +45,7 @@ class JfrRecorderTest {
   Map<String, String> settings;
   @Mock JfrSettingsReader settingsReader;
   @Mock Recording recording;
+  @Mock Consumer<Path> onNewRecordingFile;
 
   @BeforeEach
   void setup() {
@@ -73,10 +76,12 @@ class JfrRecorderTest {
     JfrRecorder jfrRecorder = buildJfrRecorder(jfr);
 
     jfrRecorder.flushSnapshot();
+    Path outputPath = pathCaptor.getValue();
 
     verify(snap).dump(isA(Path.class));
-    assertTrue(pathCaptor.getValue().startsWith(OUTDIR));
+    assertTrue(outputPath.startsWith(OUTDIR));
     verify(snap).close();
+    verify(onNewRecordingFile).accept(outputPath);
   }
 
   @Test
@@ -118,6 +123,7 @@ class JfrRecorderTest {
             .maxAgeDuration(maxAge)
             .settingsReader(settingsReader)
             .outputDir(OUTDIR)
+            .onNewRecordingFile(onNewRecordingFile)
             .jfr(jfr);
 
     return new JfrRecorder(builder) {

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrRecorderTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrRecorderTest.java
@@ -27,7 +27,6 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
-
 import jdk.jfr.Recording;
 import jdk.jfr.RecordingState;
 import org.junit.jupiter.api.BeforeEach;

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/RecordingSequencerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/RecordingSequencerTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.*;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -147,6 +148,7 @@ class RecordingSequencerTest {
           new Builder()
               .settingsReader(mock(JfrSettingsReader.class))
               .maxAgeDuration(Duration.ofSeconds(10))
+              .onNewRecordingFile(mock(Consumer.class))
               .outputDir(Paths.get(".")));
       this.flushLatch = flushLatch;
       started = false;

--- a/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/ProfilerSmokeTest.java
+++ b/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/ProfilerSmokeTest.java
@@ -59,7 +59,7 @@ public class ProfilerSmokeTest {
                 "-Dotel.javaagent.debug=true",
                 "-Dsplunk.profiler.enabled=true",
                 "-Dsplunk.profiler.directory=/app/jfr",
-                "-Dsplunk.profiler.keepfiles=true",
+                "-Dsplunk.profiler.keep-files=true",
                 "-jar",
                 "/app/spring-petclinic-rest.jar")
             .withFileSystemBind(

--- a/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/ProfilerSmokeTest.java
+++ b/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/ProfilerSmokeTest.java
@@ -59,6 +59,7 @@ public class ProfilerSmokeTest {
                 "-Dotel.javaagent.debug=true",
                 "-Dsplunk.profiler.enabled=true",
                 "-Dsplunk.profiler.directory=/app/jfr",
+                "-Dsplunk.profiler.keepfiles=true",
                 "-jar",
                 "/app/spring-petclinic-rest.jar")
             .withFileSystemBind(

--- a/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/ProfilerSmokeTest.java
+++ b/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/ProfilerSmokeTest.java
@@ -74,7 +74,7 @@ public class ProfilerSmokeTest {
   }
 
   @Test
-  void ensureJfrFilesCreated() throws Exception {
+  void ensureJfrFilesCreated() {
     System.out.println("Petclinic has been started.");
 
     await()


### PR DESCRIPTION
This establishes the foundation for the processing chain via the `JfrPathHandler`.  It also tracks files as they are created and deletes them after processing.  We also register a shutdown hook to not leave files behind.

A new config option `splunk.profiler.keepfiles` is available to leave the JFR files behind on disk if desired (this is useful for later development/comparison/analysis).