### PR TITLE
allow logs ingest endpoint to be configured

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,10 +24,10 @@ jobs:
         with:
           args: >-
             -v -n "*.md" "**/*.md"
-            --exclude-link-local
             --exclude "https://developers.redhat.com/download-manager/file/jboss-eap-.*.zip"
             --exclude "http://yourendpoint.*"
             --exclude "https://ingest.us0.signalfx.com.*"
+            --exclude "http://localhost*"
 
       - name: Fail if there were link errors
         run: exit ${{ steps.lychee.outputs.exit_code }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,7 @@ jobs:
         with:
           args: >-
             -v -n "*.md" "**/*.md"
+            --exclude-link-local
             --exclude "https://developers.redhat.com/download-manager/file/jboss-eap-.*.zip"
             --exclude "http://yourendpoint.*"
             --exclude "https://ingest.us0.signalfx.com.*"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,6 +21,7 @@ jobs:
         with:
           args: >-
             -v -n "*.md" "**/*.md"
+            --exclude-link-local
             --exclude "https://developers.redhat.com/download-manager/file/jboss-eap-.*.zip"
             --exclude "http://yourendpoint.*"
             --exclude "https://ingest.us0.signalfx.com.*"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,10 +21,10 @@ jobs:
         with:
           args: >-
             -v -n "*.md" "**/*.md"
-            --exclude-link-local
             --exclude "https://developers.redhat.com/download-manager/file/jboss-eap-.*.zip"
             --exclude "http://yourendpoint.*"
             --exclude "https://ingest.us0.signalfx.com.*"
+            --exclude "http://localhost*"
 
       - name: Fail if there were link errors
         run: exit ${{ steps.lychee.outputs.exit_code }}

--- a/profiler/README.md
+++ b/profiler/README.md
@@ -5,9 +5,10 @@ It should be considered experimental and is completely unsupported.
 
 # configuration
 
-| name                                | default | description                          |
-|-------------------------------------|---------|--------------------------------------|
-|`splunk.profiler.enabled`            | false   | set to true to enable the profiler   |
-|`splunk.profiler.directory`          | "."     | location of jfr files                |
-|`splunk.profiler.recording.duration` | 20      | number of seconds per recording unit |
-|`splunk.profiler.keep-files`         | false   | leave JFR files on disk id `true`    |
+| name                                | default                | description                          |
+|-------------------------------------|------------------------|--------------------------------------|
+|`splunk.profiler.enabled`            | false                  | set to true to enable the profiler   |
+|`splunk.profiler.directory`          | "."                    | location of jfr files                |
+|`splunk.profiler.recording.duration` | 20                     | number of seconds per recording unit |
+|`splunk.profiler.keep-files`         | false                  | leave JFR files on disk id `true`    |
+|`splunk.profiler.logs-endpoint`      | http://localhost:4317  | where to send OTLP logs              |

--- a/profiler/build.gradle
+++ b/profiler/build.gradle
@@ -31,6 +31,9 @@ dependencies {
     implementation deps.autoservice
 
     testImplementation deps.slf4j
+    testImplementation "io.grpc:grpc-netty:${versions.grpc}"
+    testImplementation "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:${versions.opentelemetryJavaagentAlpha}"
+    testImplementation "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:${versions.opentelemetryAlpha}"
     testImplementation "io.opentelemetry:opentelemetry-proto:${versions.opentelemetryAlpha}"
     testImplementation "io.opentelemetry:opentelemetry-semconv:${versions.opentelemetryAlpha}"
     testImplementation "io.opentelemetry:opentelemetry-context:${versions.opentelemetry}"

--- a/profiler/src/main/java/com/splunk/opentelemetry/logs/OtlpLogsExporter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/logs/OtlpLogsExporter.java
@@ -51,6 +51,14 @@ public class OtlpLogsExporter implements LogsExporter {
     Futures.addCallback(client.export(request), responseHandler, directExecutor());
   }
 
+  public String getEndpoint() {
+    return client.getChannel().authority();
+  }
+
+  public ResourceLogsAdapter getAdapter() {
+    return adapter;
+  }
+
   public static OtlpLogsExporterBuilder builder() {
     return new OtlpLogsExporterBuilder();
   }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
@@ -29,6 +29,7 @@ public class Configuration implements PropertySource {
   public static final String CONFIG_KEY_RECORDING_DURATION_SECONDS =
       "splunk.profiler.recording.duration";
   public static final String CONFIG_KEY_KEEP_FILES = "splunk.profiler.keep-files";
+  public static final String CONFIG_KEY_INGEST_URL = "splunk.profiler.logs-endpoint";
 
   @Override
   public Map<String, String> getProperties() {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
@@ -141,33 +141,6 @@ public class JfrActivator implements AgentListener {
     sequencer.start();
     dirCleanup.registerShutdownHook();
   }
-  //
-  //  private static LogsExporter buildExporter(Config config) {
-  //    ResourceLogsAdapter adapter = buildResourceLogsAdapter();
-  //
-  //    OtlpLogsExporterBuilder builder =
-  //        OtlpLogsExporter.builder()
-  //            .setAdapter(adapter)
-  //            .addHeader("Extra-Content-Type", "otel-profiling-stacktraces");
-  //
-  //    String ingestUrl = config.getProperty(CONFIG_KEY_INGEST_URL);
-  //    if (ingestUrl != null) {
-  //      builder.setEndpoint(ingestUrl);
-  //    }
-  //    return builder.build();
-  //  }
-  //
-  //  private static ResourceLogsAdapter buildResourceLogsAdapter() {
-  //    Resource resource = OpenTelemetrySdkAutoConfiguration.getResource();
-  //    LogEntryAdapter logEntryAdapter = new LogEntryAdapter();
-  //    InstrumentationLibraryLogsAdapter instLibraryLogsAdapter =
-  //        InstrumentationLibraryLogsAdapter.builder()
-  //            .logEntryAdapter(logEntryAdapter)
-  //            .instrumentationName(OTEL_INSTRUMENTATION_NAME)
-  //            .instrumentationVersion(OTEL_INSTRUMENTATION_VERSION)
-  //            .build();
-  //    return new ResourceLogsAdapter(instLibraryLogsAdapter, resource);
-  //  }
 
   private Consumer<Path> buildFileDeleter(Config config) {
     if (keepFiles(config)) {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/LogsExporterBuilder.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/LogsExporterBuilder.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_INGEST_URL;
+
+import com.splunk.opentelemetry.logs.InstrumentationLibraryLogsAdapter;
+import com.splunk.opentelemetry.logs.LogEntryAdapter;
+import com.splunk.opentelemetry.logs.LogsExporter;
+import com.splunk.opentelemetry.logs.OtlpLogsExporter;
+import com.splunk.opentelemetry.logs.OtlpLogsExporterBuilder;
+import com.splunk.opentelemetry.logs.ResourceLogsAdapter;
+import io.opentelemetry.instrumentation.api.config.Config;
+import io.opentelemetry.sdk.autoconfigure.OpenTelemetrySdkAutoConfiguration;
+import io.opentelemetry.sdk.resources.Resource;
+
+public class LogsExporterBuilder {
+
+  private static final String OTEL_INSTRUMENTATION_NAME = "otel.profiling";
+  private static final String OTEL_INSTRUMENTATION_VERSION = "0.1.0";
+
+  static LogsExporter fromConfig(Config config) {
+    ResourceLogsAdapter adapter = buildResourceLogsAdapter();
+
+    OtlpLogsExporterBuilder builder =
+        OtlpLogsExporter.builder()
+            .setAdapter(adapter)
+            .addHeader("Extra-Content-Type", "otel-profiling-stacktraces");
+
+    String ingestUrl = config.getProperty(CONFIG_KEY_INGEST_URL);
+    if (ingestUrl != null) {
+      builder.setEndpoint(ingestUrl);
+    }
+    return builder.build();
+  }
+
+  private static ResourceLogsAdapter buildResourceLogsAdapter() {
+    Resource resource = OpenTelemetrySdkAutoConfiguration.getResource();
+    LogEntryAdapter logEntryAdapter = new LogEntryAdapter();
+    InstrumentationLibraryLogsAdapter instLibraryLogsAdapter =
+        InstrumentationLibraryLogsAdapter.builder()
+            .logEntryAdapter(logEntryAdapter)
+            .instrumentationName(OTEL_INSTRUMENTATION_NAME)
+            .instrumentationVersion(OTEL_INSTRUMENTATION_VERSION)
+            .build();
+    return new ResourceLogsAdapter(instLibraryLogsAdapter, resource);
+  }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/LogsExporterBuilder.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/LogsExporterBuilder.java
@@ -28,7 +28,7 @@ import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.sdk.autoconfigure.OpenTelemetrySdkAutoConfiguration;
 import io.opentelemetry.sdk.resources.Resource;
 
-public class LogsExporterBuilder {
+class LogsExporterBuilder {
 
   private static final String OTEL_INSTRUMENTATION_NAME = "otel.profiling";
   private static final String OTEL_INSTRUMENTATION_VERSION = "0.1.0";

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/LogsExporterBuilderTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/LogsExporterBuilderTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.splunk.opentelemetry.logs.OtlpLogsExporter;
+import io.opentelemetry.instrumentation.api.config.Config;
+import org.junit.jupiter.api.Test;
+
+class LogsExporterBuilderTest {
+
+  @Test
+  void testBuildSimple() {
+    Config config = mock(Config.class);
+    OtlpLogsExporter exporter = (OtlpLogsExporter) LogsExporterBuilder.fromConfig(config);
+    String endpoint = exporter.getEndpoint();
+    assertEquals("localhost:4317", endpoint);
+    assertNotNull(exporter.getAdapter());
+  }
+
+  @Test
+  void testCustomEndpoint() {
+    Config config = mock(Config.class);
+    when(config.getProperty(Configuration.CONFIG_KEY_INGEST_URL))
+        .thenReturn("http://example.com:9122/");
+    OtlpLogsExporter exporter = (OtlpLogsExporter) LogsExporterBuilder.fromConfig(config);
+    String endpoint = exporter.getEndpoint();
+    assertEquals("example.com:9122", endpoint);
+    assertNotNull(exporter.getAdapter());
+  }
+}


### PR DESCRIPTION
Adds a new config property `splunk.profiler.logs-endpoint` that allows changing the collector endpoint for logs.