### PR TITLE
Disable profiler tests on GitLab because GL can't into docker

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ stages:
 build:
   stage: build
   script:
-    - ./gradlew build -x :smoke-tests:test --scan --no-daemon --stacktrace
+    - ./gradlew build -x :smoke-tests:test -x :testing:profiler-tests:test --scan --no-daemon --stacktrace
 
 release:
   stage: release

--- a/testing/profiler-tests/build.gradle
+++ b/testing/profiler-tests/build.gradle
@@ -7,13 +7,6 @@ dependencies {
   testImplementation deps.awaitility
 }
 
-
-tasks.register('copyProfilingAgentJar', Copy) {
-  from "../../agent/build/libs/"
-  include "splunk-otel-javaagent-*-all.jar"
-  into "build"
-}
-
 tasks.test {
   def shadowTask = project(":agent").tasks.named("shadowJar").get()
   inputs.files(layout.files(shadowTask))
@@ -22,9 +15,6 @@ tasks.test {
     jvmArgs("-Dio.opentelemetry.smoketest.agent.shadowJar.path=${shadowTask.archiveFile.get()}")
   }
 }
-
-copyProfilingAgentJar.dependsOn(':agent:assemble')
-test.dependsOn(copyProfilingAgentJar)
 
 jar {
   enabled = false


### PR DESCRIPTION
And also remove no longer used gradle tasks from `:testing:profiler-tests`