### PR TITLE
No stacks in ContextAttached events.

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/events/ContextAttached.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/events/ContextAttached.java
@@ -22,10 +22,12 @@ import jdk.jfr.Category;
 import jdk.jfr.Event;
 import jdk.jfr.Label;
 import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
 
 @Name(EVENT_NAME)
 @Label("otel context attached")
 @Category("opentelemetry")
+@StackTrace(false)
 public class ContextAttached extends Event {
 
   public static final String EVENT_NAME = "otel.ContextAttached";

--- a/testing/profiler-tests/build.gradle
+++ b/testing/profiler-tests/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+  testImplementation project(":profiler")
   testImplementation("org.testcontainers:testcontainers:1.15.3")
   testImplementation deps.awaitility
 }


### PR DESCRIPTION
We are not planning on using the stack data from this event, so let's omit it.

This also adds a test that confirms no stacks and enhances test code.