### PR TITLE
Refactor javaagent buildscripts

### DIFF
--- a/agent/build.gradle.kts
+++ b/agent/build.gradle.kts
@@ -14,17 +14,17 @@ java {
 }
 
 // this configuration collects libs that will be placed in the bootstrap classloader
-val bootstrapLibs by configurations.creating {
+val bootstrapLibs: Configuration by configurations.creating {
   isCanBeResolved = true
   isCanBeConsumed = false
 }
 // this configuration collects libs that will be placed in the agent classloader, isolated from the instrumented application code
-val javaagentLibs by configurations.creating {
+val javaagentLibs: Configuration by configurations.creating {
   isCanBeResolved = true
   isCanBeConsumed = false
 }
 // this configuration stores the upstream agent dep that's extended by this project
-val upstreamAgent by configurations.creating {
+val upstreamAgent: Configuration by configurations.creating {
   isCanBeResolved = true
   isCanBeConsumed = false
 }
@@ -46,6 +46,9 @@ tasks {
     enabled = false
   }
 
+  // building the final javaagent jar is done in 3 steps:
+
+  // 1. all Splunk-specific javaagent libs are relocated (by the splunk.shadow-conventions plugin)
   val relocateJavaagentLibs by registering(ShadowJar::class) {
     configurations = listOf(javaagentLibs)
 
@@ -54,8 +57,10 @@ tasks {
     archiveFileName.set("javaagentLibs-relocated.jar")
   }
 
-  // having a separate task for isolating javaagent libs is required to avoid duplicates
-  // duplicatesStrategy in shadowJar won't be applied when adding files with with(CopySpec)
+  // 2. the Splunk javaagent libs are then isolated - moved to the inst/ directory
+  // having a separate task for isolating javaagent libs is required to avoid duplicates with the upstream javaagent
+  // duplicatesStrategy in shadowJar won't be applied when adding files with with(CopySpec) because each CopySpec has
+  // its own duplicatesStrategy
   val isolateJavaagentLibs by registering(Copy::class) {
     dependsOn(relocateJavaagentLibs)
     isolateClasses(relocateJavaagentLibs.get().outputs.files)
@@ -63,6 +68,8 @@ tasks {
     into("$buildDir/isolated/javaagentLibs")
   }
 
+  // 3. the relocated and isolated javaagent libs are merged together with the bootstrap libs (which undergo relocation
+  // in this task) and the upstream javaagent jar; duplicates are removed
   shadowJar {
     configurations = listOf(bootstrapLibs, upstreamAgent)
 
@@ -86,8 +93,8 @@ tasks {
     }
   }
 
-  // create a no-classifier jar that's exactly the same as the -all one
-  // a no-classifier (main) jar is required by sonatype
+  // a separate task to create a no-classifier jar that's exactly the same as the -all one
+  // because a no-classifier (main) jar is required by sonatype
   val mainShadowJar by registering(Jar::class) {
     archiveClassifier.set("")
 

--- a/agent/build.gradle.kts
+++ b/agent/build.gradle.kts
@@ -55,6 +55,15 @@ tasks {
     duplicatesStrategy = DuplicatesStrategy.FAIL
 
     archiveFileName.set("javaagentLibs-relocated.jar")
+
+    // exclude known bootstrap dependencies - they can't appear in the inst/ directory
+    dependencies {
+      exclude(dependency("org.slf4j:slf4j-api"))
+      exclude(dependency("io.opentelemetry:opentelemetry-api"))
+      exclude(dependency("io.opentelemetry:opentelemetry-api-metrics"))
+      exclude(dependency("io.opentelemetry:opentelemetry-context"))
+      exclude(dependency("io.opentelemetry:opentelemetry-semconv"))
+    }
   }
 
   // 2. the Splunk javaagent libs are then isolated - moved to the inst/ directory

--- a/agent/build.gradle.kts
+++ b/agent/build.gradle.kts
@@ -182,7 +182,7 @@ fun CopySpec.isolateClasses(jars: Iterable<File>) {
   jars.forEach {
     from(zipTree(it)) {
       into("inst")
-      rename("(^.*)\\.class\$", "\$1.classdata")
+      rename("^(.*)\\.class\$", "\$1.classdata")
     }
   }
 }

--- a/bootstrap/build.gradle.kts
+++ b/bootstrap/build.gradle.kts
@@ -1,6 +1,9 @@
 dependencies {
   // slf4j is included in the otel javaagent, no need to add it here too
   compileOnly("org.slf4j:slf4j-api")
+  // required to access OpenTelemetryAgent
+  compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-bootstrap")
+
   // add micrometer to the bootstrap classloader so that it's available in instrumentations
   implementation("io.micrometer:micrometer-core")
 }

--- a/bootstrap/src/main/java/com/splunk/opentelemetry/javaagent/SplunkAgent.java
+++ b/bootstrap/src/main/java/com/splunk/opentelemetry/javaagent/SplunkAgent.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.splunk.opentelemetry;
+package com.splunk.opentelemetry.javaagent;
 
 import io.opentelemetry.javaagent.OpenTelemetryAgent;
 import java.lang.instrument.Instrumentation;

--- a/buildSrc/src/main/kotlin/splunk.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.java-conventions.gradle.kts
@@ -51,8 +51,9 @@ extensions.configure<DependencyManagementExtension>("dependencyManagement") {
     dependency("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:${otelInstrumentationAlphaVersion}")
     dependencySet("io.opentelemetry.javaagent:${otelInstrumentationAlphaVersion}") {
       entry("opentelemetry-agent-for-testing")
-      entry("opentelemetry-javaagent-instrumentation-api")
+      entry("opentelemetry-javaagent-bootstrap")
       entry("opentelemetry-javaagent-extension-api")
+      entry("opentelemetry-javaagent-instrumentation-api")
       entry("opentelemetry-testing-common")
     }
     dependencySet("io.opentelemetry.javaagent.instrumentation:${otelInstrumentationAlphaVersion}") {

--- a/buildSrc/src/main/kotlin/splunk.shadow-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.shadow-conventions.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 }
 
 tasks.withType<ShadowJar>().configureEach {
-  mergeServiceFiles()
   mergeServiceFiles {
     include("inst/META-INF/services/*")
   }

--- a/buildSrc/src/main/kotlin/splunk.shadow-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.shadow-conventions.gradle.kts
@@ -6,6 +6,9 @@ plugins {
 
 tasks.withType<ShadowJar>().configureEach {
   mergeServiceFiles()
+  mergeServiceFiles {
+    include("inst/META-INF/services/*")
+  }
 
   exclude("**/module-info.class")
 

--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -1,7 +1,3 @@
-plugins {
-  id("splunk.shadow-conventions")
-}
-
 dependencies {
   compileOnly(project(":bootstrap"))
   compileOnly("io.opentelemetry:opentelemetry-sdk")
@@ -12,7 +8,9 @@ dependencies {
   annotationProcessor("com.google.auto.service:auto-service")
   compileOnly("com.google.auto.service:auto-service")
 
-  implementation("io.opentelemetry:opentelemetry-exporter-jaeger-thrift")
+  implementation("io.opentelemetry:opentelemetry-exporter-jaeger-thrift") {
+    exclude("io.opentelemetry", "opentelemetry-sdk")
+  }
   implementation("io.jaegertracing:jaeger-client")
 
   compileOnly("io.micrometer:micrometer-core")

--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -1,7 +1,3 @@
-plugins {
-  id("splunk.shadow-conventions")
-}
-
 val instrumentationTest = tasks.named("test")
 val instrumentationDeps = dependencies
 
@@ -26,11 +22,5 @@ subprojects {
     compileJava {
       options.release.set(8)
     }
-  }
-}
-
-tasks {
-  shadowJar {
-    duplicatesStrategy = DuplicatesStrategy.FAIL
   }
 }

--- a/profiler/build.gradle.kts
+++ b/profiler/build.gradle.kts
@@ -1,7 +1,3 @@
-plugins {
-  id("splunk.shadow-conventions")
-}
-
 dependencies {
   compileOnly("io.opentelemetry:opentelemetry-sdk")
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
@@ -37,9 +33,5 @@ tasks {
   java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
-  }
-
-  shadowJar {
-    duplicatesStrategy = DuplicatesStrategy.FAIL
   }
 }

--- a/testing/agent-for-testing/build.gradle.kts
+++ b/testing/agent-for-testing/build.gradle.kts
@@ -86,7 +86,7 @@ fun CopySpec.isolateClasses(jars: Iterable<File>) {
   jars.forEach {
     from(zipTree(it)) {
       into("inst")
-      rename("(^.*)\\.class\$", "\$1.classdata")
+      rename("^(.*)\\.class\$", "\$1.classdata")
     }
   }
 }

--- a/testing/agent-test-extension/build.gradle.kts
+++ b/testing/agent-test-extension/build.gradle.kts
@@ -1,7 +1,3 @@
-plugins {
-  id("splunk.shadow-conventions")
-}
-
 dependencies {
   annotationProcessor("com.google.auto.service:auto-service")
   compileOnly("com.google.auto.service:auto-service")


### PR DESCRIPTION
... so that they're more similar to what we have in the upstream repo (and easier to maintain too)

* Removed shadowing from `custom`, `instrumentation` and `profiler`
* Moved `SplunkAgent` to `bootstrap` to avoid depending on `agent:jar`, which is disabled and I have no idea why this has worked before