### PR TITLE
Logs processor

### DIFF
--- a/profiler/build.gradle
+++ b/profiler/build.gradle
@@ -12,11 +12,13 @@ compileJava {
 }
 
 dependencies {
-    compileOnly("io.opentelemetry:opentelemetry-sdk:${versions.opentelemetry}")
-    compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:${versions.opentelemetryAlpha}")
-    compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api:${versions.opentelemetryJavaagentAlpha}")
-    compileOnly("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:${versions.opentelemetryJavaagentAlpha}")
-    compileOnly("io.opentelemetry:opentelemetry-semconv:${versions.opentelemetryAlpha}")
+    compileOnly "io.opentelemetry:opentelemetry-sdk:${versions.opentelemetry}"
+    compileOnly "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:${versions.opentelemetryAlpha}"
+    compileOnly "io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api:${versions.opentelemetryJavaagentAlpha}"
+    compileOnly "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:${versions.opentelemetryJavaagentAlpha}"
+    compileOnly "io.opentelemetry:opentelemetry-semconv:${versions.opentelemetryAlpha}"
+    compileOnly "io.opentelemetry:opentelemetry-proto:${versions.opentelemetryAlpha}"
+
     compileOnly deps.slf4j
 
     annotationProcessor deps.autoservice
@@ -25,7 +27,9 @@ dependencies {
     testCompile deps.slf4j
     testImplementation "io.opentelemetry:opentelemetry-context:${versions.opentelemetry}"
     testImplementation "io.opentelemetry:opentelemetry-api:${versions.opentelemetry}"
-
+    testImplementation "io.opentelemetry:opentelemetry-proto:${versions.opentelemetryAlpha}"
+    testImplementation "io.opentelemetry:opentelemetry-semconv:${versions.opentelemetryAlpha}"
+    testImplementation "io.opentelemetry:opentelemetry-sdk:${versions.opentelemetry}"
 }
 
 shadowJar {

--- a/profiler/src/main/java/com/splunk/opentelemetry/logs/BatchingLogsProcessor.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/logs/BatchingLogsProcessor.java
@@ -27,7 +27,6 @@ import java.util.function.Consumer;
  * which ever comes first.
  */
 public class BatchingLogsProcessor implements LogsProcessor {
-
   private final int maxBatchSize;
   private final Duration maxTimeBetweenBatches;
   private final List<LogEntry> batch;
@@ -43,7 +42,7 @@ public class BatchingLogsProcessor implements LogsProcessor {
     this.batch = new ArrayList<>(maxBatchSize);
   }
 
-  void start() {
+  public void start() {
     synchronized (lock) {
       if (watchdog != null) {
         throw new IllegalStateException("Already running");
@@ -70,6 +69,7 @@ public class BatchingLogsProcessor implements LogsProcessor {
       batch.add(log);
       if (batch.size() >= maxBatchSize) {
         doAction();
+        watchdog.reset();
       }
     }
   }

--- a/profiler/src/main/java/com/splunk/opentelemetry/logs/BatchingLogsProcessor.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/logs/BatchingLogsProcessor.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.logs;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * A log processor that batches logs until a max number are buffered or a time limit has passed,
+ * which ever comes first.
+ */
+public class BatchingLogsProcessor implements LogsProcessor {
+
+  private final int maxBatchSize;
+  private final Duration maxTimeBetweenBatches;
+  private final List<LogEntry> batch;
+  private final Consumer<List<LogEntry>> batchAction;
+  private final Object lock = new Object();
+  private WatchdogTimer watchdog;
+
+  public BatchingLogsProcessor(
+      Duration maxTimeBetweenBatches, int maxBatchSize, Consumer<List<LogEntry>> batchAction) {
+    this.maxTimeBetweenBatches = maxTimeBetweenBatches;
+    this.maxBatchSize = maxBatchSize;
+    this.batchAction = batchAction;
+    this.batch = new ArrayList<>(maxBatchSize);
+  }
+
+  void start() {
+    synchronized (lock) {
+      if (watchdog != null) {
+        throw new IllegalStateException("Already running");
+      }
+      watchdog = new WatchdogTimer(maxTimeBetweenBatches, this::doAction);
+      watchdog.start();
+    }
+  }
+
+  void stop() {
+    synchronized (lock) {
+      if (watchdog == null) {
+        throw new IllegalStateException("Not running");
+      }
+      watchdog.stop();
+      watchdog = null;
+      doAction();
+    }
+  }
+
+  @Override
+  public void log(LogEntry log) {
+    synchronized (lock) {
+      batch.add(log);
+      if (batch.size() >= maxBatchSize) {
+        doAction();
+      }
+    }
+  }
+
+  private void doAction() {
+    synchronized (lock) {
+      if (batch.isEmpty()) {
+        return;
+      }
+      batchAction.accept(Collections.unmodifiableList(batch));
+      batch.clear();
+    }
+  }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/logs/CommonAdapter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/logs/CommonAdapter.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.logs;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.ArrayValue;
+import io.opentelemetry.proto.common.v1.InstrumentationLibrary;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import java.util.List;
+
+/** Copied from otel internals, because it's so locked down we can't use it here. */
+final class CommonAdapter {
+  @SuppressWarnings("unchecked")
+  public static KeyValue toProtoAttribute(AttributeKey<?> key, Object value) {
+    KeyValue.Builder builder = KeyValue.newBuilder().setKey(key.getKey());
+    switch (key.getType()) {
+      case STRING:
+        return makeStringKeyValue(key, (String) value);
+      case BOOLEAN:
+        return makeBooleanKeyValue(key, (boolean) value);
+      case LONG:
+        return makeLongKeyValue(key, (Long) value);
+      case DOUBLE:
+        return makeDoubleKeyValue(key, (Double) value);
+      case BOOLEAN_ARRAY:
+        return makeBooleanArrayKeyValue(key, (List<Boolean>) value);
+      case LONG_ARRAY:
+        return makeLongArrayKeyValue(key, (List<Long>) value);
+      case DOUBLE_ARRAY:
+        return makeDoubleArrayKeyValue(key, (List<Double>) value);
+      case STRING_ARRAY:
+        return makeStringArrayKeyValue(key, (List<String>) value);
+    }
+    return builder.setValue(AnyValue.getDefaultInstance()).build();
+  }
+
+  private static KeyValue makeLongArrayKeyValue(AttributeKey<?> key, List<Long> value) {
+    KeyValue.Builder keyValueBuilder =
+        KeyValue.newBuilder()
+            .setKey(key.getKey())
+            .setValue(AnyValue.newBuilder().setArrayValue(makeLongArrayAnyValue(value)).build());
+
+    return keyValueBuilder.build();
+  }
+
+  private static KeyValue makeDoubleArrayKeyValue(AttributeKey<?> key, List<Double> value) {
+    KeyValue.Builder keyValueBuilder =
+        KeyValue.newBuilder()
+            .setKey(key.getKey())
+            .setValue(AnyValue.newBuilder().setArrayValue(makeDoubleArrayAnyValue(value)).build());
+
+    return keyValueBuilder.build();
+  }
+
+  private static KeyValue makeBooleanArrayKeyValue(AttributeKey<?> key, List<Boolean> value) {
+    KeyValue.Builder keyValueBuilder =
+        KeyValue.newBuilder()
+            .setKey(key.getKey())
+            .setValue(AnyValue.newBuilder().setArrayValue(makeBooleanArrayAnyValue(value)).build());
+
+    return keyValueBuilder.build();
+  }
+
+  private static KeyValue makeStringArrayKeyValue(AttributeKey<?> key, List<String> value) {
+    KeyValue.Builder keyValueBuilder =
+        KeyValue.newBuilder()
+            .setKey(key.getKey())
+            .setValue(AnyValue.newBuilder().setArrayValue(makeStringArrayAnyValue(value)).build());
+
+    return keyValueBuilder.build();
+  }
+
+  private static KeyValue makeLongKeyValue(AttributeKey<?> key, long value) {
+    KeyValue.Builder keyValueBuilder =
+        KeyValue.newBuilder()
+            .setKey(key.getKey())
+            .setValue(AnyValue.newBuilder().setIntValue(value).build());
+
+    return keyValueBuilder.build();
+  }
+
+  private static KeyValue makeDoubleKeyValue(AttributeKey<?> key, double value) {
+    KeyValue.Builder keyValueBuilder =
+        KeyValue.newBuilder()
+            .setKey(key.getKey())
+            .setValue(AnyValue.newBuilder().setDoubleValue(value).build());
+
+    return keyValueBuilder.build();
+  }
+
+  private static KeyValue makeBooleanKeyValue(AttributeKey<?> key, boolean value) {
+    KeyValue.Builder keyValueBuilder =
+        KeyValue.newBuilder()
+            .setKey(key.getKey())
+            .setValue(AnyValue.newBuilder().setBoolValue(value).build());
+
+    return keyValueBuilder.build();
+  }
+
+  static KeyValue makeStringKeyValue(AttributeKey<?> key, String value) {
+    KeyValue.Builder keyValueBuilder =
+        KeyValue.newBuilder()
+            .setKey(key.getKey())
+            .setValue(AnyValue.newBuilder().setStringValue(value).build());
+
+    return keyValueBuilder.build();
+  }
+
+  private static ArrayValue makeDoubleArrayAnyValue(List<Double> doubleArrayValue) {
+    ArrayValue.Builder builder = ArrayValue.newBuilder();
+    for (Double doubleValue : doubleArrayValue) {
+      builder.addValues(AnyValue.newBuilder().setDoubleValue(doubleValue).build());
+    }
+    return builder.build();
+  }
+
+  private static ArrayValue makeLongArrayAnyValue(List<Long> longArrayValue) {
+    ArrayValue.Builder builder = ArrayValue.newBuilder();
+    for (Long intValue : longArrayValue) {
+      builder.addValues(AnyValue.newBuilder().setIntValue(intValue).build());
+    }
+    return builder.build();
+  }
+
+  private static ArrayValue makeStringArrayAnyValue(List<String> stringArrayValue) {
+    ArrayValue.Builder builder = ArrayValue.newBuilder();
+    for (String string : stringArrayValue) {
+      builder.addValues(AnyValue.newBuilder().setStringValue(string).build());
+    }
+    return builder.build();
+  }
+
+  private static ArrayValue makeBooleanArrayAnyValue(List<Boolean> booleanArrayValue) {
+    ArrayValue.Builder builder = ArrayValue.newBuilder();
+    for (Boolean bool : booleanArrayValue) {
+      builder.addValues(AnyValue.newBuilder().setBoolValue(bool).build());
+    }
+    return builder.build();
+  }
+
+  static InstrumentationLibrary toProtoInstrumentationLibrary(
+      InstrumentationLibraryInfo instrumentationLibraryInfo) {
+    return InstrumentationLibrary.newBuilder()
+        .setName(instrumentationLibraryInfo.getName())
+        .setVersion(
+            instrumentationLibraryInfo.getVersion() == null
+                ? ""
+                : instrumentationLibraryInfo.getVersion())
+        .build();
+  }
+
+  private CommonAdapter() {}
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/logs/InstrumentationLibraryLogsAdapter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/logs/InstrumentationLibraryLogsAdapter.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.logs;
+
+import io.opentelemetry.proto.common.v1.InstrumentationLibrary;
+import io.opentelemetry.proto.logs.v1.InstrumentationLibraryLogs;
+import io.opentelemetry.proto.logs.v1.LogRecord;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Protobuf converter. Responsible for turning a list of LogEntry instances into an instance of
+ * InstrumentationLibraryLogs.
+ */
+public class InstrumentationLibraryLogsAdapter
+    implements Function<List<LogEntry>, InstrumentationLibraryLogs> {
+
+  public final String instrumentationName;
+  public final String instrumentationVersion;
+  private final LogEntryAdapter logEntryAdapter;
+
+  private InstrumentationLibraryLogsAdapter(Builder builder) {
+    this.instrumentationName = builder.instrumentationName;
+    this.instrumentationVersion = builder.instrumentationVersion;
+    this.logEntryAdapter = builder.logEntryAdapter;
+  }
+
+  @Override
+  public InstrumentationLibraryLogs apply(List<LogEntry> logEntries) {
+
+    InstrumentationLibrary library =
+        InstrumentationLibrary.newBuilder()
+            .setName(instrumentationName)
+            .setVersion(instrumentationVersion)
+            .build();
+
+    List<LogRecord> logs = logEntries.stream().map(logEntryAdapter).collect(Collectors.toList());
+
+    return InstrumentationLibraryLogs.newBuilder()
+        .setInstrumentationLibrary(library)
+        .addAllLogs(logs)
+        .build();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String instrumentationName;
+    private String instrumentationVersion;
+    private LogEntryAdapter logEntryAdapter;
+
+    public Builder instrumentationName(String instrumentationName) {
+      this.instrumentationName = instrumentationName;
+      return this;
+    }
+
+    public Builder instrumentationVersion(String instrumentationVersion) {
+      this.instrumentationVersion = instrumentationVersion;
+      return this;
+    }
+
+    public Builder logEntryAdapter(LogEntryAdapter logEntryAdapter) {
+      this.logEntryAdapter = logEntryAdapter;
+      return this;
+    }
+
+    public InstrumentationLibraryLogsAdapter build() {
+      return new InstrumentationLibraryLogsAdapter(this);
+    }
+  }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/logs/LogEntry.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/logs/LogEntry.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.logs;
+
+import io.opentelemetry.api.common.Attributes;
+import java.time.Instant;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/** Data object for OpenTelemetry logs */
+public class LogEntry {
+
+  private final String name;
+  private final Attributes attributes;
+  private final Instant time;
+  private final String body;
+  @Nullable private final String traceId;
+  @Nullable private final String spanId;
+
+  private LogEntry(Builder builder) {
+    this.name = builder.name;
+    this.attributes = builder.attributes;
+    this.time = builder.time;
+    this.body = builder.body;
+    this.traceId = builder.traceId;
+    this.spanId = builder.spanId;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Attributes getAttributes() {
+    return attributes;
+  }
+
+  public String getBody() {
+    return body;
+  }
+
+  public Instant getTime() {
+    return time;
+  }
+
+  public String getTraceId() {
+    return traceId;
+  }
+
+  public String getSpanId() {
+    return spanId;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String name;
+    private Attributes attributes = Attributes.empty();
+    private Instant time;
+    private String body;
+    private String traceId;
+    private String spanId;
+
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder attributes(Attributes attributes) {
+      this.attributes = attributes;
+      return this;
+    }
+
+    public Builder time(Instant time) {
+      this.time = time;
+      return this;
+    }
+
+    public Builder body(String body) {
+      this.body = body;
+      return this;
+    }
+
+    public Builder traceId(String traceId) {
+      this.traceId = traceId;
+      return this;
+    }
+
+    public Builder spanId(String spanId) {
+      this.spanId = spanId;
+      return this;
+    }
+
+    public LogEntry build() {
+      return new LogEntry(this);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    LogEntry logEntry = (LogEntry) o;
+    return name.equals(logEntry.name)
+        && attributes.equals(logEntry.attributes)
+        && time.equals(logEntry.time)
+        && body.equals(logEntry.body)
+        && Objects.equals(traceId, logEntry.traceId)
+        && Objects.equals(spanId, logEntry.spanId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, attributes, time, body, traceId, spanId);
+  }
+
+  @Override
+  public String toString() {
+    return "LogEntry{"
+        + "name='"
+        + name
+        + '\''
+        + ", attributes="
+        + attributes
+        + ", time="
+        + time
+        + ", body='"
+        + body
+        + '\''
+        + ", traceId='"
+        + traceId
+        + '\''
+        + ", spanId='"
+        + spanId
+        + '\''
+        + '}';
+  }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/logs/LogEntryAdapter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/logs/LogEntryAdapter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.logs;
+
+import com.google.protobuf.ByteString;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.logs.v1.LogRecord;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/** Turns a LogEntry into a protobuf LogRecord, ready for exporting */
+public class LogEntryAdapter implements Function<LogEntry, LogRecord> {
+
+  @Override
+  public LogRecord apply(LogEntry logEntry) {
+    AnyValue body = AnyValue.newBuilder().setStringValue(logEntry.getBody()).build();
+    Attributes sourceAttrs = logEntry.getAttributes();
+    List<KeyValue> attributes =
+        sourceAttrs.asMap().entrySet().stream()
+            .map(kv -> CommonAdapter.toProtoAttribute(kv.getKey(), kv.getValue()))
+            .collect(Collectors.toList());
+
+    LogRecord.Builder builder =
+        LogRecord.newBuilder()
+            .addAllAttributes(attributes)
+            .setBody(body)
+            .setTimeUnixNano(TimeUnit.MILLISECONDS.toNanos(logEntry.getTime().toEpochMilli()));
+
+    if (logEntry.getName() != null) {
+      builder.setName(logEntry.getName());
+    }
+    if (logEntry.getTraceId() != null) {
+      builder.setTraceId(ByteString.copyFromUtf8(logEntry.getTraceId()));
+    }
+    if (logEntry.getSpanId() != null) {
+      builder.setSpanId(ByteString.copyFromUtf8(logEntry.getSpanId()));
+    }
+    return builder.build();
+  }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/logs/LogsExporter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/logs/LogsExporter.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.logs;
+
+import java.util.List;
+
+/** Sends a list of LogEntry objects somewhere else, often to the OpenTelemetry collector. */
+public interface LogsExporter {
+  void export(List<LogEntry> logs);
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/logs/LogsProcessor.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/logs/LogsProcessor.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.logs;
+
+public interface LogsProcessor {
+
+  void log(LogEntry log);
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/logs/ResourceLogsAdapter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/logs/ResourceLogsAdapter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.logs;
+
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.logs.v1.InstrumentationLibraryLogs;
+import io.opentelemetry.proto.logs.v1.ResourceLogs;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/** Protobuf converter. Turns a LogEntry into a protobuf LogRecord */
+public class ResourceLogsAdapter implements Function<List<LogEntry>, ResourceLogs> {
+
+  private final InstrumentationLibraryLogsAdapter logsAdapter;
+  private final List<KeyValue> resourceAttributes;
+
+  public ResourceLogsAdapter(InstrumentationLibraryLogsAdapter logsAdapter, Resource resource) {
+    this(logsAdapter, convertResourceAttributes(resource));
+  }
+
+  ResourceLogsAdapter(
+      InstrumentationLibraryLogsAdapter logsAdapter, List<KeyValue> resourceAttributes) {
+    this.logsAdapter = logsAdapter;
+    this.resourceAttributes = resourceAttributes;
+  }
+
+  private static List<KeyValue> convertResourceAttributes(Resource resource) {
+    return resource.getAttributes().asMap().entrySet().stream()
+        .map(kv -> CommonAdapter.toProtoAttribute(kv.getKey(), kv.getValue()))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public ResourceLogs apply(List<LogEntry> logEntry) {
+    InstrumentationLibraryLogs instrumentationLibraryLogs = logsAdapter.apply(logEntry);
+    io.opentelemetry.proto.resource.v1.Resource protoResource =
+        io.opentelemetry.proto.resource.v1.Resource.newBuilder()
+            .addAllAttributes(resourceAttributes)
+            .build();
+    return ResourceLogs.newBuilder()
+        .setResource(protoResource)
+        .addInstrumentationLibraryLogs(instrumentationLibraryLogs)
+        .build();
+  }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/logs/WatchdogTimer.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/logs/WatchdogTimer.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.logs;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+
+/**
+ * A timer that invokes a callback at an interval, unless the reset() method is called. This class
+ * is thread safe.
+ */
+class WatchdogTimer {
+
+  private final ScheduledExecutorService threadPool = Executors.newScheduledThreadPool(1);
+  private final Duration interval;
+  private final Runnable callback;
+  private final Object lock = new Object();
+  private ScheduledFuture<?> future;
+
+  WatchdogTimer(Duration interval, Runnable callback) {
+    this.interval = interval;
+    this.callback = callback;
+  }
+
+  void start() {
+    synchronized (lock) {
+      if (future != null) {
+        throw new IllegalStateException("Already started");
+      }
+      reschedule();
+    }
+  }
+
+  void reset() {
+    synchronized (lock) {
+      if (future == null) {
+        throw new IllegalStateException("Not started");
+      }
+      future.cancel(false);
+      reschedule();
+    }
+  }
+
+  void stop() {
+    synchronized (lock) {
+      if (future == null) {
+        throw new IllegalStateException("Not started");
+      }
+      future.cancel(false);
+      future = null;
+      threadPool.shutdownNow();
+    }
+  }
+
+  private void reschedule() {
+    future =
+        threadPool.scheduleAtFixedRate(
+            callback, interval.toMillis(), interval.toMillis(), MILLISECONDS);
+  }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
@@ -90,7 +90,8 @@ public class JfrActivator implements ComponentInstaller {
     LogsExporter logsExporter = buildExporter();
     Consumer<List<LogEntry>> exportAction = logsExporter::export;
     BatchingLogsProcessor batchingLogsProcessor =
-        new BatchingLogsProcessor(Duration.ofSeconds(10), 5000, exportAction);
+        new BatchingLogsProcessor(Duration.ofSeconds(10), 250, exportAction);
+    batchingLogsProcessor.start();
     StackToSpanLinkageProcessor processor =
         new StackToSpanLinkageProcessor(logEntryCreator, batchingLogsProcessor);
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/LogEntryCreator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/LogEntryCreator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SOURCE_EVENT_NAME;
+import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SOURCE_EVENT_PERIOD;
+
+import com.splunk.opentelemetry.logs.LogEntry;
+import com.splunk.opentelemetry.profiler.context.StackToSpanLinkage;
+import io.opentelemetry.api.common.Attributes;
+import java.util.function.Function;
+
+/** Turns a linked stack into a new LogEntry instance */
+public class LogEntryCreator implements Function<StackToSpanLinkage, LogEntry> {
+
+  static final String PROFILING_SOURCE = "otel.profiling";
+
+  @Override
+  public LogEntry apply(StackToSpanLinkage linkedStack) {
+    Attributes attributes = buildAttributes(linkedStack);
+    return LogEntry.builder()
+        .name(PROFILING_SOURCE)
+        .time(linkedStack.getTime())
+        .body(linkedStack.getRawStack())
+        .traceId(linkedStack.getTraceId())
+        .spanId(linkedStack.getSpanId())
+        .attributes(attributes)
+        .build();
+  }
+
+  private Attributes buildAttributes(StackToSpanLinkage stackToSpanLinkage) {
+    String sourceEvent = stackToSpanLinkage.getSourceEventName();
+    String eventPeriodMs = "tbd";
+    return Attributes.of(
+        SOURCE_EVENT_NAME, sourceEvent,
+        SOURCE_EVENT_PERIOD, eventPeriodMs);
+  }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/ProfilingSemanticAttributes.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/ProfilingSemanticAttributes.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+import io.opentelemetry.api.common.AttributeKey;
+
+public class ProfilingSemanticAttributes {
+
+  /** The name of the originating event that generated this profiling event */
+  public static final AttributeKey<String> SOURCE_EVENT_NAME = stringKey("source.event.name");
+
+  /** The period of the source event, in ms. */
+  public static final AttributeKey<String> SOURCE_EVENT_PERIOD = stringKey("source.event.period");
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/StackToSpanLinkageProcessor.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/StackToSpanLinkageProcessor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import com.splunk.opentelemetry.logs.BatchingLogsProcessor;
+import com.splunk.opentelemetry.logs.LogEntry;
+import com.splunk.opentelemetry.profiler.context.StackToSpanLinkage;
+import java.util.function.Consumer;
+
+/**
+ * Glue helper to turn a linked stack into an otel LogEntry instance and pass it to the logs
+ * processor.
+ */
+public class StackToSpanLinkageProcessor implements Consumer<StackToSpanLinkage> {
+  private final LogEntryCreator logEntryCreator;
+  private final BatchingLogsProcessor processor;
+
+  public StackToSpanLinkageProcessor(
+      LogEntryCreator logEntryCreator, BatchingLogsProcessor processor) {
+    this.logEntryCreator = logEntryCreator;
+    this.processor = processor;
+  }
+
+  @Override
+  public void accept(StackToSpanLinkage stackToSpanLinkage) {
+    LogEntry log = logEntryCreator.apply(stackToSpanLinkage);
+    processor.log(log);
+  }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/SpanContextualizer.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/SpanContextualizer.java
@@ -19,12 +19,12 @@ package com.splunk.opentelemetry.profiler.context;
 import static com.splunk.opentelemetry.profiler.context.StackDescriptorLineParser.CANT_PARSE_THREAD_ID;
 
 import com.splunk.opentelemetry.profiler.events.ContextAttached;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import jdk.jfr.consumer.RecordedEvent;
-import jdk.jfr.consumer.RecordedThread;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,27 +53,27 @@ public class SpanContextualizer {
   }
 
   /** Parses thread info from the raw stack string and links it to a span (if available). */
-  public StackToSpanLinkage link(String rawStack) {
+  public StackToSpanLinkage link(Instant time, String rawStack) {
     List<String> frames = Arrays.asList(lineSplitter.split(rawStack));
     if (frames.size() < 2) {
       // Many GC and other VM threads don't actually have a stack...
-      return StackToSpanLinkage.withoutLinkage(rawStack);
+      return StackToSpanLinkage.withoutLinkage(time, rawStack);
     }
     long threadId = descriptorParser.parseThreadId(frames.get(0));
     if (threadId == CANT_PARSE_THREAD_ID) {
-      return StackToSpanLinkage.withoutLinkage(rawStack);
+      return StackToSpanLinkage.withoutLinkage(time, rawStack);
     }
-    return link(rawStack, threadId);
+    return link(time, rawStack, threadId);
   }
 
   /** Links the raw stack with the span info for the given thread. */
-  StackToSpanLinkage link(String rawStack, long threadId) {
+  StackToSpanLinkage link(Instant time, String rawStack, long threadId) {
     List<SpanLinkage> inFlightSpansForThisThread =
         threadContextTracker.getInFlightSpansForThread(threadId);
 
     if (inFlightSpansForThisThread.isEmpty()) {
       // We don't know about any in-flight spans for this stack
-      return StackToSpanLinkage.withoutLinkage(rawStack);
+      return StackToSpanLinkage.withoutLinkage(time, rawStack);
     }
 
     // This thread has a span happening, augment with span details
@@ -91,22 +91,20 @@ public class SpanContextualizer {
               .collect(Collectors.joining(" ")));
     }
     SpanLinkage spanLinkage = inFlightSpansForThisThread.get(inFlightSpansForThisThread.size() - 1);
-    return new StackToSpanLinkage(rawStack, spanLinkage);
+    return new StackToSpanLinkage(time, rawStack, spanLinkage);
   }
 
   private void threadContextStarting(RecordedEvent event) {
     String spanId = event.getString("spanId");
     String traceId = event.getString("traceId");
-    RecordedThread thread = event.getThread();
-    long threadId = thread.getJavaThreadId();
     logger.debug(
         "SPAN THREAD CONTEXT START : [{}] {} {} at {}",
-        threadId,
+        event.getThread().getJavaThreadId(),
         traceId,
         spanId,
         event.getStartTime());
 
-    SpanLinkage linkage = new SpanLinkage(spanId, traceId, thread);
+    SpanLinkage linkage = new SpanLinkage(traceId, spanId, event);
 
     threadContextTracker.addLinkage(linkage);
   }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/SpanLinkage.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/SpanLinkage.java
@@ -26,7 +26,7 @@ public class SpanLinkage {
 
   @Nullable private final String spanId;
   @Nullable private final String traceId;
-  private final RecordedEvent recordedEvent;
+  @Nullable private final RecordedEvent recordedEvent;
 
   public SpanLinkage(String traceId, String spanId, RecordedEvent recordedEvent) {
     this.spanId = spanId;
@@ -43,11 +43,11 @@ public class SpanLinkage {
   }
 
   RecordedThread getRecordedThread() {
-    return recordedEvent.getThread();
+    return recordedEvent == null ? null : recordedEvent.getThread();
   }
 
   Long getThreadId() {
-    return getRecordedThread().getJavaThreadId();
+    return recordedEvent == null ? Long.MIN_VALUE : getRecordedThread().getJavaThreadId();
   }
 
   boolean matches(String traceId, String spanId) {
@@ -58,6 +58,6 @@ public class SpanLinkage {
   }
 
   public String getSourceEventName() {
-    return recordedEvent.getEventType().getName();
+    return recordedEvent == null ? null : recordedEvent.getEventType().getName();
   }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/SpanLinkage.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/SpanLinkage.java
@@ -16,20 +16,22 @@
 
 package com.splunk.opentelemetry.profiler.context;
 
+import javax.annotation.Nullable;
+import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordedThread;
 
-class SpanLinkage {
+public class SpanLinkage {
 
-  static final SpanLinkage NONE = new SpanLinkage(null, null, null);
+  public static final SpanLinkage NONE = new SpanLinkage(null, null, null);
 
-  private final String spanId;
-  private final String traceId;
-  private final RecordedThread recordedThread;
+  @Nullable private final String spanId;
+  @Nullable private final String traceId;
+  private final RecordedEvent recordedEvent;
 
-  SpanLinkage(String spanId, String traceId, RecordedThread recordedThread) {
+  public SpanLinkage(String traceId, String spanId, RecordedEvent recordedEvent) {
     this.spanId = spanId;
     this.traceId = traceId;
-    this.recordedThread = recordedThread;
+    this.recordedEvent = recordedEvent;
   }
 
   String getSpanId() {
@@ -41,11 +43,11 @@ class SpanLinkage {
   }
 
   RecordedThread getRecordedThread() {
-    return recordedThread;
+    return recordedEvent.getThread();
   }
 
   Long getThreadId() {
-    return recordedThread.getJavaThreadId();
+    return getRecordedThread().getJavaThreadId();
   }
 
   boolean matches(String traceId, String spanId) {
@@ -53,5 +55,9 @@ class SpanLinkage {
         && this.traceId.equals(traceId)
         && this.spanId != null
         && this.spanId.equals(spanId);
+  }
+
+  public String getSourceEventName() {
+    return recordedEvent.getEventType().getName();
   }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/StackToSpanLinkage.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/StackToSpanLinkage.java
@@ -16,20 +16,27 @@
 
 package com.splunk.opentelemetry.profiler.context;
 
+import java.time.Instant;
 import jdk.jfr.consumer.RecordedThread;
 
 /** A wrapper for a RecordedEvent that may or may not have accompanying span information. */
 public class StackToSpanLinkage {
+  private final Instant time;
   private final String rawStack;
   private final SpanLinkage spanLinkage;
 
-  StackToSpanLinkage(String rawStack, SpanLinkage spanLinkage) {
+  public StackToSpanLinkage(Instant time, String rawStack, SpanLinkage spanLinkage) {
+    this.time = time;
     this.rawStack = rawStack;
     this.spanLinkage = spanLinkage;
   }
 
   public boolean hasSpanInfo() {
     return getSpanId() != null;
+  }
+
+  public Instant getTime() {
+    return time;
   }
 
   public String getRawStack() {
@@ -48,7 +55,11 @@ public class StackToSpanLinkage {
     return spanLinkage.getRecordedThread();
   }
 
-  static StackToSpanLinkage withoutLinkage(String rawStack) {
-    return new StackToSpanLinkage(rawStack, SpanLinkage.NONE);
+  public String getSourceEventName() {
+    return spanLinkage.getSourceEventName();
+  }
+
+  static StackToSpanLinkage withoutLinkage(Instant time, String rawStack) {
+    return new StackToSpanLinkage(time, rawStack, SpanLinkage.NONE);
   }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/logs/BatchingLogsProcessorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/logs/BatchingLogsProcessorTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.logs;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BatchingLogsProcessorTest {
+
+  LogEntry log1, log2, log3;
+
+  @BeforeEach
+  void setup() {
+    log1 =
+        LogEntry.builder()
+            .attributes(Attributes.of(AttributeKey.stringKey("one"), "one"))
+            .body("foo")
+            .build();
+    log2 =
+        LogEntry.builder()
+            .attributes(Attributes.of(AttributeKey.stringKey("two"), "two"))
+            .body("bar")
+            .build();
+    log3 =
+        LogEntry.builder()
+            .attributes(Attributes.of(AttributeKey.stringKey("three"), "three"))
+            .body("baz")
+            .build();
+  }
+
+  @Test
+  void testSimpleActionWhenSizeReached() {
+    List<LogEntry> seen = new ArrayList<>();
+    Consumer<List<LogEntry>> action = seen::addAll;
+    BatchingLogsProcessor processor = new BatchingLogsProcessor(Duration.ofHours(15), 3, action);
+    processor.start();
+    processor.log(log1);
+    assertTrue(seen.isEmpty());
+    processor.log(log2);
+    assertTrue(seen.isEmpty());
+    processor.log(log3);
+    assertEquals(Arrays.asList(log1, log2, log3), seen);
+  }
+
+  @Test
+  void testSimpleActionWhenTimeReached() throws Exception {
+    List<LogEntry> seen = new ArrayList<>();
+    CountDownLatch latch = new CountDownLatch(1);
+    Consumer<List<LogEntry>> action =
+        logs -> {
+          seen.addAll(logs);
+          latch.countDown();
+        };
+    BatchingLogsProcessor processor =
+        new BatchingLogsProcessor(Duration.ofMillis(50), 3000, action);
+    processor.start();
+    processor.log(log1);
+    processor.log(log2);
+    processor.log(log3);
+    assertTrue(latch.await(5, SECONDS));
+    assertEquals(Arrays.asList(log1, log2, log3), seen);
+  }
+
+  @Test
+  void testActionNotCalledWhenEmptyAfterTime() throws Exception {
+    List<LogEntry> seen = new ArrayList<>();
+    CountDownLatch latch = new CountDownLatch(1);
+    Consumer<List<LogEntry>> action =
+        logs -> {
+          seen.addAll(logs);
+          latch.countDown();
+        };
+    BatchingLogsProcessor processor = new BatchingLogsProcessor(Duration.ofMillis(1), 3000, action);
+    processor.start();
+    assertFalse(latch.await(1, SECONDS));
+    assertTrue(seen.isEmpty());
+  }
+
+  @Test
+  void testStopDoesAction() {
+    List<LogEntry> seen = new ArrayList<>();
+    CountDownLatch latch = new CountDownLatch(1);
+    Consumer<List<LogEntry>> action =
+        logs -> {
+          seen.addAll(logs);
+          latch.countDown();
+        };
+    BatchingLogsProcessor processor =
+        new BatchingLogsProcessor(Duration.ofSeconds(60), 3000, action);
+    processor.start();
+    processor.log(log1);
+    processor.log(log2);
+    processor.stop();
+    assertEquals(Arrays.asList(log1, log2), seen);
+  }
+
+  @Test
+  void testStopBeforeStart() {
+    Consumer<List<LogEntry>> action = logs -> {};
+    BatchingLogsProcessor processor =
+        new BatchingLogsProcessor(Duration.ofSeconds(60), 3000, action);
+    assertThrows(IllegalStateException.class, processor::stop);
+  }
+
+  @Test
+  void testMultipleStarts() {
+    Consumer<List<LogEntry>> action = logs -> {};
+    BatchingLogsProcessor processor =
+        new BatchingLogsProcessor(Duration.ofSeconds(60), 3000, action);
+    processor.start();
+    assertThrows(IllegalStateException.class, processor::start);
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/logs/InstrumentationLibraryLogEntryAdapterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/logs/InstrumentationLibraryLogEntryAdapterTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.logs;
+
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_METHOD;
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.proto.logs.v1.InstrumentationLibraryLogs;
+import io.opentelemetry.proto.logs.v1.LogRecord;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class InstrumentationLibraryLogEntryAdapterTest {
+
+  @Test
+  void testApply() {
+    Instant now = Instant.now();
+    LogEntry log1 =
+        LogEntry.builder()
+            .time(now.plus(0, MINUTES))
+            .attributes(Attributes.of(HTTP_METHOD, "get"))
+            .body("log1")
+            .build();
+    LogEntry log2 =
+        LogEntry.builder()
+            .time(now.plus(1, MINUTES))
+            .attributes(Attributes.of(HTTP_METHOD, "put"))
+            .body("log2")
+            .build();
+    LogEntry log3 =
+        LogEntry.builder()
+            .time(now.plus(2, MINUTES))
+            .attributes(Attributes.of(HTTP_METHOD, "patch"))
+            .body("log3")
+            .build();
+    List<LogEntry> logsEntries = Arrays.asList(log1, log2, log3);
+    LogEntryAdapter logEntryAdapter = new LogEntryAdapter();
+
+    InstrumentationLibraryLogsAdapter adapter =
+        InstrumentationLibraryLogsAdapter.builder()
+            .instrumentationName("otel-profiling")
+            .instrumentationVersion("1.2.3")
+            .logEntryAdapter(logEntryAdapter)
+            .build();
+    InstrumentationLibraryLogs result = adapter.apply(logsEntries);
+
+    List<LogRecord> resultLogs = result.getLogsList();
+    assertEquals("otel-profiling", result.getInstrumentationLibrary().getName());
+    assertEquals("1.2.3", result.getInstrumentationLibrary().getVersion());
+    assertEquals(3, resultLogs.size());
+    assertLog(resultLogs.get(0), now.plus(0, MINUTES), "get", "log1");
+    assertLog(resultLogs.get(1), now.plus(1, MINUTES), "put", "log2");
+    assertLog(resultLogs.get(2), now.plus(2, MINUTES), "patch", "log3");
+  }
+
+  private void assertLog(LogRecord logRecord, Instant time, String method, String body) {
+    assertEquals(time.toEpochMilli() * 1_000_000, logRecord.getTimeUnixNano());
+    assertEquals(HTTP_METHOD.getKey(), logRecord.getAttributesList().get(0).getKey());
+    assertEquals(method, logRecord.getAttributesList().get(0).getValue().getStringValue());
+    assertEquals(body, logRecord.getBody().getStringValue());
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/logs/LogEntryAdapterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/logs/LogEntryAdapterTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.logs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.logs.v1.LogRecord;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class LogEntryAdapterTest {
+
+  @Test
+  void testAdapt() {
+    Attributes attributes =
+        Attributes.of(AttributeKey.stringKey("origination"), "MyClass.myMethod(line:123)");
+    Instant time = Instant.now();
+    String body = "I am a log message!";
+    LogEntry entry = basicBuilder(attributes, time, body).build();
+
+    LogEntryAdapter adapter = new LogEntryAdapter();
+    LogRecord result = adapter.apply(entry);
+    assertEquals(body, result.getBody().getStringValue());
+
+    List<KeyValue> resultAttrs = result.getAttributesList();
+    Optional<KeyValue> origination =
+        resultAttrs.stream().filter(kv -> kv.getKey().equals("origination")).findFirst();
+
+    assertEquals(entry.getName(), result.getName());
+    assertEquals(entry.getTime().toEpochMilli() * 1_000_000L, result.getTimeUnixNano());
+    assertEquals(entry.getTraceId(), result.getTraceId().toStringUtf8());
+    assertEquals(entry.getSpanId(), result.getSpanId().toStringUtf8());
+    assertEquals(entry.getBody(), result.getBody().getStringValue());
+    assertEquals("MyClass.myMethod(line:123)", origination.get().getValue().getStringValue());
+  }
+
+  @Test
+  void testNullNameIsValid() {
+    Attributes attributes =
+        Attributes.of(AttributeKey.stringKey("origination"), "MyClass.myMethod(line:123)");
+    Instant time = Instant.now();
+    LogEntry entry = basicBuilder(attributes, time, "I am a log message!").name(null).build();
+
+    LogEntryAdapter adapter = new LogEntryAdapter();
+    LogRecord result = adapter.apply(entry);
+    assertEquals("", result.getName());
+  }
+
+  private LogEntry.Builder basicBuilder(Attributes attributes, Instant time, String body) {
+    return LogEntry.builder()
+        .name("__LOG__")
+        .time(time)
+        .body(body)
+        .traceId("abc123")
+        .spanId("zzzxxxyyy99")
+        .attributes(attributes);
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/logs/ResourceLogEntryAdapterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/logs/ResourceLogEntryAdapterTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.logs;
+
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.ENDUSER_ID;
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.logs.v1.InstrumentationLibraryLogs;
+import io.opentelemetry.proto.logs.v1.LogRecord;
+import io.opentelemetry.proto.logs.v1.ResourceLogs;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ResourceLogEntryAdapterTest {
+
+  @Test
+  void testApply() {
+    Instant now = Instant.now();
+    LogEntry log1 =
+        LogEntry.builder()
+            .time(now.plus(0, SECONDS))
+            .attributes(Attributes.of(ENDUSER_ID, "jimmy"))
+            .body("test log 1")
+            .build();
+    LogEntry log2 =
+        LogEntry.builder()
+            .time(now.plus(1, SECONDS))
+            .attributes(Attributes.of(ENDUSER_ID, "sally"))
+            .body("test log 2")
+            .build();
+    LogEntry log3 =
+        LogEntry.builder()
+            .time(now.plus(2, SECONDS))
+            .attributes(Attributes.of(ENDUSER_ID, "ward"))
+            .body("test log 3")
+            .build();
+    List<LogEntry> sourceLogs = Arrays.asList(log1, log2, log3);
+    LogEntryAdapter logEntryAdapter = new LogEntryAdapter();
+    InstrumentationLibraryLogsAdapter instLogsAdapter =
+        InstrumentationLibraryLogsAdapter.builder()
+            .logEntryAdapter(logEntryAdapter)
+            .instrumentationName("a")
+            .instrumentationVersion("b")
+            .build();
+    List<KeyValue> resourceAttrs =
+        Arrays.asList(kv("service.name", "zoom.vroom"), kv("environment.name", "staging"));
+    ResourceLogsAdapter adapter = new ResourceLogsAdapter(instLogsAdapter, resourceAttrs);
+    ResourceLogs result = adapter.apply(sourceLogs);
+
+    List<KeyValue> resultResourceAttrs = result.getResource().getAttributesList();
+    assertEquals(2, resultResourceAttrs.size());
+    assertEquals("service.name", resultResourceAttrs.get(0).getKey());
+    assertEquals("zoom.vroom", resultResourceAttrs.get(0).getValue().getStringValue());
+    assertEquals("environment.name", resultResourceAttrs.get(1).getKey());
+    assertEquals("staging", resultResourceAttrs.get(1).getValue().getStringValue());
+    List<InstrumentationLibraryLogs> resultInstLogsList =
+        result.getInstrumentationLibraryLogsList();
+    assertEquals(1, resultInstLogsList.size());
+    List<LogRecord> logRecords = resultInstLogsList.get(0).getLogsList();
+    assertEquals(3, logRecords.size());
+
+    assertLog(logRecords.get(0), now, "jimmy", "test log 1");
+    assertLog(logRecords.get(1), now.plus(1, SECONDS), "sally", "test log 2");
+    assertLog(logRecords.get(2), now.plus(2, SECONDS), "ward", "test log 3");
+  }
+
+  private void assertLog(LogRecord logRecord, Instant time, String username, String body) {
+    assertEquals(time.toEpochMilli() * 1_000_000L, logRecord.getTimeUnixNano());
+    assertEquals(body, logRecord.getBody().getStringValue());
+    assertEquals(ENDUSER_ID.getKey(), logRecord.getAttributes(0).getKey());
+    assertEquals(username, logRecord.getAttributes(0).getValue().getStringValue());
+  }
+
+  private KeyValue kv(String k, String v) {
+    return KeyValue.newBuilder()
+        .setKey(k)
+        .setValue(AnyValue.newBuilder().setStringValue(v).build())
+        .build();
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/logs/WatchdogTimerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/logs/WatchdogTimerTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.logs;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+class WatchdogTimerTest {
+
+  @Test
+  void testSimpleWatchdog() throws Exception {
+    CountDownLatch latch = new CountDownLatch(5);
+    Runnable cb = latch::countDown;
+    WatchdogTimer watchdog = new WatchdogTimer(Duration.ofMillis(10), cb);
+    watchdog.start();
+    assertTrue(latch.await(5, TimeUnit.SECONDS));
+  }
+
+  @Test
+  void testCannotStartTwice() {
+    Runnable cb = () -> {};
+    WatchdogTimer watchdog = new WatchdogTimer(Duration.ofMillis(10), cb);
+    watchdog.start();
+    assertThrows(IllegalStateException.class, watchdog::start);
+  }
+
+  @Test
+  void testMultipleResetAndStop() throws Exception {
+    AtomicBoolean run = new AtomicBoolean(false);
+    Runnable cb =
+        () -> {
+          run.set(true);
+        };
+    WatchdogTimer watchdog = new WatchdogTimer(Duration.ofMillis(50), cb);
+    watchdog.start();
+    long start = System.currentTimeMillis();
+    while (System.currentTimeMillis() - start < 250) {
+      watchdog.reset();
+      TimeUnit.MILLISECONDS.sleep(10);
+    }
+    watchdog.stop();
+    TimeUnit.MILLISECONDS.sleep(150);
+    assertFalse(run.get());
+  }
+
+  @Test
+  void testResetBeforeStart() {
+    Runnable cb = () -> {};
+    WatchdogTimer watchdog = new WatchdogTimer(Duration.ofMillis(10), cb);
+    assertThrows(IllegalStateException.class, watchdog::reset);
+  }
+
+  @Test
+  void testStopBeforeStart() {
+    Runnable cb = () -> {};
+    WatchdogTimer watchdog = new WatchdogTimer(Duration.ofMillis(10), cb);
+    assertThrows(IllegalStateException.class, watchdog::stop);
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/LogEntryCreatorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/LogEntryCreatorTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import static com.splunk.opentelemetry.profiler.LogEntryCreator.PROFILING_SOURCE;
+import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SOURCE_EVENT_NAME;
+import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SOURCE_EVENT_PERIOD;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.splunk.opentelemetry.logs.LogEntry;
+import com.splunk.opentelemetry.profiler.context.SpanLinkage;
+import com.splunk.opentelemetry.profiler.context.StackToSpanLinkage;
+import io.opentelemetry.api.common.Attributes;
+import java.time.Instant;
+import jdk.jfr.EventType;
+import jdk.jfr.consumer.RecordedEvent;
+import org.junit.jupiter.api.Test;
+
+class LogEntryCreatorTest {
+
+  @Test
+  void testCreate() {
+    Instant time = Instant.now();
+    String stack = "the.stack";
+
+    String spanId = "zzzyyyzzz";
+    String traceId = "abc123";
+
+    RecordedEvent event = mock(RecordedEvent.class);
+    EventType eventType = mock(EventType.class);
+
+    when(event.getEventType()).thenReturn(eventType);
+    when(eventType.getName()).thenReturn("GoodEventHere");
+
+    SpanLinkage linkage = new SpanLinkage(traceId, spanId, event);
+    Attributes attributes =
+        Attributes.of(
+            SOURCE_EVENT_NAME, "GoodEventHere",
+            SOURCE_EVENT_PERIOD, "tbd");
+    LogEntry expected =
+        LogEntry.builder()
+            .traceId(traceId)
+            .spanId(spanId)
+            .name(PROFILING_SOURCE)
+            .body(stack)
+            .time(time)
+            .attributes(attributes)
+            .build();
+
+    StackToSpanLinkage linkedSpan = new StackToSpanLinkage(time, stack, linkage);
+
+    LogEntryCreator creator = new LogEntryCreator();
+    LogEntry result = creator.apply(linkedSpan);
+    assertEquals(expected, result);
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackToSpanLinkageProcessorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackToSpanLinkageProcessorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.splunk.opentelemetry.logs.BatchingLogsProcessor;
+import com.splunk.opentelemetry.logs.LogEntry;
+import com.splunk.opentelemetry.profiler.context.SpanLinkage;
+import com.splunk.opentelemetry.profiler.context.StackToSpanLinkage;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class StackToSpanLinkageProcessorTest {
+
+  @Test
+  void testProcessor() {
+    Instant time = Instant.now();
+    StackToSpanLinkage linkedSpan = new StackToSpanLinkage(time, "some stack", SpanLinkage.NONE);
+    LogEntryCreator logCreator = mock(LogEntryCreator.class);
+    BatchingLogsProcessor exportProcessor = mock(BatchingLogsProcessor.class);
+
+    LogEntry log = LogEntry.builder().body("the.body").build();
+    when(logCreator.apply(linkedSpan)).thenReturn(log);
+
+    StackToSpanLinkageProcessor processor =
+        new StackToSpanLinkageProcessor(logCreator, exportProcessor);
+
+    processor.accept(linkedSpan);
+    verify(exportProcessor).log(log);
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ThreadDumpProcessorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ThreadDumpProcessorTest.java
@@ -27,6 +27,7 @@ import com.splunk.opentelemetry.profiler.context.StackToSpanLinkage;
 import com.splunk.opentelemetry.profiler.events.ContextAttached;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 import jdk.jfr.EventType;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordedThread;
@@ -57,13 +58,8 @@ class ThreadDumpProcessorTest {
     when(event.getString("result")).thenReturn(WALL_OF_STACKS);
 
     List<StackToSpanLinkage> results = new ArrayList<>();
-    ThreadDumpProcessor processor =
-        new ThreadDumpProcessor(contextualizer) {
-          @Override
-          void export(StackToSpanLinkage linkedStack) {
-            results.add(linkedStack);
-          }
-        };
+    Consumer<StackToSpanLinkage> exportProcessor = results::add;
+    ThreadDumpProcessor processor = new ThreadDumpProcessor(contextualizer, exportProcessor);
 
     processor.accept(event);
     assertEquals(3, results.size());

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/context/SpanContextualizerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/context/SpanContextualizerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.splunk.opentelemetry.profiler.events.ContextAttached;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -37,6 +38,7 @@ class SpanContextualizerTest {
   private final String spanId = "abc123";
   private final String traceId = "23489uasdpfoiajsdfph23oij";
   private final String rawStack = "raw is raw";
+  private final Instant time = Instant.now();
 
   @Test
   void testSimplePath() {
@@ -274,14 +276,14 @@ class SpanContextualizerTest {
   }
 
   private void assertLinkage(SpanContextualizer testClass, Events events, String stack) {
-    StackToSpanLinkage result = testClass.link(stack, events.threadId);
+    StackToSpanLinkage result = testClass.link(time, stack, events.threadId);
     assertEquals(events.spanId, result.getSpanId());
     assertEquals(traceId, result.getTraceId());
     assertEquals(stack, result.getRawStack());
   }
 
   private void assertNoLinkage(SpanContextualizer testClass, Events events) {
-    StackToSpanLinkage result = testClass.link(rawStack, events.threadId);
+    StackToSpanLinkage result = testClass.link(time, rawStack, events.threadId);
     assertNull(result.getSpanId());
   }
 

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/context/ThreadContextTrackerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/context/ThreadContextTrackerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordedThread;
 import org.junit.jupiter.api.Test;
 
@@ -71,7 +72,9 @@ class ThreadContextTrackerTest {
 
   private SpanLinkage makeLinkage(String spanId, long threadId) {
     RecordedThread thread = mock(RecordedThread.class);
+    RecordedEvent event = mock(RecordedEvent.class);
+    when(event.getThread()).thenReturn(thread);
     when(thread.getJavaThreadId()).thenReturn(threadId);
-    return new SpanLinkage(spanId, traceId, thread);
+    return new SpanLinkage(traceId, spanId, event);
   }
 }


### PR DESCRIPTION
This builds up the foundation of very rudimentary logs support in otel. It includes a very simple data model and a LogsProcessor and LogsExporter interfaces. A simple `BatchingLogsProcessor` implements `LogsProcessor` and will pass batches of `LogEntry` to an exporter when a size or time is reached.

This also includes some adapters in order to convert from the otel data model (`LogEntry`) to the protobuf model.