### PR TITLE
Configurable JFR event periods

### DIFF
--- a/profiler/README.md
+++ b/profiler/README.md
@@ -12,4 +12,4 @@ It should be considered experimental and is completely unsupported.
 |`splunk.profiler.recording.duration` | 20                     | number of seconds per recording unit      |
 |`splunk.profiler.keep-files`         | false                  | leave JFR files on disk id `true`         |
 |`splunk.profiler.logs-endpoint`      | http://localhost:4317  | where to send OTLP logs                   |
-|`splunk.profiler.period.{eventName}` | n/a                    | customize period for a specific jfr event |
+|`splunk.profiler.period.{eventName}` | n/a                    | customize period (in ms) for a specific jfr event. For example, to set the ThreadDump frequency to 1s (100ms): `-Dsplunk.profiler.period.threaddump=1000` |

--- a/profiler/README.md
+++ b/profiler/README.md
@@ -5,10 +5,11 @@ It should be considered experimental and is completely unsupported.
 
 # configuration
 
-| name                                | default                | description                          |
-|-------------------------------------|------------------------|--------------------------------------|
-|`splunk.profiler.enabled`            | false                  | set to true to enable the profiler   |
-|`splunk.profiler.directory`          | "."                    | location of jfr files                |
-|`splunk.profiler.recording.duration` | 20                     | number of seconds per recording unit |
-|`splunk.profiler.keep-files`         | false                  | leave JFR files on disk id `true`    |
-|`splunk.profiler.logs-endpoint`      | http://localhost:4317  | where to send OTLP logs              |
+| name                                | default                | description                               |
+|-------------------------------------|------------------------|-------------------------------------------|
+|`splunk.profiler.enabled`            | false                  | set to true to enable the profiler        |
+|`splunk.profiler.directory`          | "."                    | location of jfr files                     |
+|`splunk.profiler.recording.duration` | 20                     | number of seconds per recording unit      |
+|`splunk.profiler.keep-files`         | false                  | leave JFR files on disk id `true`         |
+|`splunk.profiler.logs-endpoint`      | http://localhost:4317  | where to send OTLP logs                   |
+|`splunk.profiler.period.{eventName}` | n/a                    | customize period for a specific jfr event |

--- a/profiler/build.gradle
+++ b/profiler/build.gradle
@@ -34,6 +34,8 @@ dependencies {
     testImplementation "io.grpc:grpc-netty:${versions.grpc}"
     testImplementation "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:${versions.opentelemetryJavaagentAlpha}"
     testImplementation "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:${versions.opentelemetryAlpha}"
+    testImplementation "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:${versions.opentelemetryJavaagentAlpha}"
+    testImplementation "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:${versions.opentelemetryAlpha}"
     testImplementation "io.opentelemetry:opentelemetry-proto:${versions.opentelemetryAlpha}"
     testImplementation "io.opentelemetry:opentelemetry-semconv:${versions.opentelemetryAlpha}"
     testImplementation "io.opentelemetry:opentelemetry-context:${versions.opentelemetry}"

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
@@ -30,6 +30,7 @@ public class Configuration implements PropertySource {
       "splunk.profiler.recording.duration";
   public static final String CONFIG_KEY_KEEP_FILES = "splunk.profiler.keep-files";
   public static final String CONFIG_KEY_INGEST_URL = "splunk.profiler.logs-endpoint";
+  public static final String CONFIG_KEY_PERIOD_PREFIX = "splunk.profiler.period";
 
   @Override
   public Map<String, String> getProperties() {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
@@ -80,8 +80,7 @@ public class JfrActivator implements AgentListener {
             .configKeepsFilesOnDisk(keepFiles(config))
             .recordingDuration(recordingDuration)
             .build();
-    JfrSettingsReader settingsReader = new JfrSettingsReader();
-    Map<String, String> jfrSettings = settingsReader.read();
+    Map<String, String> jfrSettings = buildJfrSettings(config);
 
     RecordedEventStream.Factory recordedEventStreamFactory =
         () -> new FilterSortedRecordingFile(() -> new BasicJfrRecordingFile(JFR.instance));
@@ -140,6 +139,13 @@ public class JfrActivator implements AgentListener {
 
     sequencer.start();
     dirCleanup.registerShutdownHook();
+  }
+
+  private Map<String, String> buildJfrSettings(Config config) {
+    JfrSettingsReader settingsReader = new JfrSettingsReader();
+    Map<String, String> jfrSettings = settingsReader.read();
+    JfrSettingsOverrides overrides = new JfrSettingsOverrides(config);
+    return overrides.apply(jfrSettings);
   }
 
   private Consumer<Path> buildFileDeleter(Config config) {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrSettingsOverrides.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrSettingsOverrides.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PERIOD_PREFIX;
+
+import io.opentelemetry.instrumentation.api.config.Config;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Customizes a configuration with user overrides. The config can contain
+ * splunk.profiler.period.{short-event-name} keys whose valuse are the period in milliseconds,
+ * without suffix.
+ */
+class JfrSettingsOverrides {
+
+  private static final Logger logger = LoggerFactory.getLogger(JfrSettingsOverrides.class);
+  private final Config config;
+
+  JfrSettingsOverrides(Config config) {
+    this.config = config;
+  }
+
+  Map<String, String> apply(Map<String, String> jfrSettings) {
+    Map<String, String> result = new HashMap<>(jfrSettings);
+    jfrSettings.keySet().stream()
+        .filter(key -> key.endsWith("#period"))
+        .forEach(
+            key -> {
+              String[] parts = key.split("#");
+              String eventName = parts[0];
+              String shortEventName = eventName.replaceFirst("^jdk.", "");
+              String configKey = CONFIG_KEY_PERIOD_PREFIX + "." + shortEventName.toLowerCase();
+              String customSetting = config.getProperty(configKey);
+              if (customSetting != null) {
+                String jfrFormattedDuration = customSetting + " ms";
+                logger.info(
+                    "Custom JFR period configured for {} :: {}", eventName, jfrFormattedDuration);
+                result.put(key, jfrFormattedDuration);
+              }
+            });
+    return result;
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrSettingsOverridesTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrSettingsOverridesTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.instrumentation.api.config.Config;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class JfrSettingsOverridesTest {
+
+  @Test
+  void testOverrides() {
+    Config config = mock(Config.class);
+    when(config.getProperty("splunk.profiler.period.threaddump")).thenReturn("163");
+    when(config.getProperty("splunk.profiler.period.otherevent")).thenReturn("964");
+    when(config.getProperty("splunk.profiler.period.extraunused")).thenReturn("111");
+    JfrSettingsOverrides overrides = new JfrSettingsOverrides(config);
+    Map<String, String> jfrSettings =
+        Map.of(
+            "jdk.ThreadDump#period", "12",
+            "jdk.ThreadDump#enabled", "true",
+            "jdk.OtherEvent#period", "13");
+    Map<String, String> result = overrides.apply(jfrSettings);
+    assertNotSame(result, jfrSettings);
+    assertEquals("163 ms", result.get("jdk.ThreadDump#period"));
+    assertEquals("964 ms", result.get("jdk.OtherEvent#period"));
+  }
+}


### PR DESCRIPTION
This allows the user to customize/configure the JFR period for events in a somewhat generic way. The defaults are typically in the `jfr.settings` file and don't need to be changed, but especially for development this is helpful.