### PR TITLE
Build out the recording escape hatch

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
@@ -83,12 +83,14 @@ public class JfrActivator implements ComponentInstaller {
 
     Consumer<Path> onNewRecording = buildOnNewRecording(jfrPathHandler, dirCleanup);
 
+    RecordingFileNamingConvention namingConvention = new RecordingFileNamingConvention(outputDir);
+
     JfrRecorder recorder =
         JfrRecorder.builder()
             .settingsReader(settingsReader)
             .maxAgeDuration(recordingDuration.multipliedBy(10))
             .jfr(JFR.instance)
-            .outputDir(outputDir)
+            .namingConvention(namingConvention)
             .onNewRecordingFile(onNewRecording)
             .build();
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
@@ -62,9 +62,17 @@ public class JfrActivator implements ComponentInstaller {
   private void activateJfrAndRunForever(Config config) {
     String recordingDurationStr = config.getProperty(CONFIG_KEY_RECORDING_DURATION_SECONDS, "20");
     Duration recordingDuration = Duration.ofSeconds(Integer.parseInt(recordingDurationStr));
-    RecordingEscapeHatch recordingEscapeHatch = new RecordingEscapeHatch();
-    JfrSettingsReader settingsReader = new JfrSettingsReader();
+
     Path outputDir = Paths.get(config.getProperty(CONFIG_KEY_PROFILER_DIRECTORY, "."));
+    RecordingFileNamingConvention namingConvention = new RecordingFileNamingConvention(outputDir);
+
+    RecordingEscapeHatch recordingEscapeHatch =
+        RecordingEscapeHatch.builder()
+            .namingConvention(namingConvention)
+            .configKeepsFilesOnDisk(keepFiles(config))
+            .recordingDuration(recordingDuration)
+            .build();
+    JfrSettingsReader settingsReader = new JfrSettingsReader();
 
     RecordedEventStream.Factory recordedEventStreamFactory =
         () -> new BasicJfrRecordingFile(JFR.instance);
@@ -82,8 +90,6 @@ public class JfrActivator implements ComponentInstaller {
             .build();
 
     Consumer<Path> onNewRecording = buildOnNewRecording(jfrPathHandler, dirCleanup);
-
-    RecordingFileNamingConvention namingConvention = new RecordingFileNamingConvention(outputDir);
 
     JfrRecorder recorder =
         JfrRecorder.builder()
@@ -106,10 +112,14 @@ public class JfrActivator implements ComponentInstaller {
   }
 
   private Consumer<Path> buildFileDeleter(Config config) {
-    if (config.getBooleanProperty(CONFIG_KEY_KEEP_FILES, false)) {
+    if (keepFiles(config)) {
       logger.warn("{} is enabled, leaving JFR files on disk.", CONFIG_KEY_KEEP_FILES);
       return FileDeleter.noopFileDeleter();
     }
     return FileDeleter.newDeleter();
+  }
+
+  private boolean keepFiles(Config config) {
+    return config.getBooleanProperty(CONFIG_KEY_KEEP_FILES, false);
   }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrRecorder.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrRecorder.java
@@ -21,11 +21,7 @@ import static java.util.Objects.requireNonNull;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Duration;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.function.Consumer;
 import jdk.jfr.Recording;
@@ -120,9 +116,9 @@ class JfrRecorder {
       return this;
     }
 
-    public Builder namingConvention(RecordingFileNamingConvention namingConvention){
-       this.namingConvention = namingConvention;
-       return this;
+    public Builder namingConvention(RecordingFileNamingConvention namingConvention) {
+      this.namingConvention = namingConvention;
+      return this;
     }
 
     public JfrRecorder build() {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordingEscapeHatch.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordingEscapeHatch.java
@@ -16,9 +16,148 @@
 
 package com.splunk.opentelemetry.profiler;
 
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 class RecordingEscapeHatch {
 
+  private static final long MIN_FREE_SPACE_BYTES = 100 * 1024 * 1024; // 100MiB
+  private static final Logger logger = LoggerFactory.getLogger(RecordingEscapeHatch.class);
+  private static final Duration MAX_PENDING_DURATION = Duration.ofMinutes(5);
+
+  private final RecordingFileNamingConvention namingConvention;
+  private final boolean configKeepsFilesOnDisk;
+  private final long maxFileCount;
+  private final FilesShim filesShim;
+
+  RecordingEscapeHatch(Builder builder) {
+    this.namingConvention = builder.namingConvention;
+    this.configKeepsFilesOnDisk = builder.configKeepsFilesOnDisk;
+    this.filesShim = builder.filesShim;
+    this.maxFileCount = MAX_PENDING_DURATION.toMillis() / builder.recordingDuration.toMillis();
+  }
+
   public boolean jfrCanContinue() {
-    return true;
+    boolean result = freeSpaceIsOk() && notFileBacklogged();
+    if (!result) {
+      logger.warn("** THIS WILL RESULT IN LOSS OF PROFILING DATA **");
+    }
+    return result;
+  }
+
+  private boolean freeSpaceIsOk() {
+    try {
+      Path outputPath = namingConvention.getOutputPath();
+      FileStore store = filesShim.getFileStore(outputPath);
+      long usableSpace = store.getUsableSpace();
+      boolean result = usableSpace > MIN_FREE_SPACE_BYTES;
+      if (!result) {
+        logger.warn(
+            "** NOT STARTING RECORDING, only "
+                + usableSpace
+                + " bytes free, require "
+                + MIN_FREE_SPACE_BYTES);
+      }
+      return result;
+    } catch (IOException e) {
+      logger.error("Could not check free space, assuming everything is bad", e);
+      return false;
+    }
+  }
+
+  /**
+   * Backlogged means that there are too many recent jfr files sitting on disk, and we think we are
+   * falling behind. We will never be backlogged if the user has specified
+   * -Dsplunk.profiler.keep-files=true
+   */
+  private boolean notFileBacklogged() {
+    if (configKeepsFilesOnDisk) {
+      return true;
+    }
+    try {
+      return pendingFileCount() < maxFileCount;
+    } catch (IOException e) {
+      logger.warn("Error listing files in output directory, assuming everything is bad");
+      return false;
+    }
+  }
+
+  /** Returns the number of jfr files in the output directory that match our pattern */
+  private long pendingFileCount() throws IOException {
+    Path outputPath = namingConvention.getOutputPath();
+    return filesShim
+        .list(outputPath)
+        .filter(filesShim::isRegularFile)
+        .filter(namingConvention::matches)
+        .count();
+  }
+
+  static Builder builder() {
+    return new Builder();
+  }
+
+  // To help with testing
+  interface FilesShim {
+    FilesShim DEFAULT =
+        new FilesShim() {
+          @Override
+          public FileStore getFileStore(Path path) throws IOException {
+            return Files.getFileStore(path);
+          }
+
+          @Override
+          public Stream<Path> list(Path path) throws IOException {
+            return Files.list(path);
+          }
+
+          @Override
+          public boolean isRegularFile(Path path) {
+            return Files.isRegularFile(path);
+          }
+        };
+
+    FileStore getFileStore(Path path) throws IOException;
+
+    Stream<Path> list(Path path) throws IOException;
+
+    boolean isRegularFile(Path path);
+  }
+
+  static class Builder {
+
+    RecordingFileNamingConvention namingConvention;
+    boolean configKeepsFilesOnDisk = false;
+    Duration recordingDuration;
+    FilesShim filesShim = FilesShim.DEFAULT;
+
+    Builder namingConvention(RecordingFileNamingConvention namingConvention) {
+      this.namingConvention = namingConvention;
+      return this;
+    }
+
+    Builder configKeepsFilesOnDisk(boolean configKeepsFilesOnDisk) {
+      this.configKeepsFilesOnDisk = configKeepsFilesOnDisk;
+      return this;
+    }
+
+    Builder recordingDuration(Duration recordingDuration) {
+      this.recordingDuration = recordingDuration;
+      return this;
+    }
+
+    Builder filesShim(FilesShim shim) {
+      this.filesShim = shim;
+      return this;
+    }
+
+    RecordingEscapeHatch build() {
+      return new RecordingEscapeHatch(this);
+    }
   }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordingEscapeHatch.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordingEscapeHatch.java
@@ -59,10 +59,9 @@ class RecordingEscapeHatch {
       boolean result = usableSpace > MIN_FREE_SPACE_BYTES;
       if (!result) {
         logger.warn(
-            "** NOT STARTING RECORDING, only "
-                + usableSpace
-                + " bytes free, require "
-                + MIN_FREE_SPACE_BYTES);
+            "** NOT STARTING RECORDING, only {} bytes free, require {}",
+            usableSpace,
+            MIN_FREE_SPACE_BYTES);
       }
       return result;
     } catch (IOException e) {
@@ -91,11 +90,9 @@ class RecordingEscapeHatch {
   /** Returns the number of jfr files in the output directory that match our pattern */
   private long pendingFileCount() throws IOException {
     Path outputPath = namingConvention.getOutputPath();
-    return filesShim
-        .list(outputPath)
-        .filter(filesShim::isRegularFile)
-        .filter(namingConvention::matches)
-        .count();
+    try (Stream<Path> files = filesShim.list(outputPath)) {
+      return files.filter(filesShim::isRegularFile).filter(namingConvention::matches).count();
+    }
   }
 
   static Builder builder() {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordingFileNamingConvention.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordingFileNamingConvention.java
@@ -27,12 +27,12 @@ class RecordingFileNamingConvention {
   private static final String PREFIX = "otel-profiler";
   private final Path outputDir;
 
-  public RecordingFileNamingConvention(Path outputDir) {
+  RecordingFileNamingConvention(Path outputDir) {
     this.outputDir = outputDir;
   }
 
   /** Constructs a full path for a new jfr file using the current time. */
-  public Path newOutputPath() {
+  Path newOutputPath() {
     return newOutputPath(LocalDateTime.now());
   }
 
@@ -51,7 +51,7 @@ class RecordingFileNamingConvention {
   }
 
   /** Determines if the path represents a file that we would have recorded to. */
-  public boolean matches(Path path) {
+  boolean matches(Path path) {
     return outputDir.equals(path.getParent()) && filenameMatches(path);
   }
 
@@ -62,7 +62,7 @@ class RecordingFileNamingConvention {
         && filename.matches("^" + PREFIX + "-\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.jfr$");
   }
 
-  public Path getOutputPath() {
+  Path getOutputPath() {
     return outputDir;
   }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordingFileNamingConvention.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordingFileNamingConvention.java
@@ -21,10 +21,14 @@ import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
+import java.util.regex.Pattern;
 
 class RecordingFileNamingConvention {
 
   private static final String PREFIX = "otel-profiler";
+  // ISO_DATE_TIME format is like 2021-12-03T10:15:30
+  private final Pattern filenamePattern =
+      Pattern.compile("^" + PREFIX + "-\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.jfr$");
   private final Path outputDir;
 
   RecordingFileNamingConvention(Path outputDir) {
@@ -56,10 +60,8 @@ class RecordingFileNamingConvention {
   }
 
   private boolean filenameMatches(Path path) {
-    String filename = path.getFileName().toFile().getName();
-    // ISO_DATE_TIME format is like 2021-12-03T10:15:30
-    return filename.startsWith(PREFIX)
-        && filename.matches("^" + PREFIX + "-\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.jfr$");
+    String filename = path.getFileName().toString();
+    return filenamePattern.matcher(filename).matches();
   }
 
   Path getOutputPath() {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordingFileNamingConvention.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordingFileNamingConvention.java
@@ -1,0 +1,55 @@
+package com.splunk.opentelemetry.profiler;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+class RecordingFileNamingConvention {
+
+    private final static String PREFIX = "otel-profiler";
+    private final Path outputDir;
+
+    public RecordingFileNamingConvention(Path outputDir) {
+        this.outputDir = outputDir;
+    }
+
+    /**
+     * Constructs a full path for a new jfr file using the current time.
+     */
+    public Path newOutputPath(){
+        return newOutputPath(LocalDateTime.now());
+    }
+
+    Path newOutputPath(LocalDateTime dateTime){
+        return newOutputPath(buildRecordingName(dateTime));
+    }
+
+    private Path newOutputPath(Path recordingFile){
+        return outputDir.resolve(recordingFile);
+    }
+
+    private Path buildRecordingName(LocalDateTime dateTime) {
+        String timestamp =
+                DateTimeFormatter.ISO_DATE_TIME.format(
+                        dateTime.truncatedTo(ChronoUnit.SECONDS));
+        return Paths.get(PREFIX + "-" + timestamp + ".jfr");
+    }
+
+    /**
+     * Determines if the path represents a file that we would have recorded to.
+     */
+    public boolean matches(Path path) {
+        return outputDir.equals(path.getParent()) && filenameMatches(path);
+    }
+
+    private boolean filenameMatches(Path path) {
+        String filename = path.getFileName().toFile().getName();
+        // ISO_DATE_TIME format is like 2021-12-03T10:15:30
+        return filename.startsWith(PREFIX) && filename.matches("^" + PREFIX + "-\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.jfr$");
+    }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordingFileNamingConvention.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordingFileNamingConvention.java
@@ -1,55 +1,68 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.opentelemetry.profiler;
 
-import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
-import java.util.Date;
 
 class RecordingFileNamingConvention {
 
-    private final static String PREFIX = "otel-profiler";
-    private final Path outputDir;
+  private static final String PREFIX = "otel-profiler";
+  private final Path outputDir;
 
-    public RecordingFileNamingConvention(Path outputDir) {
-        this.outputDir = outputDir;
-    }
+  public RecordingFileNamingConvention(Path outputDir) {
+    this.outputDir = outputDir;
+  }
 
-    /**
-     * Constructs a full path for a new jfr file using the current time.
-     */
-    public Path newOutputPath(){
-        return newOutputPath(LocalDateTime.now());
-    }
+  /** Constructs a full path for a new jfr file using the current time. */
+  public Path newOutputPath() {
+    return newOutputPath(LocalDateTime.now());
+  }
 
-    Path newOutputPath(LocalDateTime dateTime){
-        return newOutputPath(buildRecordingName(dateTime));
-    }
+  Path newOutputPath(LocalDateTime dateTime) {
+    return newOutputPath(buildRecordingName(dateTime));
+  }
 
-    private Path newOutputPath(Path recordingFile){
-        return outputDir.resolve(recordingFile);
-    }
+  private Path newOutputPath(Path recordingFile) {
+    return outputDir.resolve(recordingFile);
+  }
 
-    private Path buildRecordingName(LocalDateTime dateTime) {
-        String timestamp =
-                DateTimeFormatter.ISO_DATE_TIME.format(
-                        dateTime.truncatedTo(ChronoUnit.SECONDS));
-        return Paths.get(PREFIX + "-" + timestamp + ".jfr");
-    }
+  private Path buildRecordingName(LocalDateTime dateTime) {
+    String timestamp =
+        DateTimeFormatter.ISO_DATE_TIME.format(dateTime.truncatedTo(ChronoUnit.SECONDS));
+    return Paths.get(PREFIX + "-" + timestamp + ".jfr");
+  }
 
-    /**
-     * Determines if the path represents a file that we would have recorded to.
-     */
-    public boolean matches(Path path) {
-        return outputDir.equals(path.getParent()) && filenameMatches(path);
-    }
+  /** Determines if the path represents a file that we would have recorded to. */
+  public boolean matches(Path path) {
+    return outputDir.equals(path.getParent()) && filenameMatches(path);
+  }
 
-    private boolean filenameMatches(Path path) {
-        String filename = path.getFileName().toFile().getName();
-        // ISO_DATE_TIME format is like 2021-12-03T10:15:30
-        return filename.startsWith(PREFIX) && filename.matches("^" + PREFIX + "-\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.jfr$");
-    }
+  private boolean filenameMatches(Path path) {
+    String filename = path.getFileName().toFile().getName();
+    // ISO_DATE_TIME format is like 2021-12-03T10:15:30
+    return filename.startsWith(PREFIX)
+        && filename.matches("^" + PREFIX + "-\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.jfr$");
+  }
+
+  public Path getOutputPath() {
+    return outputDir;
+  }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrRecorderTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrRecorderTest.java
@@ -121,7 +121,7 @@ class JfrRecorderTest {
         JfrRecorder.builder()
             .maxAgeDuration(maxAge)
             .settingsReader(settingsReader)
-            .outputDir(OUTDIR)
+            .namingConvention(new RecordingFileNamingConvention(OUTDIR))
             .onNewRecordingFile(onNewRecordingFile)
             .jfr(jfr);
 

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/RecordingEscapeHatchTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/RecordingEscapeHatchTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RecordingEscapeHatchTest {
+
+  public static final long PLENTY_OF_SPACE = 250 * 1024 * 1024L;
+  public static final long NOT_ENOUGH_SPACE = 29L;
+  Duration recordingDuration = Duration.ofSeconds(15);
+  Path outputPath = Paths.get("/some/output/path");
+  RecordingEscapeHatch.FilesShim filesShim;
+  RecordingFileNamingConvention convention;
+  FileStore fileStore;
+
+  @BeforeEach
+  void setup() throws Exception {
+    filesShim = mock(RecordingEscapeHatch.FilesShim.class);
+    convention = mock(RecordingFileNamingConvention.class);
+    fileStore = mock(FileStore.class);
+    when(convention.getOutputPath()).thenReturn(outputPath);
+    when(filesShim.getFileStore(outputPath)).thenReturn(fileStore);
+    when(filesShim.isRegularFile(isA(Path.class))).thenReturn(true);
+    doAnswer(
+            invocation -> {
+              Path path = invocation.getArgument(0);
+              return path.toString().matches("/path/to/file\\d+.jfr");
+            })
+        .when(convention)
+        .matches(isA(Path.class));
+  }
+
+  @Test
+  void testCanContinueHappyPath() throws Exception {
+    when(fileStore.getUsableSpace()).thenReturn(PLENTY_OF_SPACE);
+    Stream<Path> outputFiles = makeFiles(5);
+    when(filesShim.list(outputPath)).thenReturn(outputFiles);
+    RecordingEscapeHatch escapeHatch = buildEscapeHatch(false);
+    assertTrue(escapeHatch.jfrCanContinue());
+  }
+
+  @Test
+  void testTooManyFilesOnDisk() throws Exception {
+    when(fileStore.getUsableSpace()).thenReturn(PLENTY_OF_SPACE);
+    Stream<Path> outputFiles = makeFiles(5000);
+    when(filesShim.list(outputPath)).thenReturn(outputFiles);
+    boolean keepFiles = false;
+    RecordingEscapeHatch escapeHatch = buildEscapeHatch(keepFiles);
+    assertFalse(escapeHatch.jfrCanContinue());
+  }
+
+  @Test
+  void testTooManyFilesOnDiskButKeepFilesSpecified() throws Exception {
+    when(fileStore.getUsableSpace()).thenReturn(PLENTY_OF_SPACE);
+    Stream<Path> outputFiles = makeFiles(5000);
+    when(filesShim.list(outputPath)).thenReturn(outputFiles);
+    RecordingEscapeHatch escapeHatch = buildEscapeHatch(true);
+    assertTrue(escapeHatch.jfrCanContinue());
+  }
+
+  @Test
+  void testNotEnoughFreeSpace() throws Exception {
+    when(fileStore.getUsableSpace()).thenReturn(NOT_ENOUGH_SPACE);
+    Stream<Path> outputFiles = makeFiles(5);
+    when(filesShim.list(outputPath)).thenReturn(outputFiles);
+    RecordingEscapeHatch escapeHatch = buildEscapeHatch(false);
+    assertFalse(escapeHatch.jfrCanContinue());
+  }
+
+  @Test
+  void testFileStoreException() throws Exception {
+    when(fileStore.getUsableSpace()).thenReturn(PLENTY_OF_SPACE);
+    when(filesShim.list(outputPath)).thenThrow(new IOException("KABOOM"));
+    RecordingEscapeHatch escapeHatch = buildEscapeHatch(false);
+    assertFalse(escapeHatch.jfrCanContinue());
+  }
+
+  private RecordingEscapeHatch buildEscapeHatch(boolean keepFiles) {
+    return RecordingEscapeHatch.builder()
+        .recordingDuration(recordingDuration)
+        .configKeepsFilesOnDisk(keepFiles)
+        .namingConvention(convention)
+        .filesShim(filesShim)
+        .build();
+  }
+
+  private Stream<Path> makeFiles(int num) {
+    return IntStream.range(0, num).mapToObj(i -> Paths.get("/path/to/file" + i + ".jfr"));
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/RecordingFileNamingConventionTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/RecordingFileNamingConventionTest.java
@@ -1,0 +1,42 @@
+package com.splunk.opentelemetry.profiler;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.Month;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RecordingFileNamingConventionTest {
+
+    Path outputDir = Paths.get("/path/to/outdir");
+
+    @Test
+    void testNewPath() {
+        RecordingFileNamingConvention convention = new RecordingFileNamingConvention(outputDir);
+        LocalDateTime now = LocalDateTime.of(1999, Month.FEBRUARY, 12, 17, 3, 21);
+        Path expected = Paths.get("/path/to/outdir/otel-profiler-1999-02-12T17:03:21.jfr");
+
+        Path path = convention.newOutputPath(now);
+
+        assertEquals(expected, path);
+    }
+
+    @Test
+    void testMatches() {
+        RecordingFileNamingConvention convention = new RecordingFileNamingConvention(outputDir);
+        LocalDateTime now = LocalDateTime.of(1999, Month.FEBRUARY, 12, 17, 3, 21);
+        Path doesMatch = Paths.get("/path/to/outdir/otel-profiler-1999-02-12T17:03:21.jfr");
+        Path differentDir = Paths.get("/no/way/out/otel-profiler-1999-02-12T17:03:21.jfr");
+        Path badFilename = Paths.get("/path/to/outdir/tugboat-1999-02-12T17:03:21.jfr");
+
+        assertTrue(convention.matches(doesMatch));
+        assertFalse(convention.matches(differentDir));
+        assertFalse(convention.matches(badFilename));
+    }
+
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/RecordingFileNamingConventionTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/RecordingFileNamingConventionTest.java
@@ -1,42 +1,56 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.opentelemetry.profiler;
-
-import org.junit.jupiter.api.Test;
-
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.LocalDateTime;
-import java.time.Month;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.Month;
+import org.junit.jupiter.api.Test;
+
 class RecordingFileNamingConventionTest {
 
-    Path outputDir = Paths.get("/path/to/outdir");
+  Path outputDir = Paths.get("/path/to/outdir");
 
-    @Test
-    void testNewPath() {
-        RecordingFileNamingConvention convention = new RecordingFileNamingConvention(outputDir);
-        LocalDateTime now = LocalDateTime.of(1999, Month.FEBRUARY, 12, 17, 3, 21);
-        Path expected = Paths.get("/path/to/outdir/otel-profiler-1999-02-12T17:03:21.jfr");
+  @Test
+  void testNewPath() {
+    RecordingFileNamingConvention convention = new RecordingFileNamingConvention(outputDir);
+    LocalDateTime now = LocalDateTime.of(1999, Month.FEBRUARY, 12, 17, 3, 21);
+    Path expected = Paths.get("/path/to/outdir/otel-profiler-1999-02-12T17:03:21.jfr");
 
-        Path path = convention.newOutputPath(now);
+    Path path = convention.newOutputPath(now);
 
-        assertEquals(expected, path);
-    }
+    assertEquals(expected, path);
+  }
 
-    @Test
-    void testMatches() {
-        RecordingFileNamingConvention convention = new RecordingFileNamingConvention(outputDir);
-        LocalDateTime now = LocalDateTime.of(1999, Month.FEBRUARY, 12, 17, 3, 21);
-        Path doesMatch = Paths.get("/path/to/outdir/otel-profiler-1999-02-12T17:03:21.jfr");
-        Path differentDir = Paths.get("/no/way/out/otel-profiler-1999-02-12T17:03:21.jfr");
-        Path badFilename = Paths.get("/path/to/outdir/tugboat-1999-02-12T17:03:21.jfr");
+  @Test
+  void testMatches() {
+    RecordingFileNamingConvention convention = new RecordingFileNamingConvention(outputDir);
+    LocalDateTime now = LocalDateTime.of(1999, Month.FEBRUARY, 12, 17, 3, 21);
+    Path doesMatch = Paths.get("/path/to/outdir/otel-profiler-1999-02-12T17:03:21.jfr");
+    Path differentDir = Paths.get("/no/way/out/otel-profiler-1999-02-12T17:03:21.jfr");
+    Path badFilename = Paths.get("/path/to/outdir/tugboat-1999-02-12T17:03:21.jfr");
 
-        assertTrue(convention.matches(doesMatch));
-        assertFalse(convention.matches(differentDir));
-        assertFalse(convention.matches(badFilename));
-    }
-
+    assertTrue(convention.matches(doesMatch));
+    assertFalse(convention.matches(differentDir));
+    assertFalse(convention.matches(badFilename));
+  }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/RecordingSequencerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/RecordingSequencerTest.java
@@ -149,7 +149,7 @@ class RecordingSequencerTest {
               .settingsReader(mock(JfrSettingsReader.class))
               .maxAgeDuration(Duration.ofSeconds(10))
               .onNewRecordingFile(mock(Consumer.class))
-              .outputDir(Paths.get(".")));
+              .namingConvention(new RecordingFileNamingConvention(Paths.get("."))));
       this.flushLatch = flushLatch;
       started = false;
     }


### PR DESCRIPTION
The desire is to no longer record to files when the disk is low on space or if the number of files are backing up too much.  The `keep-files` configuration is considered a rare override that allows recording to continue even when files are backed up (also useful for development).