### PR TITLE
fetch ingested logs and make a few assertions

### DIFF
--- a/testing/profiler-tests/build.gradle
+++ b/testing/profiler-tests/build.gradle
@@ -4,7 +4,9 @@ plugins {
 
 dependencies {
   testImplementation project(":profiler")
-  testImplementation("org.testcontainers:testcontainers:1.15.3")
+  testImplementation "io.opentelemetry:opentelemetry-proto:${versions.opentelemetryAlpha}"
+  testImplementation "com.google.protobuf:protobuf-java-util:3.17.3"
+  testImplementation "org.testcontainers:testcontainers:1.15.3"
   testImplementation deps.awaitility
 }
 

--- a/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/profiler/TestHelpers.java
+++ b/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/profiler/TestHelpers.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.google.protobuf.util.JsonFormat;
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.logs.v1.LogRecord;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.JsonNode;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+
+public class TestHelpers {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  static boolean isThreadDumpEvent(LogRecord log) {
+    String name = getStringAttr(log, "source.event.name");
+    return "jdk.ThreadDump".equals(name);
+  }
+
+  static List<LogRecord> flattenToLogRecords(List<ExportLogsServiceRequest> resourceLogs) {
+    return resourceLogs.stream()
+        .flatMap(log -> log.getResourceLogsList().stream())
+        .flatMap(log -> log.getInstrumentationLibraryLogsList().stream())
+        .flatMap(log -> log.getLogsList().stream())
+        .collect(Collectors.toList());
+  }
+
+  static String getStringAttr(LogRecord log, String name) {
+    Optional<KeyValue> foundAttr = findAttr(log, name);
+    return foundAttr.map(attr -> attr.getValue().getStringValue()).orElse(null);
+  }
+
+  static Long getLongAttr(LogRecord log, String name) {
+    Optional<KeyValue> foundAttr = findAttr(log, name);
+    return foundAttr.map(attr -> attr.getValue().getIntValue()).orElse(null);
+  }
+
+  static Optional<KeyValue> findAttr(LogRecord log, String name) {
+    return log.getAttributesList().stream().filter(a -> a.getKey().equals(name)).findFirst();
+  }
+
+  static List<ExportLogsServiceRequest> parseToExportLogsServiceRequests(String bodyContent)
+      throws IOException {
+    JsonNode root = OBJECT_MAPPER.readTree(bodyContent);
+    return StreamSupport.stream(root.spliterator(), false)
+        .map(TestHelpers::deserializeJsonToObject)
+        .collect(Collectors.toList());
+  }
+
+  private static ExportLogsServiceRequest deserializeJsonToObject(JsonNode node) {
+    ExportLogsServiceRequest.Builder builder = ExportLogsServiceRequest.newBuilder();
+    try {
+      JsonFormat.parser().merge(OBJECT_MAPPER.writeValueAsString(node), builder);
+      return builder.build();
+    } catch (Exception e) {
+      fail("Error mapping log results", e);
+      return null;
+    }
+  }
+}

--- a/testing/profiler-tests/src/test/resources/collector.yaml
+++ b/testing/profiler-tests/src/test/resources/collector.yaml
@@ -1,0 +1,45 @@
+extensions:
+  health_check:
+  pprof:
+    endpoint: 0.0.0.0:1777
+  zpages:
+    endpoint: 0.0.0.0:55679
+
+receivers:
+  jaeger:
+    protocols:
+      grpc:
+      thrift_http:
+  otlp:
+    protocols:
+      grpc:
+  signalfx:
+
+processors:
+  batch:
+
+exporters:
+  logging/logging_debug:
+    loglevel: debug
+  logging/logging_info:
+    loglevel: info
+  otlp:
+    endpoint: backend:8080
+    insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [ jaeger, otlp ]
+      processors: [ batch ]
+      exporters: [ logging/logging_debug, otlp ]
+    metrics:
+      receivers: [ signalfx ]
+      processors: [ batch ]
+      exporters: [ logging/logging_info, otlp ]
+    logs:
+      receivers: [ otlp ]
+      processors: [ batch ]
+      exporters: [ logging/logging_debug, otlp ]
+
+  extensions: [ health_check, pprof, zpages ]


### PR DESCRIPTION
This stands up a collector now along with the fake backend from upstream, just like the smoke tests. It waits for log data to be present in the fake backend and then fetches/deserializes the data in order to make some assertions about it.  For now, we just verify that the period was propagated and that the sourcetype is specified and that we captured stacks for the `main` thread and the JFR thread itself.