### PR TITLE
Smoke tests base image

### DIFF
--- a/.github/publish-profiling-base-petclinic.yml
+++ b/.github/publish-profiling-base-petclinic.yml
@@ -1,0 +1,25 @@
+name: publish-profiling-base-petclinic-image
+on: workflow_dispatch
+jobs:
+  push_to_registry:
+    name: publish custom spring-petclinic base image for profiling
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: check out the repo
+        uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: push to gh packages
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          file: testing/profiler-tests/Dockerfile
+          tags: ghcr.io/signalfx/splunk-otel-java/profiling-petclinic-base:latest

--- a/.github/publish-profiling-base-petclinic.yml
+++ b/.github/publish-profiling-base-petclinic.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: check out the repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: docker/setup-buildx-action@v1
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1

--- a/testing/profiler-tests/Dockerfile
+++ b/testing/profiler-tests/Dockerfile
@@ -6,7 +6,7 @@ RUN apt update && apt install -y git
 RUN git clone https://github.com/spring-petclinic/spring-petclinic-rest.git /src
 
 WORKDIR /src
-RUN ./mvnw package
+RUN ./mvnw -Dmaven.test.skip=true package
 
 RUN mkdir /app && cp /src/target/spring-petclinic-rest*.jar /app/spring-petclinic-rest.jar
 WORKDIR /app


### PR DESCRIPTION
Hopefully resolves #276.

This creates a manually triggered GH action that will publish a base image for spring-petclinic-rest to ghcr.  This base image can then be used by the profiling smoke tests. 

Having this base image should greatly speed up build/test cycle time (largely spent in mvn downloading deps).