### PR TITLE
Fix test by removing unnecessary check

### DIFF
--- a/instrumentation/khttp/src/test/groovy/com/splunk/opentelemetry/KHttpClientTest.groovy
+++ b/instrumentation/khttp/src/test/groovy/com/splunk/opentelemetry/KHttpClientTest.groovy
@@ -18,7 +18,6 @@ class KHttpClientTest extends HttpClientTest<Void> implements AgentTestTrait {
 
   @Override
   int sendRequest(Void request, String method, URI uri, Map<String, String> headers) {
-    headers.put("User-Agent", "khttp")
     // khttp applies the same timeout for both connect and read
     def timeoutSeconds = CONNECT_TIMEOUT_MS / 1000
     def response = KHttp.request(method, uri.toString(), headers, Collections.emptyMap(), null, null, null, null, timeoutSeconds)
@@ -41,8 +40,4 @@ class KHttpClientTest extends HttpClientTest<Void> implements AgentTestTrait {
     return false
   }
 
-  @Override
-  String userAgent() {
-    return "khttp"
-  }
 }


### PR DESCRIPTION
Fixes #376

Headers map became immutable in the upstream. Instead of wrapping it and add this optional header, I decided to remove it. As khttp itself does not set it anyway.