### PR TITLE
remove logs workaround for trace/span id attributes.

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/LogEntryCreator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/LogEntryCreator.java
@@ -16,8 +16,6 @@
 
 package com.splunk.opentelemetry.profiler;
 
-import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.LINKED_SPAN_ID;
-import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.LINKED_TRACE_ID;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SOURCE_EVENT_NAME;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SOURCE_EVENT_PERIOD;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SOURCE_TYPE;
@@ -65,11 +63,7 @@ public class LogEntryCreator implements Function<StackToSpanLinkage, LogEntry> {
     // until the collector/ingest can be remedied.
 
     AttributesBuilder builder =
-        Attributes.builder()
-            .put(LINKED_TRACE_ID, linkedStack.getTraceId())
-            .put(LINKED_SPAN_ID, linkedStack.getSpanId())
-            .put(SOURCE_TYPE, PROFILING_SOURCE)
-            .put(SOURCE_EVENT_NAME, sourceEvent);
+        Attributes.builder().put(SOURCE_TYPE, PROFILING_SOURCE).put(SOURCE_EVENT_NAME, sourceEvent);
 
     if (!EventPeriods.UNKNOWN.equals(eventPeriod)) {
       builder.put(SOURCE_EVENT_PERIOD, eventPeriod.toMillis());

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/LogEntryCreatorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/LogEntryCreatorTest.java
@@ -17,8 +17,6 @@
 package com.splunk.opentelemetry.profiler;
 
 import static com.splunk.opentelemetry.profiler.LogEntryCreator.PROFILING_SOURCE;
-import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.LINKED_SPAN_ID;
-import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.LINKED_TRACE_ID;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SOURCE_EVENT_NAME;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SOURCE_EVENT_PERIOD;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SOURCE_TYPE;
@@ -59,10 +57,6 @@ class LogEntryCreatorTest {
     SpanLinkage linkage = new SpanLinkage(traceId, spanId, threadId);
     Attributes attributes =
         Attributes.of(
-            LINKED_TRACE_ID,
-            traceId,
-            LINKED_SPAN_ID,
-            spanId,
             SOURCE_EVENT_NAME,
             "GoodEventHere",
             SOURCE_EVENT_PERIOD,


### PR DESCRIPTION
These are fields on `LogRecord` and the HEC exporter now knows about these and propagates them as log attributes. As such, we don't need to duplicate them now.