### PR TITLE
Track span thread context and link stacks

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/EventProcessingChain.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/EventProcessingChain.java
@@ -16,12 +16,30 @@
 
 package com.splunk.opentelemetry.profiler;
 
-import java.nio.file.Path;
+import com.splunk.opentelemetry.profiler.context.SpanContextualizer;
+import com.splunk.opentelemetry.profiler.events.ContextAttached;
 import jdk.jfr.consumer.RecordedEvent;
 
 class EventProcessingChain {
 
-  public void accept(Path path, RecordedEvent event) {
-    // NO-OP for now....
+  private final SpanContextualizer spanContextualizer;
+  private final ThreadDumpProcessor threadDumpProcessor;
+
+  EventProcessingChain(
+      SpanContextualizer spanContextualizer, ThreadDumpProcessor threadDumpProcessor) {
+    this.spanContextualizer = spanContextualizer;
+    this.threadDumpProcessor = threadDumpProcessor;
+  }
+
+  void accept(RecordedEvent event) {
+    String eventName = event.getEventType().getName();
+    switch (eventName) {
+      case ContextAttached.EVENT_NAME:
+        spanContextualizer.updateContext(event);
+        break;
+      case "jdk.ThreadDump":
+        threadDumpProcessor.accept(event);
+        break;
+    }
   }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/EventProcessingChain.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/EventProcessingChain.java
@@ -37,7 +37,7 @@ class EventProcessingChain {
       case ContextAttached.EVENT_NAME:
         spanContextualizer.updateContext(event);
         break;
-      case "jdk.ThreadDump":
+      case ThreadDumpProcessor.EVENT_NAME:
         threadDumpProcessor.accept(event);
         break;
     }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrPathHandler.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrPathHandler.java
@@ -46,7 +46,7 @@ class JfrPathHandler implements Consumer<Path> {
     logger.info("New jfr file detected: {}", path);
     RecordedEventStream recordingFile = recordedEventStreamFactory.get();
     try (Stream<RecordedEvent> events = recordingFile.open(path)) {
-      events.forEach(event -> eventProcessingChain.accept(path, event));
+      events.forEach(eventProcessingChain::accept);
     }
     onFileFinished.accept(path);
   }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/ThreadDumpProcessor.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/ThreadDumpProcessor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import com.splunk.opentelemetry.profiler.context.SpanContextualizer;
+import com.splunk.opentelemetry.profiler.context.StackToSpanLinkage;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import jdk.jfr.consumer.RecordedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ThreadDumpProcessor {
+  public static final String EVENT_NAME = "jdk.ThreadDump";
+  private static final Logger logger = LoggerFactory.getLogger(ThreadDumpProcessor.class);
+  private final Pattern stackSeparator = Pattern.compile("\n\n");
+  private final SpanContextualizer contextualizer;
+
+  public ThreadDumpProcessor(SpanContextualizer contextualizer) {
+    this.contextualizer = contextualizer;
+  }
+
+  public void accept(RecordedEvent event) {
+    String eventName = event.getEventType().getName();
+    logger.debug("Processing JFR event {}", eventName);
+    String wallOfStacks = event.getString("result");
+    String[] stacks = stackSeparator.split(wallOfStacks);
+    // TODO: Filter out all the VM and GC entries without real stack traces?
+    Stream.of(stacks)
+        .filter(stack -> stack.charAt(0) == '"') // omit non-stack entries
+        .map(contextualizer::link)
+        .forEach(this::export);
+  }
+
+  void export(StackToSpanLinkage linkedStack) {
+    // NOP - placeholder for now
+  }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/SpanContextualizer.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/SpanContextualizer.java
@@ -74,13 +74,13 @@ public class SpanContextualizer {
 
     // This thread has a span happening, augment with span details
     if (inFlightSpansForThisThread.size() > 1) {
-      logger.warn("!! Nested spans detected: We will only use the last span for now...");
-      logger.info(
+      logger.debug("!! Nested spans detected: We will only use the last span for now...");
+      logger.debug(
           "trace for thread -> {}",
           inFlightSpansForThisThread.stream()
               .map(SpanLinkage::getTraceId)
               .collect(Collectors.joining(" ")));
-      logger.info(
+      logger.debug(
           "spans for thread -> {}",
           inFlightSpansForThisThread.stream()
               .map(SpanLinkage::getSpanId)

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/SpanContextualizer.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/SpanContextualizer.java
@@ -65,7 +65,7 @@ public class SpanContextualizer {
   /** Links the raw stack with the span info for the given thread. */
   StackToSpanLinkage link(String rawStack, long threadId) {
     List<SpanLinkage> inFlightSpansForThisThread =
-        threadContextTracker.getInfLightSpansForThread(threadId);
+        threadContextTracker.getInFlightSpansForThread(threadId);
 
     if (inFlightSpansForThisThread.isEmpty()) {
       // We don't know about any in-flight spans for this stack
@@ -76,7 +76,7 @@ public class SpanContextualizer {
     if (inFlightSpansForThisThread.size() > 1) {
       logger.debug("!! Nested spans detected: We will only use the last span for now...");
       logger.debug(
-          "trace for thread -> {}",
+          "traceIds for thread -> {}",
           inFlightSpansForThisThread.stream()
               .map(SpanLinkage::getTraceId)
               .collect(Collectors.joining(" ")));
@@ -90,6 +90,10 @@ public class SpanContextualizer {
     return new StackToSpanLinkage(rawStack, spanLinkage);
   }
 
+  /**
+   * The first line is a meta/descriptor that has information about the following call stack. This
+   * method parses out the thread id, which is the second field (space separated).
+   */
   private long parseThreadIdFromDescriptor(String descriptorLine) {
     int secondQuote = descriptorLine.indexOf('"', 1);
     int firstSpaceAfterSecondQuote = secondQuote + 1;

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/SpanContextualizer.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/SpanContextualizer.java
@@ -41,7 +41,8 @@ public class SpanContextualizer {
   private final StackDescriptorLineParser descriptorParser = new StackDescriptorLineParser();
 
   /**
-   * This updates the tracked context for a This must only be called with ContextAttached events.
+   * This updates the tracked thread context for a given span. This must only be called with
+   * ContextAttached events.
    */
   public void updateContext(RecordedEvent event) {
     if (event.getByte("direction") == ContextAttached.IN) {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/SpanContextualizer.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/SpanContextualizer.java
@@ -77,7 +77,7 @@ public class SpanContextualizer {
     }
 
     // This thread has a span happening, augment with span details
-    if (inFlightSpansForThisThread.size() > 1) {
+    if ((inFlightSpansForThisThread.size() > 1) && logger.isDebugEnabled()) {
       logger.debug("!! Nested spans detected: We will only use the last span for now...");
       logger.debug(
           "traceIds for thread -> {}",

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/SpanContextualizer.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/SpanContextualizer.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler.context;
+
+import com.splunk.opentelemetry.profiler.events.ContextAttached;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedThread;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Keeps track of span scope changes and, when applicable, can wrap the RecordedEvent with span
+ * context information. This class is not thread safe.
+ */
+public class SpanContextualizer {
+
+  private static final Logger logger = LoggerFactory.getLogger(SpanContextualizer.class);
+  private final long CANT_PARSE_THREAD_ID = Long.MIN_VALUE;
+  private final Pattern lineSplitter = Pattern.compile("\n");
+  private final ThreadContextTracker threadContextTracker = new ThreadContextTracker();
+
+  /**
+   * This updates the tracked context for a This must only be called with ContextAttached events.
+   */
+  public void updateContext(RecordedEvent event) {
+    if (event.getByte("direction") == ContextAttached.IN) {
+      threadContextStarting(event);
+    } else {
+      threadContextEnding(event);
+    }
+  }
+
+  /** Parses thread info from the raw stack string and links it to a span (if available). */
+  public StackToSpanLinkage link(String rawStack) {
+    List<String> frames = Arrays.asList(lineSplitter.split(rawStack));
+    if (frames.size() < 2) {
+      // Many GC and other VM threads don't actually have a stack...
+      return StackToSpanLinkage.withoutLinkage(rawStack);
+    }
+    long threadId = parseThreadIdFromDescriptor(frames.get(0));
+    if (threadId == CANT_PARSE_THREAD_ID) {
+      return StackToSpanLinkage.withoutLinkage(rawStack);
+    }
+    return link(rawStack, threadId);
+  }
+
+  /** Links the raw stack with the span info for the given thread. */
+  StackToSpanLinkage link(String rawStack, long threadId) {
+    List<SpanLinkage> inFlightSpansForThisThread =
+        threadContextTracker.getInfLightSpansForThread(threadId);
+
+    if (inFlightSpansForThisThread.isEmpty()) {
+      // We don't know about any in-flight spans for this stack
+      return StackToSpanLinkage.withoutLinkage(rawStack);
+    }
+
+    // This thread has a span happening, augment with span details
+    if (inFlightSpansForThisThread.size() > 1) {
+      logger.warn("!! Nested spans detected: We will only use the last span for now...");
+      logger.info(
+          "trace for thread -> {}",
+          inFlightSpansForThisThread.stream()
+              .map(SpanLinkage::getTraceId)
+              .collect(Collectors.joining(" ")));
+      logger.info(
+          "spans for thread -> {}",
+          inFlightSpansForThisThread.stream()
+              .map(SpanLinkage::getSpanId)
+              .collect(Collectors.joining(" ")));
+    }
+    SpanLinkage spanLinkage = inFlightSpansForThisThread.get(inFlightSpansForThisThread.size() - 1);
+    return new StackToSpanLinkage(rawStack, spanLinkage);
+  }
+
+  private long parseThreadIdFromDescriptor(String descriptorLine) {
+    int secondQuote = descriptorLine.indexOf('"', 1);
+    int firstSpaceAfterSecondQuote = secondQuote + 1;
+    if (descriptorLine.charAt(firstSpaceAfterSecondQuote + 1) != '#') {
+      // Unexpected format, fail to parse
+      return CANT_PARSE_THREAD_ID;
+    }
+    int secondSpace = descriptorLine.indexOf(' ', firstSpaceAfterSecondQuote + 1);
+    return Long.parseLong(descriptorLine.substring(firstSpaceAfterSecondQuote + 2, secondSpace));
+  }
+
+  private void threadContextStarting(RecordedEvent event) {
+    String spanId = event.getString("spanId");
+    String traceId = event.getString("traceId");
+    RecordedThread thread = event.getThread();
+    long threadId = thread.getJavaThreadId();
+    logger.debug(
+        "SPAN THREAD CONTEXT START : [{}] {} {} at {}",
+        threadId,
+        traceId,
+        spanId,
+        event.getStartTime());
+
+    SpanLinkage linkage = new SpanLinkage(spanId, traceId, thread);
+
+    threadContextTracker.addLinkage(linkage);
+  }
+
+  private void threadContextEnding(RecordedEvent event) {
+    String spanId = event.getString("spanId");
+    String traceId = event.getString("traceId");
+    long threadId = event.getThread().getJavaThreadId();
+    logger.debug(
+        "SPAN THREAD CONTEXT END : [{}] {} {} at {}",
+        threadId,
+        traceId,
+        spanId,
+        event.getStartTime());
+
+    threadContextTracker.unlink(traceId, spanId, threadId);
+  }
+
+  // Exists for testing
+  int inFlightThreadCount() {
+    return threadContextTracker.getNumberOfInFlightThreads();
+  }
+
+  // Exists for testing
+  int inFlightSpanCount() {
+    return threadContextTracker.getNumberOfInFlightSpans();
+  }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/SpanLinkage.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/SpanLinkage.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler.context;
+
+import jdk.jfr.consumer.RecordedThread;
+
+class SpanLinkage {
+
+  static final SpanLinkage NONE = new SpanLinkage(null, null, null);
+
+  private final String spanId;
+  private final String traceId;
+  private final RecordedThread recordedThread;
+
+  SpanLinkage(String spanId, String traceId, RecordedThread recordedThread) {
+    this.spanId = spanId;
+    this.traceId = traceId;
+    this.recordedThread = recordedThread;
+  }
+
+  String getSpanId() {
+    return spanId;
+  }
+
+  String getTraceId() {
+    return traceId;
+  }
+
+  RecordedThread getRecordedThread() {
+    return recordedThread;
+  }
+
+  Long getThreadId() {
+    return recordedThread.getJavaThreadId();
+  }
+
+  boolean matches(String traceId, String spanId) {
+    return this.traceId != null
+        && this.traceId.equals(traceId)
+        && this.spanId != null
+        && this.spanId.equals(spanId);
+  }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/StackDescriptorLineParser.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/StackDescriptorLineParser.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler.context;
+
+/**
+ * Class that parses the "descriptor" line from a stack trace. At the moment, it only parses out the
+ * thread ID.
+ */
+class StackDescriptorLineParser {
+
+  static final long CANT_PARSE_THREAD_ID = Long.MIN_VALUE;
+
+  /**
+   * The first line is a meta/descriptor that has information about the following call stack. This
+   * method parses out the thread id, which is the second field (space separated).
+   */
+  long parseThreadId(String descriptorLine) {
+    // Require a quoted thread name field at the start
+    if (descriptorLine.charAt(0) != '"') {
+      return CANT_PARSE_THREAD_ID;
+    }
+    int secondQuote = descriptorLine.indexOf('"', 1);
+    if (secondQuote == -1) {
+      return CANT_PARSE_THREAD_ID;
+    }
+    int firstSpaceAfterSecondQuote = secondQuote + 1;
+    if (firstSpaceAfterSecondQuote >= descriptorLine.length() - 2
+        || descriptorLine.charAt(firstSpaceAfterSecondQuote) != ' ') {
+      return CANT_PARSE_THREAD_ID;
+    }
+    if (descriptorLine.charAt(firstSpaceAfterSecondQuote + 1) != '#') {
+      // Unexpected format, fail to parse
+      return CANT_PARSE_THREAD_ID;
+    }
+    int secondSpace = descriptorLine.indexOf(' ', firstSpaceAfterSecondQuote + 1);
+    if (secondSpace == -1) {
+      return CANT_PARSE_THREAD_ID;
+    }
+    try {
+      return Long.parseLong(descriptorLine.substring(firstSpaceAfterSecondQuote + 2, secondSpace));
+    } catch (NumberFormatException e) {
+      return CANT_PARSE_THREAD_ID;
+    }
+  }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/StackToSpanLinkage.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/StackToSpanLinkage.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler.context;
+
+import jdk.jfr.consumer.RecordedThread;
+
+/** A wrapper for a RecordedEvent that may or may not have accompanying span information. */
+public class StackToSpanLinkage {
+  private final String rawStack;
+  private final SpanLinkage spanLinkage;
+
+  StackToSpanLinkage(String rawStack, SpanLinkage spanLinkage) {
+    this.rawStack = rawStack;
+    this.spanLinkage = spanLinkage;
+  }
+
+  public boolean hasSpanInfo() {
+    return getSpanId() != null;
+  }
+
+  public String getRawStack() {
+    return rawStack;
+  }
+
+  public String getTraceId() {
+    return spanLinkage.getTraceId();
+  }
+
+  public String getSpanId() {
+    return spanLinkage.getSpanId();
+  }
+
+  public RecordedThread getSpanStartThread() {
+    return spanLinkage.getRecordedThread();
+  }
+
+  static StackToSpanLinkage withoutLinkage(String rawStack) {
+    return new StackToSpanLinkage(rawStack, SpanLinkage.NONE);
+  }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/ThreadContextTracker.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/ThreadContextTracker.java
@@ -62,15 +62,15 @@ class ThreadContextTracker {
     Stack<SpanLinkage> inFlightForThread = inFlightSpansByThreadId.get(threadId);
     if (inFlightForThread == null) {
       // No spans in flight for this thread....shouldn't happen
-      logger.warn("No spans in flight for thread {}", threadId);
+      logger.debug("!!! No spans in flight for thread {}", threadId);
       return;
     }
     SpanLinkage spanInfo = findLinkage(inFlightForThread, traceId, spanId);
     if (spanInfo == null || !inFlightForThread.remove(spanInfo)) {
       // We arrived in a bad state where we can't find our span info to remove from our tracked
       // "in-flight" spans.
-      logger.warn("!!!! Could not find our started span! trace = {} span = {}", traceId, spanId);
-      logger.warn("!!!! tried to find thread {} => {} {}", threadId, traceId, spanId);
+      logger.debug("!!! Could not find our started span! trace = {} span = {}", traceId, spanId);
+      logger.debug("!!! tried to find thread {} => {} {}", threadId, traceId, spanId);
     }
     if (inFlightForThread.isEmpty()) {
       inFlightSpansByThreadId.remove(threadId);

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/ThreadContextTracker.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/ThreadContextTracker.java
@@ -32,7 +32,7 @@ class ThreadContextTracker {
   private final Map<Long, Stack<SpanLinkage>> inFlightSpansByThreadId = new HashMap<>();
   private final Map<String, Stack<Long>> inFlightSpansToThreadId = new HashMap<>();
 
-  List<SpanLinkage> getInfLightSpansForThread(long threadId) {
+  List<SpanLinkage> getInFlightSpansForThread(long threadId) {
     Stack<SpanLinkage> result = inFlightSpansByThreadId.get(threadId);
     return result == null ? Collections.emptyList() : result;
   }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/ThreadContextTracker.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/ThreadContextTracker.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler.context;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Keeps track of what threads are working on which spans when replaying an event stream. */
+class ThreadContextTracker {
+
+  private static final Logger logger = LoggerFactory.getLogger(ThreadContextTracker.class);
+
+  private final Map<Long, Stack<SpanLinkage>> inFlightSpansByThreadId = new HashMap<>();
+  private final Map<String, Stack<Long>> inFlightSpansToThreadId = new HashMap<>();
+
+  List<SpanLinkage> getInfLightSpansForThread(long threadId) {
+    Stack<SpanLinkage> result = inFlightSpansByThreadId.get(threadId);
+    return result == null ? Collections.emptyList() : result;
+  }
+
+  void addLinkage(SpanLinkage linkage) {
+    Stack<SpanLinkage> spanLinkages =
+        inFlightSpansByThreadId.computeIfAbsent(linkage.getThreadId(), tid -> new Stack<>());
+    spanLinkages.push(linkage);
+
+    Stack<Long> threadIds =
+        inFlightSpansToThreadId.computeIfAbsent(linkage.getSpanId(), sid -> new Stack<>());
+    threadIds.push(linkage.getThreadId());
+  }
+
+  void unlink(String traceId, String spanId, long threadId) {
+    Stack<Long> spanThreadStack = inFlightSpansToThreadId.get(spanId);
+    if (spanThreadStack != null) {
+      spanThreadStack.remove(threadId);
+      if (spanThreadStack.isEmpty()) {
+        inFlightSpansToThreadId.remove(spanId);
+      }
+    }
+    removeFromInFlight(threadId, spanId, traceId);
+  }
+
+  private void removeFromInFlight(long threadId, String spanId, String traceId) {
+    Stack<SpanLinkage> inFlightForThread = inFlightSpansByThreadId.get(threadId);
+    if (inFlightForThread == null) {
+      // No spans in flight for this thread....shouldn't happen
+      logger.warn("No spans in flight for thread {}", threadId);
+      return;
+    }
+    SpanLinkage spanInfo = findLinkage(inFlightForThread, traceId, spanId);
+    if (spanInfo == null || !inFlightForThread.remove(spanInfo)) {
+      // We arrived in a bad state where we can't find our span info to remove from our tracked
+      // "in-flight" spans.
+      logger.warn("!!!! Could not find our started span! trace = {} span = {}", traceId, spanId);
+      logger.warn("!!!! tried to find thread {} => {} {}", threadId, traceId, spanId);
+    }
+    if (inFlightForThread.isEmpty()) {
+      inFlightSpansByThreadId.remove(threadId);
+    }
+  }
+
+  // TODO: This is inefficient and we might want to have an additional structure/map for doing a
+  // fast lookup rather than iterating
+  private SpanLinkage findLinkage(
+      List<SpanLinkage> inFlightForThread, String traceId, String spanId) {
+    return inFlightForThread.stream()
+        .filter(s -> s.matches(traceId, spanId))
+        .findFirst()
+        .orElse(null);
+  }
+
+  public int getNumberOfInFlightThreads() {
+    return inFlightSpansByThreadId.size();
+  }
+
+  public int getNumberOfInFlightSpans() {
+    return inFlightSpansToThreadId.size();
+  }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/events/ContextAttached.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/events/ContextAttached.java
@@ -16,16 +16,19 @@
 
 package com.splunk.opentelemetry.profiler.events;
 
+import static com.splunk.opentelemetry.profiler.events.ContextAttached.EVENT_NAME;
+
 import jdk.jfr.Category;
 import jdk.jfr.Event;
 import jdk.jfr.Label;
 import jdk.jfr.Name;
 
-@Name("otel.ContextAttached")
+@Name(EVENT_NAME)
 @Label("otel context attached")
 @Category("opentelemetry")
 public class ContextAttached extends Event {
 
+  public static final String EVENT_NAME = "otel.ContextAttached";
   // Context is starting
   public static final byte IN = 0;
   // Context is ending/closing

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/events/RelevantEvents.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/events/RelevantEvents.java
@@ -16,6 +16,7 @@
 
 package com.splunk.opentelemetry.profiler.events;
 
+import com.splunk.opentelemetry.profiler.ThreadDumpProcessor;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -24,5 +25,5 @@ import java.util.Set;
 public class RelevantEvents {
   public static Set<String> EVENT_NAMES =
       Collections.unmodifiableSet(
-          new HashSet<>(Arrays.asList("jdk.ThreadDump", "otel.ContextAttached")));
+          new HashSet<>(Arrays.asList(ThreadDumpProcessor.EVENT_NAME, ContextAttached.EVENT_NAME)));
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrPathHandlerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrPathHandlerTest.java
@@ -58,9 +58,9 @@ class JfrPathHandlerTest {
 
     jfrPathHandler.accept(path);
 
-    verify(chain).accept(path, e1);
-    verify(chain).accept(path, e2);
-    verify(chain).accept(path, e3);
+    verify(chain).accept(e1);
+    verify(chain).accept(e2);
+    verify(chain).accept(e3);
     verifyNoMoreInteractions(chain);
     verify(onFileFinished).accept(path);
     assertTrue(closeWasCalled.get());

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ThreadDumpProcessorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ThreadDumpProcessorTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.splunk.opentelemetry.profiler.context.SpanContextualizer;
+import com.splunk.opentelemetry.profiler.context.StackToSpanLinkage;
+import com.splunk.opentelemetry.profiler.events.ContextAttached;
+import java.util.ArrayList;
+import java.util.List;
+import jdk.jfr.EventType;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedThread;
+import org.junit.jupiter.api.Test;
+
+class ThreadDumpProcessorTest {
+
+  @Test
+  void testProcessEvent() {
+    String traceId = "abc123";
+    String spanId = "xxxxxxyyyyyyyzyzzz";
+    SpanContextualizer contextualizer = new SpanContextualizer();
+
+    RecordedEvent event = mock(RecordedEvent.class);
+    RecordedEvent threadStartingSpan = mock(RecordedEvent.class);
+    RecordedThread threadRunningSpan = mock(RecordedThread.class);
+
+    when(threadStartingSpan.getByte("direction")).thenReturn(ContextAttached.IN);
+    when(threadStartingSpan.getString("traceId")).thenReturn(traceId);
+    when(threadStartingSpan.getString("spanId")).thenReturn(spanId);
+    when(threadStartingSpan.getThread()).thenReturn(threadRunningSpan);
+    when(threadRunningSpan.getJavaThreadId()).thenReturn(3L);
+
+    contextualizer.updateContext(threadStartingSpan);
+    EventType eventType = mock(EventType.class);
+    when(event.getEventType()).thenReturn(eventType);
+    when(eventType.getName()).thenReturn(ThreadDumpProcessor.EVENT_NAME);
+    when(event.getString("result")).thenReturn(WALL_OF_STACKS);
+
+    List<StackToSpanLinkage> results = new ArrayList<>();
+    ThreadDumpProcessor processor =
+        new ThreadDumpProcessor(contextualizer) {
+          @Override
+          void export(StackToSpanLinkage linkedStack) {
+            results.add(linkedStack);
+          }
+        };
+
+    processor.accept(event);
+    assertEquals(3, results.size());
+
+    assertFalse(results.get(0).hasSpanInfo());
+    assertTrue(
+        results.get(0).getRawStack().contains("at java.lang.ref.Reference$ReferenceHandler"));
+
+    assertTrue(results.get(1).hasSpanInfo());
+    assertEquals(spanId, results.get(1).getSpanId());
+    assertEquals(traceId, results.get(1).getTraceId());
+    assertEquals(threadRunningSpan, results.get(1).getSpanStartThread());
+    assertTrue(results.get(1).getRawStack().contains("AwesomeThinger.overHereDoingSpanThings"));
+
+    assertFalse(results.get(2).hasSpanInfo());
+    assertTrue(results.get(2).getRawStack().contains("0x0000000625152778"));
+  }
+
+  static final String WALL_OF_STACKS =
+      "2021-06-07 16:02:56\n"
+          + "Full thread dump OpenJDK 64-Bit Server VM (11.0.9.1+1 mixed mode):\n"
+          + "\n"
+          + "Threads class SMR info:\n"
+          + "_java_thread_list=0x00007fb484055190, length=55, elements={\n"
+          + "0x00007fb51702b000, 0x00007fb517030000, 0x00007fb507828000, 0x00007fb50701d800,\n"
+          + "(truncated)\n"
+          + "0x00007fb486067000, 0x00007fb517031000, 0x00007fb507547800, 0x00007fb4918f3000,\n"
+          + "0x00007fb4860b5000, 0x00007fb491817800, 0x00007fb4859f4800\n"
+          + "}\n"
+          + "\n"
+          + "\"Reference Handler\" #2 daemon prio=10 os_prio=31 cpu=4.92ms elapsed=50.48s tid=0x00007fb51702b000 nid=0x3403 waiting on condition  [0x000070000c6d6000]\n"
+          + "   java.lang.Thread.State: RUNNABLE\n"
+          + "        at java.lang.ref.Reference.waitForReferencePendingList(java.base@11.0.9.1/Native Method)\n"
+          + "        at java.lang.ref.Reference.processPendingReferences(java.base@11.0.9.1/Reference.java:241)\n"
+          + "        at java.lang.ref.Reference$ReferenceHandler.run(java.base@11.0.9.1/Reference.java:213)\n"
+          + "\n"
+          + "\"AwesomeSpanHere\" #3 daemon prio=8 os_prio=31 cpu=0.41ms elapsed=50.48s tid=0x00007fb517030000 nid=0x3703 in Object.wait()  [0x000070000c7d9000]\n"
+          + "   java.lang.Thread.State: WAITING (on object monitor)\n"
+          + "        at java.lang.Object.wait(java.base@11.0.9.1/Native Method)\n"
+          + "        - waiting on <0x000000060066b908> (a java.lang.ref.ReferenceQueue$Lock)\n"
+          + "        at java.lang.ref.ReferenceQueue.remove(java.base@11.0.9.1/ReferenceQueue.java:155)\n"
+          + "        - waiting to re-lock in wait() <0x000000060066b908> (a java.lang.ref.ReferenceQueue$Lock)\n"
+          + "        at com.something.something.AwesomeThinger.overHereDoingSpanThings(MyServer.java:123)\n"
+          + "\n"
+          + "\"JFR Recording Scheduler\" #27 daemon prio=5 os_prio=31 cpu=0.13ms elapsed=48.39s tid=0x00007fb4b74b3000 nid=0x15103 in Object.wait()  [0x000070000ed4b000]\n"
+          + "   java.lang.Thread.State: WAITING (on object monitor)\n"
+          + "        at java.lang.Object.wait(java.base@11.0.9.1/Native Method)\n"
+          + "        - waiting on <0x0000000625152778> (a java.util.TaskQueue)\n"
+          + "        at java.lang.Object.wait(java.base@11.0.9.1/Object.java:328)\n"
+          + "        at java.util.TimerThread.mainLoop(java.base@11.0.9.1/Timer.java:527)\n"
+          + "        - waiting to re-lock in wait() <0x0000000625152778> (a java.util.TaskQueue)\n"
+          + "        at java.util.TimerThread.run(java.base@11.0.9.1/Timer.java:506)";
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/context/SpanContextualizerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/context/SpanContextualizerTest.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler.context;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.splunk.opentelemetry.profiler.events.ContextAttached;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.IntStream;
+import jdk.jfr.EventType;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedThread;
+import org.junit.jupiter.api.Test;
+
+class SpanContextualizerTest {
+
+  private final String spanId = "abc123";
+  private final String traceId = "23489uasdpfoiajsdfph23oij";
+  private final String rawStack = "raw is raw";
+
+  @Test
+  void testSimplePath() {
+    SpanContextualizer testClass = new SpanContextualizer();
+
+    Events events = buildEvents(spanId, 906);
+
+    assertNoLinkage(testClass, events);
+    testClass.updateContext(events.scopeStart);
+    assertLinkage(testClass, events);
+    testClass.updateContext(events.scopeEnd);
+    assertNoLinkage(testClass, events);
+    testClass.updateContext(events.scopeEnd);
+    assertNoLinkage(testClass, events);
+  }
+
+  @Test
+  void testNestedChildSpanOneThread() {
+    SpanContextualizer testClass = new SpanContextualizer();
+
+    String childSpanId = "xyz987";
+    String rawStack1 = "raw is raw1";
+    String rawStack2 = "raw is raw2";
+    long threadId = 906;
+
+    Events parent = buildEvents(spanId, threadId);
+    Events child = buildEvents(childSpanId, threadId);
+
+    testClass.updateContext(parent.scopeStart);
+    assertLinkage(testClass, parent, rawStack1);
+
+    testClass.updateContext(child.scopeStart);
+    assertLinkage(testClass, child, rawStack2);
+
+    testClass.updateContext(child.scopeEnd);
+    assertLinkage(testClass, parent, rawStack1);
+
+    testClass.updateContext(parent.scopeEnd);
+    assertNoLinkage(testClass, parent);
+  }
+
+  @Test
+  void testOneSpanThreadHops() {
+    SpanContextualizer testClass = new SpanContextualizer();
+
+    Events events1 = buildEvents(spanId, 906);
+    Events events2 = buildEvents(spanId, 907);
+
+    testClass.updateContext(events1.scopeStart); // has some scope on the first thread
+    testClass.updateContext(events2.scopeStart); // context switch to a new thread
+
+    assertLinkage(testClass, events1);
+    assertLinkage(testClass, events2);
+
+    testClass.updateContext(events2.scopeEnd);
+
+    assertNoLinkage(testClass, events2);
+    assertLinkage(testClass, events1); // thread 1 is still linked
+  }
+
+  @Test
+  void testMultipleThreadsOneSpanAllLinked() {
+    SpanContextualizer testClass = new SpanContextualizer();
+
+    long threadId1 = 907;
+    long threadId2 = 908;
+    long threadId3 = 909;
+    Events events1 = buildEvents(spanId, threadId1);
+    Events events2 = buildEvents(spanId, threadId2);
+    Events events3 = buildEvents(spanId, threadId3);
+
+    testClass.updateContext(events1.scopeStart); // context switch to a new thread
+    assertLinkage(testClass, events1);
+    assertNoLinkage(testClass, events2);
+    assertNoLinkage(testClass, events3);
+
+    testClass.updateContext(events2.scopeStart); // context switch to a new thread
+    assertLinkage(testClass, events1);
+    assertLinkage(testClass, events2);
+    assertNoLinkage(testClass, events3);
+
+    testClass.updateContext(events3.scopeStart); // context switch to a new thread
+    assertLinkage(testClass, events1);
+    assertLinkage(testClass, events2);
+    assertLinkage(testClass, events3);
+
+    testClass.updateContext(events2.scopeEnd);
+    assertLinkage(testClass, events1);
+    assertNoLinkage(testClass, events2);
+    assertLinkage(testClass, events3);
+
+    testClass.updateContext(events3.scopeEnd);
+    assertLinkage(testClass, events1);
+    assertNoLinkage(testClass, events2);
+    assertNoLinkage(testClass, events3);
+
+    testClass.updateContext(events1.scopeEnd);
+    assertNoLinkage(testClass, events1);
+    assertNoLinkage(testClass, events2);
+    assertNoLinkage(testClass, events3);
+  }
+
+  @Test
+  void testBackgroundWorkerThreads() {
+    SpanContextualizer testClass = new SpanContextualizer();
+
+    Events events1 = buildEvents(spanId, 906);
+    Events events2 = buildEvents(spanId, 907);
+    Events events3 = buildEvents(spanId, 908);
+
+    testClass.updateContext(events1.scopeStart);
+    testClass.updateContext(events2.scopeStart);
+    testClass.updateContext(events3.scopeStart);
+
+    // All are linked
+    assertLinkage(testClass, events1);
+    assertLinkage(testClass, events2);
+    assertLinkage(testClass, events3);
+
+    testClass.updateContext(events1.scopeEnd);
+
+    // One is no longer linked, but 2 and 3 are
+    assertNoLinkage(testClass, events1);
+    assertLinkage(testClass, events2);
+    assertLinkage(testClass, events3);
+
+    testClass.updateContext(events3.scopeEnd);
+    assertNoLinkage(testClass, events1);
+    assertLinkage(testClass, events2);
+    assertNoLinkage(testClass, events3);
+
+    testClass.updateContext(events2.scopeEnd);
+    assertNoLinkage(testClass, events1);
+    assertNoLinkage(testClass, events2);
+    assertNoLinkage(testClass, events3);
+
+    assertEquals(0, testClass.inFlightSpanCount());
+    assertEquals(0, testClass.inFlightThreadCount());
+  }
+
+  @Test
+  void testMultipleChildThreadedSpansEndWithinParent() {
+    SpanContextualizer testClass = new SpanContextualizer();
+
+    Events events1 = buildEvents("abc123", 906);
+    Events events2 = buildEvents("xyz666", 907);
+    Events events3 = buildEvents("zzybal", 908);
+
+    testClass.updateContext(events1.scopeStart);
+    testClass.updateContext(events2.scopeStart);
+    testClass.updateContext(events3.scopeStart);
+
+    assertLinkage(testClass, events1);
+    assertLinkage(testClass, events2);
+    assertLinkage(testClass, events3);
+
+    // 3 is ending before 2, even tho it was started after
+    testClass.updateContext(events3.scopeEnd);
+    assertLinkage(testClass, events1);
+    assertLinkage(testClass, events1);
+    assertNoLinkage(testClass, events3);
+    assertLinkage(testClass, events2);
+
+    // Now 2 is ending
+    testClass.updateContext(events2.scopeEnd);
+    assertLinkage(testClass, events1);
+    assertLinkage(testClass, events1);
+    assertNoLinkage(testClass, events2);
+    assertNoLinkage(testClass, events3);
+
+    testClass.updateContext(events1.scopeEnd);
+    assertNoLinkage(testClass, events1);
+
+    // TODO: Verify size?
+  }
+
+  @Test
+  void testOneSpanThreadHop_FirstThreadClosesFirst() {
+    SpanContextualizer testClass = new SpanContextualizer();
+    Events events1 = buildEvents(spanId, 906);
+    Events events2 = buildEvents(spanId, 907);
+    testClass.updateContext(events1.scopeStart);
+    testClass.updateContext(events2.scopeStart); //  hop to new thread
+
+    assertLinkage(testClass, events1); // thread 1 is linked
+    assertLinkage(testClass, events2); // thread 2 is also linked
+
+    testClass.updateContext(events1.scopeEnd); // thread 1 closes
+
+    assertNoLinkage(testClass, events1); // thread 1 no longer linked
+    assertLinkage(testClass, events2); // thread 2 still linked
+
+    testClass.updateContext(events2.scopeEnd);
+    assertNoLinkage(testClass, events1); // thread 1 no longer linked
+    assertNoLinkage(testClass, events2); // thread 2 no longer linked
+  }
+
+  @Test
+  void testVeryLargeNumberOfDynamicThreads() {
+    SpanContextualizer testClass = new SpanContextualizer();
+    Random rand = new Random();
+    int num = 500;
+    Events rootEvents = buildEvents(spanId, 906);
+    testClass.updateContext(rootEvents.scopeStart);
+    List<Events> openEventThreads = new ArrayList<>();
+
+    IntStream.range(0, num)
+        .forEach(
+            i -> {
+              long threadId = rootEvents.threadId + i + 1;
+              Events ev = buildEvents(spanId, threadId);
+              testClass.updateContext(ev.scopeStart);
+              if (rand.nextInt(100) > 50) { // sometimes nested, sometimes hopping
+                testClass.updateContext(ev.scopeEnd);
+              } else {
+                openEventThreads.add(ev);
+              }
+            });
+
+    assertLinkage(testClass, rootEvents);
+    Collections.shuffle(openEventThreads);
+
+    // Close all that are still open
+    openEventThreads.forEach(ev -> testClass.updateContext(ev.scopeEnd));
+    openEventThreads.forEach(ev -> assertNoLinkage(testClass, ev));
+
+    testClass.updateContext(rootEvents.scopeEnd);
+    assertNoLinkage(testClass, rootEvents);
+    assertEquals(0, testClass.inFlightThreadCount());
+    assertEquals(0, testClass.inFlightSpanCount());
+  }
+
+  private void assertLinkage(SpanContextualizer testClass, Events events) {
+    assertLinkage(testClass, events, rawStack);
+  }
+
+  private void assertLinkage(SpanContextualizer testClass, Events events, String stack) {
+    StackToSpanLinkage result = testClass.link(stack, events.threadId);
+    assertEquals(events.spanId, result.getSpanId());
+    assertEquals(traceId, result.getTraceId());
+    assertEquals(stack, result.getRawStack());
+  }
+
+  private void assertNoLinkage(SpanContextualizer testClass, Events events) {
+    StackToSpanLinkage result = testClass.link(rawStack, events.threadId);
+    assertNull(result.getSpanId());
+  }
+
+  private Events buildEvents(String spanId, long threadId) {
+    Events result = new Events(spanId, threadId);
+    result.scopeStart = contextEventIn(spanId, threadId);
+    result.scopeEnd = contextEventOut(spanId, threadId);
+    return result;
+  }
+
+  static class Events {
+    private final String spanId;
+    private final long threadId;
+    public RecordedEvent scopeStart;
+    public RecordedEvent scopeEnd;
+
+    Events(String spanId, long threadId) {
+      this.spanId = spanId;
+      this.threadId = threadId;
+    }
+  }
+
+  private RecordedEvent contextEventIn(String spanId, long threadId) {
+    return contextEvent(spanId, threadId, ContextAttached.IN);
+  }
+
+  private RecordedEvent contextEventOut(String spanId, long threadId) {
+    return contextEvent(spanId, threadId, ContextAttached.OUT);
+  }
+
+  private RecordedEvent contextEvent(String spanId, long threadId, byte direction) {
+    RecordedEvent event = mock(RecordedEvent.class);
+    EventType type = mock(EventType.class);
+    when(type.getName()).thenReturn(ContextAttached.EVENT_NAME);
+    when(event.getEventType()).thenReturn(type);
+    when(event.getString("traceId")).thenReturn(traceId);
+    when(event.getString("spanId")).thenReturn(spanId);
+    when(event.getByte("direction")).thenReturn(direction);
+    RecordedThread thread = mock(RecordedThread.class);
+    when(thread.getJavaThreadId()).thenReturn(threadId);
+    when(event.getThread()).thenReturn(thread);
+    return event;
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/context/StackDescriptorLineParserTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/context/StackDescriptorLineParserTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler.context;
+
+import static com.splunk.opentelemetry.profiler.context.StackDescriptorLineParser.CANT_PARSE_THREAD_ID;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class StackDescriptorLineParserTest {
+
+  static final String GOOD_DESC =
+      "\"AwesomeSpanHere\" #31 daemon prio=8 os_prio=31 cpu=0.41ms elapsed=50.48s tid=0x00007fb517030000 nid=0x3703 in Object.wait()  [0x000070000c7d9000]\n";
+  static final String NO_QUOTES_DESC =
+      "MissingQuotesHere #31 daemon prio=8 os_prio=31 cpu=0.41ms elapsed=50.48s tid=0x00007fb517030000 nid=0x3703 in Object.wait()  [0x000070000c7d9000]\n";
+
+  @Test
+  void testHappyPathParses() {
+    StackDescriptorLineParser parser = new StackDescriptorLineParser();
+    long result = parser.parseThreadId(GOOD_DESC);
+    assertEquals(31, result);
+  }
+
+  @Test
+  void testHappyPathSimplerInput() {
+    StackDescriptorLineParser parser = new StackDescriptorLineParser();
+    long result = parser.parseThreadId("\"test\" #33 ");
+    assertEquals(33, result);
+  }
+
+  @Test
+  void testMissingQuotes() {
+    StackDescriptorLineParser parser = new StackDescriptorLineParser();
+    long result = parser.parseThreadId(NO_QUOTES_DESC);
+    assertEquals(CANT_PARSE_THREAD_ID, result);
+  }
+
+  @Test
+  void testPurposefullyDeviantInput() {
+    StackDescriptorLineParser parser = new StackDescriptorLineParser();
+    long result = parser.parseThreadId(".#31 daemon x");
+    assertEquals(CANT_PARSE_THREAD_ID, result);
+  }
+
+  @Test
+  void testQuoteAtEnd() {
+    StackDescriptorLineParser parser = new StackDescriptorLineParser();
+    long result =
+        parser.parseThreadId(
+            ".#31 daemon prio=8 os_prio=31 cpu=0.41ms elapsed=50.48s tid=0x00007fb517030000\"");
+    assertEquals(CANT_PARSE_THREAD_ID, result);
+  }
+
+  @Test
+  void testEntireLineQuoted() {
+    StackDescriptorLineParser parser = new StackDescriptorLineParser();
+    long result =
+        parser.parseThreadId(
+            "\".#31 daemon prio=8 os_prio=31 cpu=0.41ms elapsed=50.48s tid=0x00007fb517030000\"");
+    assertEquals(CANT_PARSE_THREAD_ID, result);
+  }
+
+  @Test
+  void testFallOffTheEnd() {
+    StackDescriptorLineParser parser = new StackDescriptorLineParser();
+    long result =
+        parser.parseThreadId(
+            "\".#31 daemon prio=8 os_prio=31 cpu=0.41ms elapsed=50.48s tid=0x00007fb517030000\" ");
+    assertEquals(CANT_PARSE_THREAD_ID, result);
+  }
+
+  @Test
+  void testFallOffTheEndWithHash() {
+    StackDescriptorLineParser parser = new StackDescriptorLineParser();
+    long result = parser.parseThreadId("\"test\" #");
+    assertEquals(CANT_PARSE_THREAD_ID, result);
+  }
+
+  @Test
+  void testSecondSpaceMissing() {
+    StackDescriptorLineParser parser = new StackDescriptorLineParser();
+    long result = parser.parseThreadId("\"test\" #33");
+    assertEquals(CANT_PARSE_THREAD_ID, result);
+  }
+
+  @Test
+  void testNotNumeric() {
+    StackDescriptorLineParser parser = new StackDescriptorLineParser();
+    long result = parser.parseThreadId("\"test\" #zoinks ");
+    assertEquals(CANT_PARSE_THREAD_ID, result);
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/context/ThreadContextTrackerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/context/ThreadContextTrackerTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler.context;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import jdk.jfr.consumer.RecordedThread;
+import org.junit.jupiter.api.Test;
+
+class ThreadContextTrackerTest {
+
+  final long threadId = 21L;
+  final String traceId = "9999-99--9999999-9-9-9";
+
+  @Test
+  void testDefaultStateNoLinkFound() {
+    ThreadContextTracker tracker = new ThreadContextTracker();
+    List<SpanLinkage> inFlight = tracker.getInfLightSpansForThread(threadId);
+    assertTrue(inFlight.isEmpty());
+  }
+
+  @Test
+  void testSingleSpanLinkedAndFound() {
+    String spanId = "abc-123-fgggg";
+    SpanLinkage linkage = makeLinkage(spanId, threadId);
+
+    ThreadContextTracker tracker = new ThreadContextTracker();
+    tracker.addLinkage(linkage);
+    List<SpanLinkage> inFlight = tracker.getInfLightSpansForThread(threadId);
+
+    assertEquals(1, inFlight.size());
+    assertEquals(traceId, inFlight.get(0).getTraceId());
+    assertEquals(threadId, inFlight.get(0).getThreadId());
+    assertEquals(spanId, inFlight.get(0).getSpanId());
+  }
+
+  @Test
+  void testAddAndRemoveWithMultipleFound() {
+    ThreadContextTracker tracker = new ThreadContextTracker();
+    tracker.addLinkage(makeLinkage("abc1", 12));
+    tracker.addLinkage(makeLinkage("abc2", 13));
+    tracker.addLinkage(makeLinkage("abc3", 12));
+    tracker.unlink(traceId, "abc2", 13);
+    tracker.addLinkage(makeLinkage("abc3", 12));
+    tracker.unlink(traceId, "abc3", 12);
+    tracker.addLinkage(makeLinkage("abc9", 13));
+    tracker.addLinkage(makeLinkage("abc4", 14));
+    tracker.addLinkage(makeLinkage("abc5", 12));
+
+    assertEquals(3, tracker.getInfLightSpansForThread(12).size());
+    assertEquals(1, tracker.getInfLightSpansForThread(13).size());
+    assertEquals(1, tracker.getInfLightSpansForThread(14).size());
+  }
+
+  private SpanLinkage makeLinkage(String spanId, long threadId) {
+    RecordedThread thread = mock(RecordedThread.class);
+    when(thread.getJavaThreadId()).thenReturn(threadId);
+    return new SpanLinkage(spanId, traceId, thread);
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/context/ThreadContextTrackerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/context/ThreadContextTrackerTest.java
@@ -32,7 +32,7 @@ class ThreadContextTrackerTest {
   @Test
   void testDefaultStateNoLinkFound() {
     ThreadContextTracker tracker = new ThreadContextTracker();
-    List<SpanLinkage> inFlight = tracker.getInfLightSpansForThread(threadId);
+    List<SpanLinkage> inFlight = tracker.getInFlightSpansForThread(threadId);
     assertTrue(inFlight.isEmpty());
   }
 
@@ -43,7 +43,7 @@ class ThreadContextTrackerTest {
 
     ThreadContextTracker tracker = new ThreadContextTracker();
     tracker.addLinkage(linkage);
-    List<SpanLinkage> inFlight = tracker.getInfLightSpansForThread(threadId);
+    List<SpanLinkage> inFlight = tracker.getInFlightSpansForThread(threadId);
 
     assertEquals(1, inFlight.size());
     assertEquals(traceId, inFlight.get(0).getTraceId());
@@ -64,9 +64,9 @@ class ThreadContextTrackerTest {
     tracker.addLinkage(makeLinkage("abc4", 14));
     tracker.addLinkage(makeLinkage("abc5", 12));
 
-    assertEquals(3, tracker.getInfLightSpansForThread(12).size());
-    assertEquals(1, tracker.getInfLightSpansForThread(13).size());
-    assertEquals(1, tracker.getInfLightSpansForThread(14).size());
+    assertEquals(3, tracker.getInFlightSpansForThread(12).size());
+    assertEquals(1, tracker.getInFlightSpansForThread(13).size());
+    assertEquals(1, tracker.getInFlightSpansForThread(14).size());
   }
 
   private SpanLinkage makeLinkage(String spanId, long threadId) {


### PR DESCRIPTION
We leverage the JFR events that track span thread context in order to link stack traces to active spans.

This change also introduces the `ThreadDumpProcessor` which is responsible for handling the `jdk.ThreadDump` JFR events. It doesn't yet export.