### PR TITLE
Add internal_root_off sampler

### DIFF
--- a/custom/src/main/java/com/splunk/opentelemetry/InternalRootOffSampler.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/InternalRootOffSampler.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
+import io.opentelemetry.sdk.trace.samplers.SamplingResult;
+import java.util.List;
+
+/**
+ * This sampler drops span of INTERNAL kind without parent. The goal is to silence traces with
+ * INTERNAL root spans, because in most cases those traces are created by scheduled jobs and are of
+ * no interest.
+ *
+ * <p>NB! Currently this sampler will drop even spans/traces created by known scheduled
+ * instrumentations such as Spring Scheduling. It cannot be done until OpenTelemetry spec is
+ * updated, see https://github.com/open-telemetry/opentelemetry-specification/issues/1588. For the
+ * same reason this sampler will drop INTERNAL spans created by user manual instrumentations.
+ */
+public class InternalRootOffSampler implements Sampler {
+
+  public static final SamplingResult RECORD =
+      SamplingResult.create(SamplingDecision.RECORD_AND_SAMPLE);
+  public static final SamplingResult DROP = SamplingResult.create(SamplingDecision.DROP);
+
+  @Override
+  public SamplingResult shouldSample(
+      Context parentContext,
+      String traceId,
+      String name,
+      SpanKind spanKind,
+      Attributes attributes,
+      List<LinkData> parentLinks) {
+    SpanContext parentSpanContext = Span.fromContext(parentContext).getSpanContext();
+    if (!parentSpanContext.isValid()) {
+      if (spanKind == SpanKind.SERVER || spanKind == SpanKind.CONSUMER) {
+        return RECORD;
+      } else {
+        return DROP;
+      }
+    } else {
+      return parentSpanContext.isSampled() ? RECORD : DROP;
+    }
+  }
+
+  @Override
+  public String getDescription() {
+    return "InternalRootOffSampler";
+  }
+}

--- a/custom/src/main/java/com/splunk/opentelemetry/InternalRootOffSamplerProvider.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/InternalRootOffSamplerProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.sdk.autoconfigure.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurableSamplerProvider;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+
+@AutoService(ConfigurableSamplerProvider.class)
+public class InternalRootOffSamplerProvider implements ConfigurableSamplerProvider {
+  @Override
+  public Sampler createSampler(ConfigProperties config) {
+    return new InternalRootOffSampler();
+  }
+
+  @Override
+  public String getName() {
+    return "internal_root_off";
+  }
+}

--- a/custom/src/main/java/com/splunk/opentelemetry/SplunkConfiguration.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/SplunkConfiguration.java
@@ -43,6 +43,7 @@ public class SplunkConfiguration implements PropertySource {
     config.put("otel.instrumentation.spring-batch.enabled", "true");
     config.put("otel.instrumentation.spring-batch.item.enabled", "true");
 
+    config.put("otel.traces.sampler", "always_on");
     return config;
   }
 }

--- a/custom/src/main/java/com/splunk/opentelemetry/SplunkTracerProviderConfigurer.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/SplunkTracerProviderConfigurer.java
@@ -20,21 +20,18 @@ import com.google.auto.service.AutoService;
 import io.opentelemetry.sdk.autoconfigure.spi.SdkTracerProviderConfigurer;
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
 import io.opentelemetry.sdk.trace.SpanLimits;
-import io.opentelemetry.sdk.trace.samplers.Sampler;
 
 @AutoService(SdkTracerProviderConfigurer.class)
 public class SplunkTracerProviderConfigurer implements SdkTracerProviderConfigurer {
   @Override
   public void configure(SdkTracerProviderBuilder tracerProvider) {
-    tracerProvider
-        .setSampler(Sampler.alwaysOn())
-        .setSpanLimits(
-            SpanLimits.builder()
-                .setMaxNumberOfAttributes(Integer.MAX_VALUE)
-                .setMaxNumberOfEvents(Integer.MAX_VALUE)
-                .setMaxNumberOfLinks(1000)
-                .setMaxNumberOfAttributesPerEvent(Integer.MAX_VALUE)
-                .setMaxNumberOfAttributesPerLink(Integer.MAX_VALUE)
-                .build());
+    tracerProvider.setSpanLimits(
+        SpanLimits.builder()
+            .setMaxNumberOfAttributes(Integer.MAX_VALUE)
+            .setMaxNumberOfEvents(Integer.MAX_VALUE)
+            .setMaxNumberOfLinks(1000)
+            .setMaxNumberOfAttributesPerEvent(Integer.MAX_VALUE)
+            .setMaxNumberOfAttributesPerLink(Integer.MAX_VALUE)
+            .build());
   }
 }

