### PR TITLE
add context storage to generate jfr scope tracking events

### DIFF
--- a/profiler/build.gradle
+++ b/profiler/build.gradle
@@ -23,6 +23,9 @@ dependencies {
     implementation deps.autoservice
 
     testCompile deps.slf4j
+    testImplementation "io.opentelemetry:opentelemetry-context:${versions.opentelemetry}"
+    testImplementation "io.opentelemetry:opentelemetry-api:${versions.opentelemetry}"
+
 }
 
 shadowJar {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrContextStorage.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrContextStorage.java
@@ -37,18 +37,18 @@ class JfrContextStorage implements ContextStorage {
     this(delegate, Span::fromContext, JfrContextStorage::newEvent);
   }
 
-  static ContextAttached newEvent(SpanContext spanContext, byte direction) {
-    return new ContextAttached(spanContext.getTraceId(), spanContext.getSpanId(), direction);
-  }
-
   @VisibleForTesting
   JfrContextStorage(
-      ContextStorage delegate,
-      Function<Context, Span> spanFromContext,
-      BiFunction<SpanContext, Byte, ContextAttached> newEvent) {
+          ContextStorage delegate,
+          Function<Context, Span> spanFromContext,
+          BiFunction<SpanContext, Byte, ContextAttached> newEvent) {
     this.delegate = delegate;
     this.spanFromContext = spanFromContext;
     this.newEvent = newEvent;
+  }
+
+  static ContextAttached newEvent(SpanContext spanContext, byte direction) {
+    return new ContextAttached(spanContext.getTraceId(), spanContext.getSpanId(), direction);
   }
 
   @Override

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrContextStorage.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrContextStorage.java
@@ -39,9 +39,9 @@ class JfrContextStorage implements ContextStorage {
 
   @VisibleForTesting
   JfrContextStorage(
-          ContextStorage delegate,
-          Function<Context, Span> spanFromContext,
-          BiFunction<SpanContext, Byte, ContextAttached> newEvent) {
+      ContextStorage delegate,
+      Function<Context, Span> spanFromContext,
+      BiFunction<SpanContext, Byte, ContextAttached> newEvent) {
     this.delegate = delegate;
     this.spanFromContext = spanFromContext;
     this.newEvent = newEvent;

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrContextStorage.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrContextStorage.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.splunk.opentelemetry.profiler.events.ContextAttached;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextStorage;
+import io.opentelemetry.context.Scope;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+
+class JfrContextStorage implements ContextStorage {
+
+  private final ContextStorage delegate;
+  private final Function<Context, Span> spanFromContext;
+  private final BiFunction<SpanContext, Byte, ContextAttached> newEvent;
+
+  JfrContextStorage(ContextStorage delegate) {
+    this(delegate, Span::fromContext, JfrContextStorage::newEvent);
+  }
+
+  static ContextAttached newEvent(SpanContext spanContext, byte direction) {
+    return new ContextAttached(spanContext.getTraceId(), spanContext.getSpanId(), direction);
+  }
+
+  @VisibleForTesting
+  JfrContextStorage(
+      ContextStorage delegate,
+      Function<Context, Span> spanFromContext,
+      BiFunction<SpanContext, Byte, ContextAttached> newEvent) {
+    this.delegate = delegate;
+    this.spanFromContext = spanFromContext;
+    this.newEvent = newEvent;
+  }
+
+  @Override
+  public Scope attach(Context toAttach) {
+    Scope delegatedScope = delegate.attach(toAttach);
+    Span span = spanFromContext.apply(toAttach);
+    generateEvent(span, ContextAttached.IN);
+    return () -> {
+      generateEvent(span, ContextAttached.OUT);
+      delegatedScope.close();
+    };
+  }
+
+  private void generateEvent(Span span, byte direction) {
+    if (!span.getSpanContext().isValid()) {
+      return;
+    }
+    ContextAttached event = newEvent.apply(span.getSpanContext(), direction);
+    event.begin();
+    if (event.shouldCommit()) {
+      event.commit();
+    }
+  }
+
+  @Nullable
+  @Override
+  public Context current() {
+    return delegate.current();
+  }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/SdkCustomizer.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/SdkCustomizer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_ENABLE_PROFILER;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.context.ContextStorage;
+import io.opentelemetry.instrumentation.api.config.Config;
+import io.opentelemetry.sdk.autoconfigure.spi.SdkTracerProviderConfigurer;
+import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@AutoService(SdkTracerProviderConfigurer.class)
+public class SdkCustomizer implements SdkTracerProviderConfigurer {
+
+  private static final Logger logger = LoggerFactory.getLogger(SdkCustomizer.class);
+
+  @Override
+  public void configure(SdkTracerProviderBuilder tracerProvider) {
+    if (Config.get().getBooleanProperty(CONFIG_KEY_ENABLE_PROFILER, false)) {
+      logger.info("Enabling JfrContextStorage");
+      ContextStorage.addWrapper(JfrContextStorage::new);
+    }
+  }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/events/ContextAttached.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/events/ContextAttached.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler.events;
+
+import jdk.jfr.Category;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+
+@Name("otel.ContextAttached")
+@Label("otel context attached")
+@Category("opentelemetry")
+public class ContextAttached extends Event {
+
+  // Context is starting
+  public static final byte IN = 0;
+  // Context is ending/closing
+  public static final byte OUT = 1;
+
+  public final String traceId;
+  public final String spanId;
+  public final byte direction;
+
+  public ContextAttached(String traceId, String spanId, byte direction) {
+    this.traceId = traceId;
+    this.spanId = spanId;
+    this.direction = direction;
+  }
+
+  public String getTraceId() {
+    return traceId;
+  }
+
+  public String getSpanId() {
+    return spanId;
+  }
+
+  public byte getDirection() {
+    return direction;
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrContextStorageTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrContextStorageTest.java
@@ -96,7 +96,7 @@ class JfrContextStorageTest {
   }
 
   @Test
-  void testAttachInvalidContext() {
+  void testAttachWithInvalidContextDoesNotCreateAnyEvents() {
     BiFunction<SpanContext, Byte, ContextAttached> newEvent =
         (sc, b) -> {
           fail("Should not have attempted to create events");
@@ -114,7 +114,7 @@ class JfrContextStorageTest {
   }
 
   @Test
-  void testCurrent() {
+  void testCurrentSimplyDelegates() {
     Context expected = mock(Context.class);
     ContextStorage delegate = mock(JfrContextStorage.class);
 

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrContextStorageTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrContextStorageTest.java
@@ -122,7 +122,7 @@ class JfrContextStorageTest {
   @Test
   void testCurrentSimplyDelegates() {
     Context expected = mock(Context.class);
-    ContextStorage delegate = mock(JfrContextStorage.class);
+    ContextStorage delegate = mock(ContextStorage.class);
 
     when(delegate.current()).thenReturn(expected);
 

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrContextStorageTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrContextStorageTest.java
@@ -45,6 +45,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class JfrContextStorageTest {
 
+  String traceId;
+  String spanId;
   Span span;
   Context newContext;
   SpanContext spanContext;
@@ -53,27 +55,17 @@ class JfrContextStorageTest {
 
   @BeforeEach
   void setup() {
+    traceId = TraceId.fromLongs(123, 455);
+    spanId = SpanId.fromLong(23498);
     spanContext =
-        SpanContext.create(
-            TraceId.fromLongs(123, 455),
-            SpanId.fromLong(23498),
-            TraceFlags.getDefault(),
-            TraceState.getDefault());
+        SpanContext.create(traceId, spanId, TraceFlags.getDefault(), TraceState.getDefault());
     span = Span.wrap(spanContext);
     newContext = Context.root().with(span);
   }
 
   @Test
   void testNewEvent() {
-    String traceId = "nter108y";
-    String spanId = "abc123";
-
-    SpanContext context = mock(SpanContext.class);
-
-    when(context.getSpanId()).thenReturn(spanId);
-    when(context.getTraceId()).thenReturn(traceId);
-
-    ContextAttached result = JfrContextStorage.newEvent(context, ContextAttached.OUT);
+    ContextAttached result = JfrContextStorage.newEvent(spanContext, ContextAttached.OUT);
     assertEquals(traceId, result.getTraceId());
     assertEquals(spanId, result.getSpanId());
     assertEquals(ContextAttached.OUT, result.getDirection());

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrContextStorageTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrContextStorageTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.splunk.opentelemetry.profiler.events.ContextAttached;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextStorage;
+import io.opentelemetry.context.Scope;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class JfrContextStorageTest {
+
+  @Mock Span span;
+  @Mock ContextStorage delegate;
+  @Mock Context newContext;
+  @Mock Scope delegatedScope;
+  @Mock Function<Context, Span> spanFromContext;
+  @Mock SpanContext spanContext;
+
+  @Test
+  void testNewEvent() {
+    String traceId = "nter108y";
+    String spanId = "abc123";
+
+    SpanContext context = mock(SpanContext.class);
+
+    when(context.getSpanId()).thenReturn(spanId);
+    when(context.getTraceId()).thenReturn(traceId);
+
+    ContextAttached result = JfrContextStorage.newEvent(context, ContextAttached.OUT);
+    assertEquals(traceId, result.getTraceId());
+    assertEquals(spanId, result.getSpanId());
+    assertEquals(ContextAttached.OUT, result.getDirection());
+  }
+
+  @Test
+  void testAttachLifecycle() {
+    ContextAttached inEvent = mock(ContextAttached.class);
+    ContextAttached outEvent = mock(ContextAttached.class);
+    BiFunction<SpanContext, Byte, ContextAttached> newEvent = mock(BiFunction.class);
+
+    when(delegate.attach(newContext)).thenReturn(delegatedScope);
+    when(spanFromContext.apply(newContext)).thenReturn(span);
+    when(span.getSpanContext()).thenReturn(spanContext);
+    when(spanContext.isValid()).thenReturn(true);
+    when(inEvent.shouldCommit()).thenReturn(true);
+    when(outEvent.shouldCommit()).thenReturn(true);
+    when(newEvent.apply(spanContext, ContextAttached.IN)).thenReturn(inEvent);
+    when(newEvent.apply(spanContext, ContextAttached.OUT)).thenReturn(outEvent);
+
+    JfrContextStorage contextStorage = new JfrContextStorage(delegate, spanFromContext, newEvent);
+
+    Scope resultScope = contextStorage.attach(newContext);
+    verify(inEvent).begin();
+    verify(inEvent).commit();
+    verify(newEvent, never()).apply(isA(SpanContext.class), eq(ContextAttached.OUT));
+    verify(outEvent, never()).begin();
+    verify(outEvent, never()).commit();
+    verify(delegatedScope, never()).close();
+
+    resultScope.close();
+    verify(outEvent).begin();
+    verify(outEvent).commit();
+    verify(delegatedScope).close();
+  }
+
+  @Test
+  void testAttachInvalidContext() {
+    BiFunction<SpanContext, Byte, ContextAttached> newEvent =
+        (sc, b) -> {
+          fail("Should not have attempted to create events");
+          throw new RuntimeException("boom");
+        };
+
+    when(delegate.attach(newContext)).thenReturn(delegatedScope);
+    when(spanFromContext.apply(newContext)).thenReturn(span);
+    when(span.getSpanContext()).thenReturn(spanContext);
+    when(spanContext.isValid()).thenReturn(false);
+
+    JfrContextStorage contextStorage = new JfrContextStorage(delegate, spanFromContext, newEvent);
+
+    contextStorage.attach(newContext);
+  }
+
+  @Test
+  void testCurrent() {
+    Context expected = mock(Context.class);
+    ContextStorage delegate = mock(JfrContextStorage.class);
+
+    when(delegate.current()).thenReturn(expected);
+
+    JfrContextStorage contextStorage = new JfrContextStorage(delegate);
+    Context result = contextStorage.current();
+    assertEquals(expected, result);
+  }
+}


### PR DESCRIPTION
If the profiler is enabled, we configure the SDK with a context storage that will generate custom JFR events for scope start/stops.  This allows us to later associate stack with spans.