### PR TITLE
look for specific events in the jfr file output

### DIFF
--- a/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/ProfilerSmokeTest.java
+++ b/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/ProfilerSmokeTest.java
@@ -35,6 +35,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -46,6 +48,7 @@ import org.testcontainers.utility.MountableFile;
 
 public class ProfilerSmokeTest {
 
+  private static final Logger logger = LoggerFactory.getLogger(ProfilerSmokeTest.class);
   public static final Path agentPath =
       Paths.get(System.getProperty("io.opentelemetry.smoketest.agent.shadowJar.path"));
   public static final int PETCLINIC_PORT = 9966;
@@ -83,7 +86,7 @@ public class ProfilerSmokeTest {
 
   @Test
   void ensureJfrFilesContainContextChangeEvents() throws Exception {
-    System.out.println("Petclinic has been started.");
+    logger.info("Petclinic has been started.");
 
     generateSomeSpans();
 
@@ -113,7 +116,7 @@ public class ProfilerSmokeTest {
   }
 
   private void generateSomeSpans() throws Exception {
-    System.out.println("Generating some spans...");
+    logger.info("Generating some spans...");
     OkHttpClient client = buildClient();
     int port = petclinic.getMappedPort(PETCLINIC_PORT);
     doGetRequest(client, "http://localhost:" + port + "/petclinic/api/vets");
@@ -136,7 +139,7 @@ public class ProfilerSmokeTest {
   }
 
   private List<Path> findJfrFilesInOutputDir() throws Exception {
-    System.out.println("Opening dir to look for jfr files...");
+    logger.info("Opening dir to look for jfr files...");
     try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(tempDir)) {
 
       return StreamSupport.stream(dirStream.spliterator(), false)

--- a/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/ProfilerSmokeTest.java
+++ b/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/ProfilerSmokeTest.java
@@ -48,6 +48,7 @@ public class ProfilerSmokeTest {
 
   public static final Path agentPath =
       Paths.get(System.getProperty("io.opentelemetry.smoketest.agent.shadowJar.path"));
+  public static final int PETCLINIC_PORT = 9966;
 
   static GenericContainer<?> petclinic;
 
@@ -58,7 +59,7 @@ public class ProfilerSmokeTest {
     MountableFile agentJar = MountableFile.forHostPath(agentPath);
     petclinic =
         new GenericContainer<>(new ImageFromDockerfile().withDockerfile(Path.of("./Dockerfile")))
-            .withExposedPorts(9966)
+            .withExposedPorts(PETCLINIC_PORT)
             .withCopyFileToContainer(agentJar, "/app/javaagent.jar")
             .withCreateContainerCmdModifier(cmd -> cmd.withEntrypoint("java"))
             .withCommand(
@@ -114,7 +115,7 @@ public class ProfilerSmokeTest {
   private void generateSomeSpans() throws Exception {
     System.out.println("Generating some spans...");
     OkHttpClient client = buildClient();
-    int port = petclinic.getMappedPort(9966);
+    int port = petclinic.getMappedPort(PETCLINIC_PORT);
     doGetRequest(client, "http://localhost:" + port + "/petclinic/api/vets");
     doGetRequest(client, "http://localhost:" + port + "/petclinic/api/visits");
   }
@@ -127,13 +128,11 @@ public class ProfilerSmokeTest {
   }
 
   private OkHttpClient buildClient() {
-    OkHttpClient client =
-        new OkHttpClient.Builder()
-            .connectTimeout(10, TimeUnit.SECONDS)
-            .writeTimeout(10, TimeUnit.SECONDS)
-            .readTimeout(10, TimeUnit.SECONDS)
-            .build();
-    return client;
+    return new OkHttpClient.Builder()
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .writeTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(10, TimeUnit.SECONDS)
+        .build();
   }
 
   private List<Path> findJfrFilesInOutputDir() throws Exception {


### PR DESCRIPTION
Adds some additional details in the profiling smoke test. We look for the synthetic `otel.ContextAttached` events in the JFR files now (instead of only checking for their existence).