--- a/custom/src/test/java/com/splunk/opentelemetry/InternalRootOffSamplerTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/InternalRootOffSamplerTest.java
@@ -1,0 +1,87 @@
+package com.splunk.opentelemetry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.IdGenerator;
+import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class InternalRootOffSamplerTest {
+  private final IdGenerator idsGenerator = IdGenerator.random();
+  private final String traceId = idsGenerator.generateTraceId();
+  private final String parentSpanId = idsGenerator.generateSpanId();
+  private final SpanContext sampledSpanContext =
+      SpanContext.create(traceId, parentSpanId, TraceFlags.getSampled(), TraceState.getDefault());
+  private final Context sampledParentContext = Context.root().with(Span.wrap(sampledSpanContext));
+  private final Context notSampledParentContext =
+      Context.root()
+          .with(
+              Span.wrap(
+                  SpanContext.create(
+                      traceId, parentSpanId, TraceFlags.getDefault(), TraceState.getDefault())));
+  private final Context invalidContext = Context.root().with(Span.getInvalid());
+
+  @Test
+  void shouldHonourParentDecision() {
+    InternalRootOffSampler sampler = new InternalRootOffSampler();
+
+    String traceId = idsGenerator.generateTraceId();
+    String spanId = idsGenerator.generateSpanId();
+    assertEquals(SamplingDecision.RECORD_AND_SAMPLE, sampler.shouldSample(sampledParentContext, traceId, spanId, SpanKind.INTERNAL, Attributes.empty(), Collections.emptyList()).getDecision());
+    assertEquals(SamplingDecision.DROP, sampler.shouldSample(notSampledParentContext, traceId, spanId, SpanKind.INTERNAL, Attributes.empty(), Collections.emptyList()).getDecision());
+  }
+
+  @Test
+  void shouldSampleServerRoot(){
+    InternalRootOffSampler sampler = new InternalRootOffSampler();
+
+    String traceId = idsGenerator.generateTraceId();
+    String spanId = idsGenerator.generateSpanId();
+    assertEquals(SamplingDecision.RECORD_AND_SAMPLE, sampler.shouldSample(invalidContext, traceId, spanId, SpanKind.SERVER, Attributes.empty(), Collections.emptyList()).getDecision());
+  }
+
+  @Test
+  void shouldSampleConsumerRoot(){
+    InternalRootOffSampler sampler = new InternalRootOffSampler();
+
+    String traceId = idsGenerator.generateTraceId();
+    String spanId = idsGenerator.generateSpanId();
+    assertEquals(SamplingDecision.RECORD_AND_SAMPLE, sampler.shouldSample(invalidContext, traceId, spanId, SpanKind.CONSUMER, Attributes.empty(), Collections.emptyList()).getDecision());
+  }
+
+  @Test
+  void shouldDropInternalRoot(){
+    InternalRootOffSampler sampler = new InternalRootOffSampler();
+
+    String traceId = idsGenerator.generateTraceId();
+    String spanId = idsGenerator.generateSpanId();
+    assertEquals(SamplingDecision.DROP, sampler.shouldSample(invalidContext, traceId, spanId, SpanKind.INTERNAL, Attributes.empty(), Collections.emptyList()).getDecision());
+  }
+
+  @Test
+  void shouldDropClientRoot(){
+    InternalRootOffSampler sampler = new InternalRootOffSampler();
+
+    String traceId = idsGenerator.generateTraceId();
+    String spanId = idsGenerator.generateSpanId();
+    assertEquals(SamplingDecision.DROP, sampler.shouldSample(invalidContext, traceId, spanId, SpanKind.CLIENT, Attributes.empty(), Collections.emptyList()).getDecision());
+  }
+
+  @Test
+  void shouldDropProducerRoot(){
+    InternalRootOffSampler sampler = new InternalRootOffSampler();
+
+    String traceId = idsGenerator.generateTraceId();
+    String spanId = idsGenerator.generateSpanId();
+    assertEquals(SamplingDecision.DROP, sampler.shouldSample(invalidContext, traceId, spanId, SpanKind.PRODUCER, Attributes.empty(), Collections.emptyList()).getDecision());
+  }
+
+}

