### PR TITLE
Add the period to each log event

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrRecorder.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrRecorder.java
@@ -33,7 +33,8 @@ import org.slf4j.LoggerFactory;
 class JfrRecorder {
   private static final Logger logger = LoggerFactory.getLogger(JfrRecorder.class.getName());
   static final String RECORDING_NAME = "otel_agent_jfr_profiler";
-  private final JfrSettingsReader settingsReader;
+  private final Map<String, String> settings;
+
   private final Duration maxAgeDuration;
   private final JFR jfr;
   private final Consumer<Path> onNewRecordingFile;
@@ -41,7 +42,7 @@ class JfrRecorder {
   private volatile Recording recording;
 
   JfrRecorder(Builder builder) {
-    this.settingsReader = requireNonNull(builder.settingsReader);
+    this.settings = requireNonNull(builder.settings);
     this.maxAgeDuration = requireNonNull(builder.maxAgeDuration);
     this.jfr = requireNonNull(builder.jfr);
     this.onNewRecordingFile = requireNonNull(builder.onNewRecordingFile);
@@ -51,7 +52,6 @@ class JfrRecorder {
   public void start() {
     logger.debug("Profiler is starting a JFR recording");
     recording = newRecording();
-    Map<String, String> settings = settingsReader.read();
     recording.setSettings(settings);
     recording.setToDisk(false);
     recording.setName(RECORDING_NAME);
@@ -91,13 +91,13 @@ class JfrRecorder {
 
   public static class Builder {
     private RecordingFileNamingConvention namingConvention;
-    private JfrSettingsReader settingsReader;
+    private Map<String, String> settings;
     private Duration maxAgeDuration;
     private JFR jfr = JFR.instance;
     public Consumer<Path> onNewRecordingFile;
 
-    public Builder settingsReader(JfrSettingsReader settingsReader) {
-      this.settingsReader = settingsReader;
+    public Builder settings(Map<String, String> settings) {
+      this.settings = settings;
       return this;
     }
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/events/EventPeriods.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/events/EventPeriods.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler.events;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+public class EventPeriods {
+
+  public static final Duration UNKNOWN = Duration.ZERO;
+  private final Map<String, Duration> cache = new HashMap<>();
+  private final Function<String, String> configFinder;
+
+  public EventPeriods(Function<String, String> configFinder) {
+    this.configFinder = configFinder;
+  }
+
+  public Duration getDuration(String eventName) {
+    return cache.computeIfAbsent(
+        eventName,
+        event -> {
+          String value = configFinder.apply(event + "#period");
+          return parseToDuration(value);
+        });
+  }
+
+  private Duration parseToDuration(String value) {
+    if (value == null) {
+      return UNKNOWN;
+    }
+    // format is "TTT UUU" where TTT is some numbers and UUU is some units suffix (ms or s)
+    try {
+      String[] parts = value.split(" ");
+      if (parts.length < 2) {
+        return UNKNOWN;
+      }
+      long multiplier = 1;
+      if ("s".equals(parts[1])) {
+        multiplier = 1000;
+      }
+      return Duration.ofMillis(multiplier * Integer.parseInt(parts[0]));
+    } catch (NumberFormatException e) {
+      return UNKNOWN;
+    }
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrRecorderTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrRecorderTest.java
@@ -42,7 +42,6 @@ class JfrRecorderTest {
   static final Path OUTDIR = Path.of("/some/path");
   Duration maxAge = Duration.ofMinutes(13);
   Map<String, String> settings;
-  @Mock JfrSettingsReader settingsReader;
   @Mock Recording recording;
   @Mock Consumer<Path> onNewRecordingFile;
 
@@ -54,7 +53,6 @@ class JfrRecorderTest {
 
   @Test
   void testStart() {
-    when(settingsReader.read()).thenReturn(settings);
     JfrRecorder jfrRecorder = buildJfrRecorder(mock(JFR.class));
     jfrRecorder.start();
     verify(recording).setSettings(settings);
@@ -120,7 +118,7 @@ class JfrRecorderTest {
     JfrRecorder.Builder builder =
         JfrRecorder.builder()
             .maxAgeDuration(maxAge)
-            .settingsReader(settingsReader)
+            .settings(settings)
             .namingConvention(new RecordingFileNamingConvention(OUTDIR))
             .onNewRecordingFile(onNewRecordingFile)
             .jfr(jfr);

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/RecordingSequencerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/RecordingSequencerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.*;
 
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
@@ -146,7 +147,7 @@ class RecordingSequencerTest {
     public MockRecorder(CountDownLatch flushLatch) {
       super(
           new Builder()
-              .settingsReader(mock(JfrSettingsReader.class))
+              .settings(Collections.emptyMap())
               .maxAgeDuration(Duration.ofSeconds(10))
               .onNewRecordingFile(mock(Consumer.class))
               .namingConvention(new RecordingFileNamingConvention(Paths.get("."))));

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/events/EventPeriodsTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/events/EventPeriodsTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler.events;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EventPeriodsTest {
+
+  @Mock Function<String, String> configFinder;
+
+  @Test
+  void testNotCachedFirstParse() {
+    EventPeriods eventPeriods = new EventPeriods(configFinder);
+    when(configFinder.apply("jdk.SomeEvent#period")).thenReturn("250 ms");
+    Duration result = eventPeriods.getDuration("jdk.SomeEvent");
+    assertEquals(Duration.ofMillis(250), result);
+  }
+
+  @Test
+  void testCached() {
+    EventPeriods eventPeriods = new EventPeriods(configFinder);
+    when(configFinder.apply("jdk.SomeEvent#period"))
+        .thenReturn("26 s")
+        .thenThrow(new IllegalStateException());
+    Duration result1 = eventPeriods.getDuration("jdk.SomeEvent");
+    Duration result2 = eventPeriods.getDuration("jdk.SomeEvent");
+    Duration result3 = eventPeriods.getDuration("jdk.SomeEvent");
+    assertEquals(Duration.ofSeconds(26), result1);
+    assertEquals(Duration.ofSeconds(26), result2);
+    assertEquals(Duration.ofSeconds(26), result3);
+  }
+
+  @Test
+  void testNotFoundAlsoCached() {
+    EventPeriods eventPeriods = new EventPeriods(configFinder);
+    when(configFinder.apply("jdk.SomeEvent#period"))
+        .thenReturn(null)
+        .thenThrow(new IllegalStateException());
+    Duration result1 = eventPeriods.getDuration("jdk.SomeEvent");
+    Duration result2 = eventPeriods.getDuration("jdk.SomeEvent");
+    assertEquals(EventPeriods.UNKNOWN, result1);
+    assertEquals(EventPeriods.UNKNOWN, result2);
+  }
+
+  @Test
+  void testNotParsedAlsoCached() {
+    EventPeriods eventPeriods = new EventPeriods(configFinder);
+    when(configFinder.apply("jdk.SomeEvent#period"))
+        .thenReturn("BLEAK BLOOP")
+        .thenThrow(new IllegalStateException());
+    Duration result1 = eventPeriods.getDuration("jdk.SomeEvent");
+    Duration result2 = eventPeriods.getDuration("jdk.SomeEvent");
+    assertEquals(EventPeriods.UNKNOWN, result1);
+    assertEquals(EventPeriods.UNKNOWN, result2);
+  }
+
+  @Test
+  void testConfigNotFound() {
+    EventPeriods eventPeriods = new EventPeriods(configFinder);
+    when(configFinder.apply("jdk.SomeEvent#period")).thenReturn(null);
+    Duration result = eventPeriods.getDuration("jdk.SomeEvent");
+    assertEquals(EventPeriods.UNKNOWN, result);
+  }
+
+  @Test
+  void testEveryChunk() {
+    // Sometimes the JFR config might have the word "everyChunk" instead of an actual value
+    EventPeriods eventPeriods = new EventPeriods(configFinder);
+    when(configFinder.apply("jdk.SomeEvent#period")).thenReturn("everyChunk");
+    Duration result = eventPeriods.getDuration("jdk.SomeEvent");
+    assertEquals(EventPeriods.UNKNOWN, result);
+  }
+}


### PR DESCRIPTION
We need to report the sampling period for the backend to compute times. We source it from the JFR configuration, which does require some special parsing. We cache the values as they are parsed so that we don't have to repeat that work.