### PR TITLE
Add otel.traces.sampler parameter to the advanced configuration page

### DIFF
--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -83,6 +83,15 @@ export OTEL_PROPAGATORS=b3multi
 | `otel.span.event.count.limit`                                    | `OTEL_SPAN_EVENT_COUNT_LIMIT`                                    | unlimited     | Stable  | Maximum number of events per span.
 | `otel.span.link.count.limit`                                     | `OTEL_SPAN_LINK_COUNT_LIMIT`                                     | `1000`        | Stable  | Maximum number of links per span.
 
+## Sampling configuration
+
+| System property          | Environment variable     | Default value  | Support | Description |
+| ------------------------ | ------------------------ | -------------- | ------- | ----------- |
+| `otel.traces.sampler`    | `OTEL_TRACE_SAMPLER`  	  | `always_on`    | Stable  | The sampler to use for tracing.	|
+
+Set `otel.traces.sampler` to `internal_root_off` to drop all traces with root spans where `spanKind` is `INTERNAL`, `CLIENT` or `PRODUCER`. This setting only keeps root spans where `spanKind` is `SERVER` and `CONSUMER`.
+
+
 ## Java agent configuration
 
 | System property          | Environment variable     | Default value  | Support | Description |

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -87,7 +87,7 @@ export OTEL_PROPAGATORS=b3multi
 
 | System property          | Environment variable     | Default value  | Support | Description |
 | ------------------------ | ------------------------ | -------------- | ------- | ----------- |
-| `otel.traces.sampler`    | `OTEL_TRACE_SAMPLER` | `always_on`    | Stable  | The sampler to use for tracing.	|
+| `otel.traces.sampler`    | `OTEL_TRACE_SAMPLER`     | `always_on`    | Stable  | The sampler to use for tracing.	|
 
 Set `otel.traces.sampler` to `internal_root_off` to drop all traces with root spans where `spanKind` is `INTERNAL`, `CLIENT` or `PRODUCER`. This setting only keeps root spans where `spanKind` is `SERVER` and `CONSUMER`.
 

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -87,7 +87,7 @@ export OTEL_PROPAGATORS=b3multi
 
 | System property          | Environment variable     | Default value  | Support | Description |
 | ------------------------ | ------------------------ | -------------- | ------- | ----------- |
-| `otel.traces.sampler`    | `OTEL_TRACE_SAMPLER` 	| `always_on`    | Stable  | The sampler to use for tracing.	|
+| `otel.traces.sampler`    | `OTEL_TRACE_SAMPLER` | `always_on`    | Stable  | The sampler to use for tracing.	|
 
 Set `otel.traces.sampler` to `internal_root_off` to drop all traces with root spans where `spanKind` is `INTERNAL`, `CLIENT` or `PRODUCER`. This setting only keeps root spans where `spanKind` is `SERVER` and `CONSUMER`.
 

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -87,7 +87,7 @@ export OTEL_PROPAGATORS=b3multi
 
 | System property          | Environment variable     | Default value  | Support | Description |
 | ------------------------ | ------------------------ | -------------- | ------- | ----------- |
-| `otel.traces.sampler`    | `OTEL_TRACE_SAMPLER`  	  | `always_on`    | Stable  | The sampler to use for tracing.	|
+| `otel.traces.sampler`    | `OTEL_TRACE_SAMPLER` 	| `always_on`    | Stable  | The sampler to use for tracing.	|
 
 Set `otel.traces.sampler` to `internal_root_off` to drop all traces with root spans where `spanKind` is `INTERNAL`, `CLIENT` or `PRODUCER`. This setting only keeps root spans where `spanKind` is `SERVER` and `CONSUMER`.
 


### PR DESCRIPTION
This PR adds a new section to the advanced configuration page, "Sampling configuration", that documents the new value for `otel.traces.sampler` introduced in v1.1.0, `internal_root_off`.