--- a/custom/src/test/java/com/splunk/opentelemetry/InternalRootOffSamplerTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/InternalRootOffSamplerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.opentelemetry;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,53 +51,122 @@ class InternalRootOffSamplerTest {
 
     String traceId = idsGenerator.generateTraceId();
     String spanId = idsGenerator.generateSpanId();
-    assertEquals(SamplingDecision.RECORD_AND_SAMPLE, sampler.shouldSample(sampledParentContext, traceId, spanId, SpanKind.INTERNAL, Attributes.empty(), Collections.emptyList()).getDecision());
-    assertEquals(SamplingDecision.DROP, sampler.shouldSample(notSampledParentContext, traceId, spanId, SpanKind.INTERNAL, Attributes.empty(), Collections.emptyList()).getDecision());
+    assertEquals(
+        SamplingDecision.RECORD_AND_SAMPLE,
+        sampler
+            .shouldSample(
+                sampledParentContext,
+                traceId,
+                spanId,
+                SpanKind.INTERNAL,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision());
+    assertEquals(
+        SamplingDecision.DROP,
+        sampler
+            .shouldSample(
+                notSampledParentContext,
+                traceId,
+                spanId,
+                SpanKind.INTERNAL,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision());
   }
 
   @Test
-  void shouldSampleServerRoot(){
+  void shouldSampleServerRoot() {
     InternalRootOffSampler sampler = new InternalRootOffSampler();
 
     String traceId = idsGenerator.generateTraceId();
     String spanId = idsGenerator.generateSpanId();
-    assertEquals(SamplingDecision.RECORD_AND_SAMPLE, sampler.shouldSample(invalidContext, traceId, spanId, SpanKind.SERVER, Attributes.empty(), Collections.emptyList()).getDecision());
+    assertEquals(
+        SamplingDecision.RECORD_AND_SAMPLE,
+        sampler
+            .shouldSample(
+                invalidContext,
+                traceId,
+                spanId,
+                SpanKind.SERVER,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision());
   }
 
   @Test
-  void shouldSampleConsumerRoot(){
+  void shouldSampleConsumerRoot() {
     InternalRootOffSampler sampler = new InternalRootOffSampler();
 
     String traceId = idsGenerator.generateTraceId();
     String spanId = idsGenerator.generateSpanId();
-    assertEquals(SamplingDecision.RECORD_AND_SAMPLE, sampler.shouldSample(invalidContext, traceId, spanId, SpanKind.CONSUMER, Attributes.empty(), Collections.emptyList()).getDecision());
+    assertEquals(
+        SamplingDecision.RECORD_AND_SAMPLE,
+        sampler
+            .shouldSample(
+                invalidContext,
+                traceId,
+                spanId,
+                SpanKind.CONSUMER,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision());
   }
 
   @Test
-  void shouldDropInternalRoot(){
+  void shouldDropInternalRoot() {
     InternalRootOffSampler sampler = new InternalRootOffSampler();
 
     String traceId = idsGenerator.generateTraceId();
     String spanId = idsGenerator.generateSpanId();
-    assertEquals(SamplingDecision.DROP, sampler.shouldSample(invalidContext, traceId, spanId, SpanKind.INTERNAL, Attributes.empty(), Collections.emptyList()).getDecision());
+    assertEquals(
+        SamplingDecision.DROP,
+        sampler
+            .shouldSample(
+                invalidContext,
+                traceId,
+                spanId,
+                SpanKind.INTERNAL,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision());
   }
 
   @Test
-  void shouldDropClientRoot(){
+  void shouldDropClientRoot() {
     InternalRootOffSampler sampler = new InternalRootOffSampler();
 
     String traceId = idsGenerator.generateTraceId();
     String spanId = idsGenerator.generateSpanId();
-    assertEquals(SamplingDecision.DROP, sampler.shouldSample(invalidContext, traceId, spanId, SpanKind.CLIENT, Attributes.empty(), Collections.emptyList()).getDecision());
+    assertEquals(
+        SamplingDecision.DROP,
+        sampler
+            .shouldSample(
+                invalidContext,
+                traceId,
+                spanId,
+                SpanKind.CLIENT,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision());
   }
 
   @Test
-  void shouldDropProducerRoot(){
+  void shouldDropProducerRoot() {
     InternalRootOffSampler sampler = new InternalRootOffSampler();
 
     String traceId = idsGenerator.generateTraceId();
     String spanId = idsGenerator.generateSpanId();
-    assertEquals(SamplingDecision.DROP, sampler.shouldSample(invalidContext, traceId, spanId, SpanKind.PRODUCER, Attributes.empty(), Collections.emptyList()).getDecision());
+    assertEquals(
+        SamplingDecision.DROP,
+        sampler
+            .shouldSample(
+                invalidContext,
+                traceId,
+                spanId,
+                SpanKind.PRODUCER,
+                Attributes.empty(),
+                Collections.emptyList())
+            .getDecision());
   }
-
 }

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/AbstractTestContainerManager.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/AbstractTestContainerManager.java
@@ -39,6 +39,9 @@ public abstract class AbstractTestContainerManager implements TestContainerManag
     environment.put("SPLUNK_METRICS_EXPORT_INTERVAL", "1000");
     environment.put("SPLUNK_METRICS_ENDPOINT", "http://" + COLLECTOR_ALIAS + ":9943/v2/datapoint");
     environment.put("OTEL_RESOURCE_ATTRIBUTES", "service.name=smoke-test");
+    // This does not affect tests in any way but serves to verify that agent can actually load this
+    // sampler
+    environment.put("OTEL_TRACES_SAMPLER", "internal_root_off");
     return environment;
   }
 }


### PR DESCRIPTION
This is a POC sampler to gather feedback from customers. They can select this new sampler by providing `OTEL_TRACES_SAMPLER=internal_root_off` configuration option.