### PR TITLE
Ensure that the file is closed at stream end

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/BasicJfrRecordingFile.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/BasicJfrRecordingFile.java
@@ -42,24 +42,26 @@ class BasicJfrRecordingFile implements RecordedEventStream {
   public Stream<RecordedEvent> open(Path path) {
     RecordingFile file = jfr.openRecordingFile(path);
     return StreamSupport.stream(
-        new Spliterators.AbstractSpliterator<RecordedEvent>(Long.MAX_VALUE, Spliterator.ORDERED) {
-          public boolean tryAdvance(Consumer<? super RecordedEvent> action) {
-            if (file.hasMoreEvents()) {
-              action.accept(jfr.readEvent(file, path));
-              return true;
-            }
-            closeSafely(file);
-            return false;
-          }
+            new Spliterators.AbstractSpliterator<RecordedEvent>(
+                Long.MAX_VALUE, Spliterator.ORDERED) {
+              public boolean tryAdvance(Consumer<? super RecordedEvent> action) {
+                if (file.hasMoreEvents()) {
+                  action.accept(jfr.readEvent(file, path));
+                  return true;
+                }
+                closeSafely(file);
+                return false;
+              }
 
-          public void forEachRemaining(Consumer<? super RecordedEvent> action) {
-            while (file.hasMoreEvents()) {
-              action.accept(jfr.readEvent(file, path));
-            }
-            closeSafely(file);
-          }
-        },
-        false);
+              public void forEachRemaining(Consumer<? super RecordedEvent> action) {
+                while (file.hasMoreEvents()) {
+                  action.accept(jfr.readEvent(file, path));
+                }
+                closeSafely(file);
+              }
+            },
+            false)
+        .onClose(() -> closeSafely(file));
   }
 
   private void closeSafely(RecordingFile file) {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrPathHandler.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrPathHandler.java
@@ -45,8 +45,9 @@ class JfrPathHandler implements Consumer<Path> {
   public void accept(Path path) {
     logger.info("New jfr file detected: {}", path);
     RecordedEventStream recordingFile = recordedEventStreamFactory.get();
-    Stream<RecordedEvent> events = recordingFile.open(path);
-    events.forEach(event -> eventProcessingChain.accept(path, event));
+    try (Stream<RecordedEvent> events = recordingFile.open(path)) {
+      events.forEach(event -> eventProcessingChain.accept(path, event));
+    }
     onFileFinished.accept(path);
   }
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordedEventStream.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordedEventStream.java
@@ -23,6 +23,15 @@ import jdk.jfr.consumer.RecordedEvent;
 
 /** Tag interface for turning a file path into a stream of JFR RecordedEvent instances. */
 interface RecordedEventStream {
+
+  /**
+   * Opens a path to a jfr recording file and turns it into a stream of RecordedEvents from that
+   * file. It is the callers responsibility to call close() on the stream when finished, and failing
+   * to do so might result in resources being leaked or held open.
+   *
+   * @param path - path to a jfr recording file
+   * @return Stream of all RecordedEvents from the given file
+   */
   Stream<RecordedEvent> open(Path path);
 
   interface Factory extends Supplier<RecordedEventStream> {}


### PR DESCRIPTION
Could possibly have been holding open resources.  Not sure how this could impact the file deletion, but on some platforms maybe this could be a problem and it just seems better to close it.