### PR TITLE
Filter and sort event stream

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/FilterSortedRecordingFile.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/FilterSortedRecordingFile.java
@@ -26,11 +26,11 @@ import jdk.jfr.consumer.RecordedEvent;
  * Limits a delegate stream to just the events that we care about and returns them sorted by start
  * time.
  */
-public class FilterSortedRecordingFile implements RecordedEventStream {
+class FilterSortedRecordingFile implements RecordedEventStream {
 
   private final RecordedEventStream.Factory delegateStreamFactory;
 
-  public FilterSortedRecordingFile(RecordedEventStream.Factory delegateStreamFactory) {
+  FilterSortedRecordingFile(RecordedEventStream.Factory delegateStreamFactory) {
     this.delegateStreamFactory = delegateStreamFactory;
   }
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/FilterSortedRecordingFile.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/FilterSortedRecordingFile.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import com.splunk.opentelemetry.profiler.events.RelevantEvents;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.stream.Stream;
+import jdk.jfr.consumer.RecordedEvent;
+
+/**
+ * Limits a delegate stream to just the events that we care about and returns them sorted by start
+ * time.
+ */
+public class FilterSortedRecordingFile implements RecordedEventStream {
+
+  private final RecordedEventStream.Factory delegateStreamFactory;
+
+  public FilterSortedRecordingFile(RecordedEventStream.Factory delegateStreamFactory) {
+    this.delegateStreamFactory = delegateStreamFactory;
+  }
+
+  @Override
+  public Stream<RecordedEvent> open(Path path) {
+    return delegateStreamFactory
+        .get()
+        .open(path)
+        .filter(event -> RelevantEvents.EVENT_NAMES.contains(event.getEventType().getName()))
+        .sorted(Comparator.comparing(RecordedEvent::getStartTime));
+  }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
@@ -67,7 +67,7 @@ public class JfrActivator implements ComponentInstaller {
     Path outputDir = Paths.get(config.getProperty(CONFIG_KEY_PROFILER_DIRECTORY, "."));
 
     RecordedEventStream.Factory recordedEventStreamFactory =
-        () -> new BasicJfrRecordingFile(JFR.instance);
+        () -> new FilterSortedRecordingFile(() -> new BasicJfrRecordingFile(JFR.instance));
     EventProcessingChain eventProcessingChain = new EventProcessingChain();
     Consumer<Path> deleter = buildFileDeleter(config);
     JfrDirCleanup dirCleanup = new JfrDirCleanup(deleter);

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/events/RelevantEvents.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/events/RelevantEvents.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler.events;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class RelevantEvents {
+  public static Set<String> EVENT_NAMES =
+      Collections.unmodifiableSet(
+          new HashSet<>(Arrays.asList("jdk.ThreadDump", "otel.ContextAttached")));
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/FilterSortedRecordingFileTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/FilterSortedRecordingFileTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import jdk.jfr.EventType;
+import jdk.jfr.consumer.RecordedEvent;
+import org.junit.jupiter.api.Test;
+
+class FilterSortedRecordingFileTest {
+
+  @Test
+  void testFiltersort() {
+    Path path = Paths.get("/path/to/file.jfr");
+    Instant now = Instant.now();
+    RecordedEvent event1 = makeEvent("jdk.ThreadDump", now.plus(Duration.ofSeconds(1)));
+    RecordedEvent event2 = makeEvent("jdk.DoNotCareX", now.plus(Duration.ofSeconds(2)));
+    RecordedEvent event3 = makeEvent("otel.ContextAttached", now.plus(Duration.ofSeconds(3)));
+    RecordedEvent event4 = makeEvent("jdk.ThreadDump", now.plus(Duration.ofSeconds(4)));
+    RecordedEvent event5 = makeEvent("otel.ContextAttached", now.plus(Duration.ofSeconds(5)));
+    Stream<RecordedEvent> str = Stream.of(event5, event1, event4, event3, event2);
+    List<RecordedEvent> expected = Arrays.asList(event1, event3, event4, event5);
+
+    RecordedEventStream delegate = mock(RecordedEventStream.class);
+    when(delegate.open(path)).thenReturn(str);
+    RecordedEventStream.Factory delegateFactory = () -> delegate;
+    FilterSortedRecordingFile recordingFile = new FilterSortedRecordingFile(delegateFactory);
+    List<RecordedEvent> result = recordingFile.open(path).collect(Collectors.toList());
+    assertEquals(expected, result);
+  }
+
+  private RecordedEvent makeEvent(String name, Instant startTime) {
+    RecordedEvent event = mock(RecordedEvent.class);
+    EventType eventType = mock(EventType.class);
+    when(event.getEventType()).thenReturn(eventType);
+    when(eventType.getName()).thenReturn(name);
+    when(event.getStartTime()).thenReturn(startTime);
+    return event;
+  }
+}


### PR DESCRIPTION
JFR does not guarantee that events are time sorted.  In order to detect that a thread for a given stack frame was working as part of a span (and to link the two) we need to sort.