### PR TITLE
wrap the assignees in a string

### DIFF
--- a/.github/workflows/nightly-failed.template
+++ b/.github/workflows/nightly-failed.template
@@ -1,6 +1,6 @@
 ---
 title: Nightly build #{{ env.GITHUB_RUN_NUMBER }} failed
-assignees: @signalfx/gdi-java-maintainers
+assignees: '@signalfx/gdi-java-maintainers'
 labels: bug, area:build, priority:p1
 ---
 <a href="https://github.com/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}">


### PR DESCRIPTION
I think the `@` breaks the yaml if not in a string?

![image](https://user-images.githubusercontent.com/75337021/123994914-b0326280-d982-11eb-8109-063383f849c4.png)
