### PR TITLE
Fix attribute name for sourcetype in HEC.

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/ProfilingSemanticAttributes.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/ProfilingSemanticAttributes.java
@@ -31,7 +31,7 @@ public class ProfilingSemanticAttributes {
   public static final AttributeKey<String> LINKED_TRACE_ID = stringKey("trace_id");
 
   /** This is a HEC field that shows up in the Logging UI. */
-  public static final AttributeKey<String> SOURCE_TYPE = stringKey("sourcetype");
+  public static final AttributeKey<String> SOURCE_TYPE = stringKey("com.splunk.sourcetype");
 
   /** The name of the originating event that generated this profiling event */
   public static final AttributeKey<String> SOURCE_EVENT_NAME = stringKey("source.event.name");


### PR DESCRIPTION
According to the [logic in HEC exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/03672d578069676c51e6bccb71519b14c0751a4e/exporter/splunkhecexporter/logdata_to_splunk.go#L72) attribute key in the log record [should be `com.splunk.sourcetype`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/03672d578069676c51e6bccb71519b14c0751a4e/internal/splunk/common.go#L29) to end up in HEC's `sourcetype` attribute.

@breedx-splk 