### PR TITLE
Rename middleware to webengine

### DIFF
--- a/bootstrap/src/main/java/com/splunk/opentelemetry/javaagent/bootstrap/WebengineHolder.java
+++ b/bootstrap/src/main/java/com/splunk/opentelemetry/javaagent/bootstrap/WebengineHolder.java
@@ -20,23 +20,23 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class MiddlewareHolder {
+public class WebengineHolder {
 
-  private static final Logger log = LoggerFactory.getLogger(MiddlewareHolder.class);
+  private static final Logger log = LoggerFactory.getLogger(WebengineHolder.class);
 
-  public static final AtomicReference<String> middlewareName = new AtomicReference<>();
-  public static final AtomicReference<String> middlewareVersion = new AtomicReference<>();
+  public static final AtomicReference<String> webengineName = new AtomicReference<>();
+  public static final AtomicReference<String> webengineVersion = new AtomicReference<>();
 
   public static void trySetName(String name) {
-    if (!middlewareName.compareAndSet(null, name)) {
-      log.debug("Trying to re-set middleware name from {} to {}", middlewareName.get(), name);
+    if (!webengineName.compareAndSet(null, name)) {
+      log.debug("Trying to re-set webengine name from {} to {}", webengineName.get(), name);
     }
   }
 
   public static void trySetVersion(String version) {
-    if (!middlewareVersion.compareAndSet(null, version)) {
+    if (!webengineVersion.compareAndSet(null, version)) {
       log.debug(
-          "Trying to re-set middleware version from {} to {}", middlewareVersion.get(), version);
+          "Trying to re-set webengine version from {} to {}", webengineVersion.get(), version);
     }
   }
 }

--- a/custom/src/main/java/com/splunk/opentelemetry/webengine/WebengineAttributeSpanProcessor.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/webengine/WebengineAttributeSpanProcessor.java
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package com.splunk.opentelemetry.middleware;
+package com.splunk.opentelemetry.webengine;
 
-import com.splunk.opentelemetry.javaagent.bootstrap.MiddlewareHolder;
+import com.splunk.opentelemetry.javaagent.bootstrap.WebengineHolder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.CompletableResultCode;
@@ -24,23 +24,22 @@ import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 
-public class MiddlewareAttributeSpanProcessor implements SpanProcessor {
+public class WebengineAttributeSpanProcessor implements SpanProcessor {
 
   @Override
   public void onStart(Context parentContext, ReadWriteSpan span) {
-    String middlewareName = MiddlewareHolder.middlewareName.get();
-    String middlewareVersion = MiddlewareHolder.middlewareVersion.get();
+    String webengineName = WebengineHolder.webengineName.get();
+    String webengineVersion = WebengineHolder.webengineVersion.get();
 
-    if ((middlewareName == null && middlewareVersion == null)
-        || span.getKind() != SpanKind.SERVER) {
+    if ((webengineName == null && webengineVersion == null) || span.getKind() != SpanKind.SERVER) {
       return;
     }
 
-    if (middlewareName != null) {
-      span.setAttribute(MiddlewareAttributes.MIDDLEWARE_NAME.key, middlewareName);
+    if (webengineName != null) {
+      span.setAttribute(WebengineAttributes.WEBENGINE_NAME.key, webengineName);
     }
-    if (middlewareVersion != null) {
-      span.setAttribute(MiddlewareAttributes.MIDDLEWARE_VERSION.key, middlewareVersion);
+    if (webengineVersion != null) {
+      span.setAttribute(WebengineAttributes.WEBENGINE_VERSION.key, webengineVersion);
     }
   }
 

--- a/custom/src/main/java/com/splunk/opentelemetry/webengine/WebengineAttributes.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/webengine/WebengineAttributes.java
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package com.splunk.opentelemetry.middleware;
+package com.splunk.opentelemetry.webengine;
 
-public enum MiddlewareAttributes {
-  MIDDLEWARE_NAME("middleware.name"),
-  MIDDLEWARE_VERSION("middleware.version");
+public enum WebengineAttributes {
+  WEBENGINE_NAME("webengine.name"),
+  WEBENGINE_VERSION("webengine.version");
 
   public final String key;
 
-  MiddlewareAttributes(String key) {
+  WebengineAttributes(String key) {
     this.key = key;
   }
 }

--- a/custom/src/main/java/com/splunk/opentelemetry/webengine/WebengineBootstrapPackagesProvider.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/webengine/WebengineBootstrapPackagesProvider.java
@@ -14,16 +14,19 @@
  * limitations under the License.
  */
 
-package com.splunk.opentelemetry.middleware;
+package com.splunk.opentelemetry.webengine;
 
 import com.google.auto.service.AutoService;
-import io.opentelemetry.sdk.autoconfigure.spi.SdkTracerProviderConfigurer;
-import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
+import com.splunk.opentelemetry.javaagent.bootstrap.WebengineHolder;
+import io.opentelemetry.instrumentation.api.config.Config;
+import io.opentelemetry.javaagent.extension.bootstrap.BootstrapPackagesBuilder;
+import io.opentelemetry.javaagent.extension.bootstrap.BootstrapPackagesConfigurer;
 
-@AutoService(SdkTracerProviderConfigurer.class)
-public class MiddlewareTracerProviderConfigurer implements SdkTracerProviderConfigurer {
+@AutoService(BootstrapPackagesConfigurer.class)
+public class WebengineBootstrapPackagesProvider implements BootstrapPackagesConfigurer {
+
   @Override
-  public void configure(SdkTracerProviderBuilder tracerProvider) {
-    tracerProvider.addSpanProcessor(new MiddlewareAttributeSpanProcessor());
+  public void configure(Config config, BootstrapPackagesBuilder builder) {
+    builder.add(WebengineHolder.class.getPackage().getName());
   }
 }

--- a/custom/src/main/java/com/splunk/opentelemetry/webengine/WebengineTracerProviderConfigurer.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/webengine/WebengineTracerProviderConfigurer.java
@@ -14,19 +14,16 @@
  * limitations under the License.
  */
 
-package com.splunk.opentelemetry.middleware;
+package com.splunk.opentelemetry.webengine;
 
 import com.google.auto.service.AutoService;
-import com.splunk.opentelemetry.javaagent.bootstrap.MiddlewareHolder;
-import io.opentelemetry.instrumentation.api.config.Config;
-import io.opentelemetry.javaagent.extension.bootstrap.BootstrapPackagesBuilder;
-import io.opentelemetry.javaagent.extension.bootstrap.BootstrapPackagesConfigurer;
+import io.opentelemetry.sdk.autoconfigure.spi.SdkTracerProviderConfigurer;
+import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
 
-@AutoService(BootstrapPackagesConfigurer.class)
-public class MiddlewareBootstrapPackagesProvider implements BootstrapPackagesConfigurer {
-
+@AutoService(SdkTracerProviderConfigurer.class)
+public class WebengineTracerProviderConfigurer implements SdkTracerProviderConfigurer {
   @Override
-  public void configure(Config config, BootstrapPackagesBuilder builder) {
-    builder.add(MiddlewareHolder.class.getPackage().getName());
+  public void configure(SdkTracerProviderBuilder tracerProvider) {
+    tracerProvider.addSpanProcessor(new WebengineAttributeSpanProcessor());
   }
 }

--- a/docs/supported-libraries.md
+++ b/docs/supported-libraries.md
@@ -10,7 +10,7 @@ additional custom features:
 
 * We instrument [several HTTP server frameworks](server-trace-info.md#supported-frameworks-and-libraries)
   and return server trace information in the HTTP response;
-* We collect information about [application servers](middleware-attributes.md) that are being used and store it in
+* We collect information about [application servers](webengine-attributes.md) that are being used and store it in
   server span attributes;
 * We gather [basic application and JVM metrics](metrics.md) and export it to the Smart Agent, the OpenTelemetry
   Collector or Splunk ingest.

--- a/docs/webengine-attributes.md
+++ b/docs/webengine-attributes.md
@@ -1,6 +1,6 @@
-> The official Splunk documentation for this page is [Middleware attributes](https://docs.splunk.com/Observability/gdi/get-data-in/application/java/configuration/java-otel-metrics-attributes.html#middleware-attributes-java-otel).
+> The official Splunk documentation for this page is [Webengine attributes](https://docs.splunk.com/Observability/gdi/get-data-in/application/java/configuration/java-otel-metrics-attributes.html#middleware-attributes-java-otel).
 
-# Middleware Attributes
+# Webengine Attributes
 
 > :construction: &nbsp;Status: Experimental
 
@@ -9,8 +9,8 @@ adds the following attributes to `SERVER` spans:
 
 | Span attribute       | Example     | Description |
 | -------------------- | ----------- | ----------- |
-| `middleware.name`    | `tomcat`    | The name of the application server.
-| `middleware.version` | `7.0.107.0` | The version of the application server.
+| `webengine.name`    | `tomcat`    | The name of the application server.
+| `webengine.version` | `7.0.107.0` | The version of the application server.
 
 All application servers
 from [this list](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/supported-libraries.md#application-servers)

--- a/instrumentation/tomcat/src/main/java/com/splunk/opentelemetry/webengine/TomcatAttributesInstrumentationModule.java
+++ b/instrumentation/tomcat/src/main/java/com/splunk/opentelemetry/webengine/TomcatAttributesInstrumentationModule.java
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package com.splunk.opentelemetry.middleware;
+package com.splunk.opentelemetry.webengine;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
-import static net.bytebuddy.matcher.ElementMatchers.isTypeInitializer;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import com.google.auto.service.AutoService;
-import com.splunk.opentelemetry.javaagent.bootstrap.MiddlewareHolder;
-import com.sun.appserv.server.util.Version;
+import com.splunk.opentelemetry.javaagent.bootstrap.WebengineHolder;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
@@ -31,17 +31,19 @@ import java.util.List;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.catalina.util.ServerInfo;
 
 @AutoService(InstrumentationModule.class)
-public class GlassfishAttributesInstrumentationModule extends InstrumentationModule {
+public class TomcatAttributesInstrumentationModule extends InstrumentationModule {
 
-  public GlassfishAttributesInstrumentationModule() {
-    super("glassfish");
+  public TomcatAttributesInstrumentationModule() {
+    super("tomcat");
   }
 
   @Override
   public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
-    return hasClassesNamed("com.sun.appserv.server.util.Version");
+    return hasClassesNamed(
+        "org.apache.catalina.startup.Catalina", "org.apache.catalina.util.ServerInfo");
   }
 
   @Override
@@ -53,24 +55,23 @@ public class GlassfishAttributesInstrumentationModule extends InstrumentationMod
 
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
-      return named("com.sun.appserv.server.util.Version");
+      return named("org.apache.catalina.startup.Catalina");
     }
 
     @Override
     public void transform(TypeTransformer typeTransformer) {
       typeTransformer.applyAdviceToMethod(
-          isTypeInitializer(),
-          GlassfishAttributesInstrumentationModule.class.getName()
-              + "$MiddlewareInitializedAdvice");
+          isMethod().and(isPublic()).and(named("start")),
+          TomcatAttributesInstrumentationModule.class.getName() + "$WebengineInitializedAdvice");
     }
   }
 
   @SuppressWarnings("unused")
-  public static class MiddlewareInitializedAdvice {
-    @Advice.OnMethodExit(suppress = Throwable.class)
-    public static void onExit() {
-      MiddlewareHolder.trySetName(Version.getProductName());
-      MiddlewareHolder.trySetVersion(Version.getVersionNumber());
+  public static class WebengineInitializedAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter() {
+      WebengineHolder.trySetVersion(ServerInfo.getServerNumber());
+      WebengineHolder.trySetName("tomcat");
     }
   }
 }

--- a/instrumentation/weblogic/src/main/java/com/splunk/opentelemetry/webengine/weblogic/WebLogicAttributeCollector.java
+++ b/instrumentation/weblogic/src/main/java/com/splunk/opentelemetry/webengine/weblogic/WebLogicAttributeCollector.java
@@ -14,25 +14,25 @@
  * limitations under the License.
  */
 
-package com.splunk.opentelemetry.middleware.weblogic;
+package com.splunk.opentelemetry.webengine.weblogic;
 
-import com.splunk.opentelemetry.javaagent.bootstrap.MiddlewareHolder;
+import com.splunk.opentelemetry.javaagent.bootstrap.WebengineHolder;
 import java.util.HashMap;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 
 public class WebLogicAttributeCollector {
   private static final String CONTEXT_ATTRIBUTE_NAME = "otel.weblogic.attributes";
-  public static final String REQUEST_ATTRIBUTE_NAME = "otel.middleware";
+  public static final String REQUEST_ATTRIBUTE_NAME = "otel.webengine";
 
-  public static void attachMiddlewareAttributes(HttpServletRequest servletRequest) {
+  public static void attachWebengineAttributes(HttpServletRequest servletRequest) {
     WebLogicEntity.Request request = WebLogicEntity.Request.wrap(servletRequest);
 
-    Map<?, ?> attributes = fetchMiddlewareAttributes(request.getContext());
+    Map<?, ?> attributes = fetchWebengineAttributes(request.getContext());
     request.instance.setAttribute(REQUEST_ATTRIBUTE_NAME, attributes);
   }
 
-  private static Map<?, ?> fetchMiddlewareAttributes(WebLogicEntity.Context context) {
+  private static Map<?, ?> fetchWebengineAttributes(WebLogicEntity.Context context) {
     if (context.instance == null) {
       return null;
     }
@@ -44,19 +44,19 @@ public class WebLogicAttributeCollector {
     }
 
     // Do this here to avoid duplicate work
-    storeMiddlewareIdentity(context);
+    storeWebengineIdentity(context);
 
-    Map<String, String> middleware = collectMiddlewareAttributes(context);
-    context.instance.setAttribute(CONTEXT_ATTRIBUTE_NAME, middleware);
-    return middleware;
+    Map<String, String> webengine = collectWebengineAttributes(context);
+    context.instance.setAttribute(CONTEXT_ATTRIBUTE_NAME, webengine);
+    return webengine;
   }
 
-  private static void storeMiddlewareIdentity(WebLogicEntity.Context context) {
-    MiddlewareHolder.trySetName("WebLogic Server");
-    MiddlewareHolder.trySetVersion(detectVersion(context));
+  private static void storeWebengineIdentity(WebLogicEntity.Context context) {
+    WebengineHolder.trySetName("WebLogic Server");
+    WebengineHolder.trySetVersion(detectVersion(context));
   }
 
-  private static Map<String, String> collectMiddlewareAttributes(WebLogicEntity.Context context) {
+  private static Map<String, String> collectWebengineAttributes(WebLogicEntity.Context context) {
     WebLogicEntity.Bean applicationBean = context.getBean();
     WebLogicEntity.Bean webServerBean = context.getServer().getBean();
     WebLogicEntity.Bean serverBean = webServerBean.getParent();
@@ -64,10 +64,10 @@ public class WebLogicAttributeCollector {
     WebLogicEntity.Bean domainBean = serverBean.getParent();
 
     Map<String, String> attributes = new HashMap<>();
-    attributes.put("middleware.weblogic.domain", domainBean.getName());
-    attributes.put("middleware.weblogic.cluster", clusterBean.getName());
-    attributes.put("middleware.weblogic.server", webServerBean.getName());
-    attributes.put("middleware.weblogic.application", applicationBean.getName());
+    attributes.put("webengine.weblogic.domain", domainBean.getName());
+    attributes.put("webengine.weblogic.cluster", clusterBean.getName());
+    attributes.put("webengine.weblogic.server", webServerBean.getName());
+    attributes.put("webengine.weblogic.application", applicationBean.getName());
 
     return attributes;
   }

--- a/instrumentation/weblogic/src/main/java/com/splunk/opentelemetry/webengine/weblogic/WebLogicEntity.java
+++ b/instrumentation/weblogic/src/main/java/com/splunk/opentelemetry/webengine/weblogic/WebLogicEntity.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.splunk.opentelemetry.middleware.weblogic;
+package com.splunk.opentelemetry.webengine.weblogic;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;

--- a/instrumentation/weblogic/src/main/java/com/splunk/opentelemetry/webengine/weblogic/WebLogicInstrumentationModule.java
+++ b/instrumentation/weblogic/src/main/java/com/splunk/opentelemetry/webengine/weblogic/WebLogicInstrumentationModule.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.splunk.opentelemetry.middleware.weblogic;
+package com.splunk.opentelemetry.webengine.weblogic;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.extendsClass;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
@@ -40,7 +40,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 /**
- * Adds an instrumentation to collect middleware attributes for WebLogic Server 12 and 14. As span
+ * Adds an instrumentation to collect webengine attributes for WebLogic Server 12 and 14. As span
  * detection on WebLogic does not require any special logic, this does not initiate servlet spans by
  * itself, but saves the special attributes as a map to a servlet request attribute, which is then
  * later read when span is started by generic servlet instrumentation.
@@ -60,10 +60,10 @@ public class WebLogicInstrumentationModule extends InstrumentationModule {
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return Arrays.asList(new MiddlewareInstrumentation(), new ServletInstrumentation());
+    return Arrays.asList(new WebengineInstrumentation(), new ServletInstrumentation());
   }
 
-  private static class MiddlewareInstrumentation implements TypeInstrumentation {
+  private static class WebengineInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       return named("weblogic.servlet.internal.WebAppServletContext$ServletInvocationAction");
@@ -75,14 +75,14 @@ public class WebLogicInstrumentationModule extends InstrumentationModule {
           named("wrapRun")
               .and(takesArgument(1, named("javax.servlet.http.HttpServletRequest")))
               .and(isPrivate()),
-          WebLogicInstrumentationModule.class.getName() + "$MiddlewareAdvice");
+          WebLogicInstrumentationModule.class.getName() + "$WebengineAdvice");
     }
   }
 
-  private static class MiddlewareAdvice {
+  private static class WebengineAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void start(@Advice.Argument(1) HttpServletRequest servletRequest) {
-      WebLogicAttributeCollector.attachMiddlewareAttributes(servletRequest);
+      WebLogicAttributeCollector.attachWebengineAttributes(servletRequest);
     }
   }
 
@@ -113,7 +113,7 @@ public class WebLogicInstrumentationModule extends InstrumentationModule {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void start(
         @Advice.Argument(value = 0, readOnly = false) HttpServletRequest request) {
-      Object value = request.getAttribute("otel.middleware");
+      Object value = request.getAttribute("otel.webengine");
 
       if (value instanceof Map<?, ?>) {
         Span span = Java8BytecodeBridge.currentSpan();

--- a/instrumentation/wildfly/src/main/java/com/splunk/opentelemetry/webengine/WildFlyAttributesInstrumentationModule.java
+++ b/instrumentation/wildfly/src/main/java/com/splunk/opentelemetry/webengine/WildFlyAttributesInstrumentationModule.java
@@ -14,35 +14,35 @@
  * limitations under the License.
  */
 
-package com.splunk.opentelemetry.middleware;
+package com.splunk.opentelemetry.webengine;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
-import static net.bytebuddy.matcher.ElementMatchers.isMethod;
-import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import com.google.auto.service.AutoService;
-import com.ibm.ws.kernel.productinfo.ProductInfo;
-import com.splunk.opentelemetry.javaagent.bootstrap.MiddlewareHolder;
+import com.splunk.opentelemetry.javaagent.bootstrap.WebengineHolder;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import io.opentelemetry.javaagent.instrumentation.api.CallDepth;
 import java.util.Collections;
 import java.util.List;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
+import org.jboss.as.version.ProductConfig;
 
 @AutoService(InstrumentationModule.class)
-public class LibertyAttributesInstrumentationModule extends InstrumentationModule {
+public class WildFlyAttributesInstrumentationModule extends InstrumentationModule {
 
-  public LibertyAttributesInstrumentationModule() {
-    super("liberty");
+  public WildFlyAttributesInstrumentationModule() {
+    super("wildfly");
   }
 
   @Override
   public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
-    return hasClassesNamed("com.ibm.ws.kernel.boot.internal.KernelBootstrap");
+    return hasClassesNamed("org.jboss.as.version.ProductConfig");
   }
 
   @Override
@@ -54,35 +54,33 @@ public class LibertyAttributesInstrumentationModule extends InstrumentationModul
 
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
-      return named("com.ibm.ws.kernel.boot.internal.KernelBootstrap");
+      return named("org.jboss.as.server.ServerEnvironment");
     }
 
     @Override
     public void transform(TypeTransformer typeTransformer) {
       typeTransformer.applyAdviceToMethod(
-          isMethod().and(isPublic()).and(named("go")),
-          LibertyAttributesInstrumentationModule.class.getName() + "$MiddlewareInitializedAdvice");
+          isConstructor(),
+          WildFlyAttributesInstrumentationModule.class.getName() + "$WebengineInitializedAdvice");
     }
   }
 
   @SuppressWarnings("unused")
-  public static class MiddlewareInitializedAdvice {
-    @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void onEnter() {
-      String version = null;
-      for (ProductInfo p : ProductInfo.getAllProductInfo().values()) {
-        // older versions have only WebSphereApplicationServer.properties
-        // openliberty distribution only has openliberty.properties
-        // ibm distribution has both
-        if ("openliberty.properties".equals(p.getFile().getName())
-            || "WebSphereApplicationServer.properties".equals(p.getFile().getName())) {
-          version = p.getVersion();
-          break;
-        }
-      }
+  public static class WebengineInitializedAdvice {
+    @Advice.OnMethodEnter
+    public static void onEnter(@Advice.Local("splunkCallDepth") CallDepth callDepth) {
+      callDepth = CallDepth.forClass(ProductConfig.class);
+      callDepth.getAndIncrement();
+    }
 
-      MiddlewareHolder.trySetVersion(version);
-      MiddlewareHolder.trySetName("websphere liberty");
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onExit(
+        @Advice.Local("splunkCallDepth") CallDepth callDepth,
+        @Advice.FieldValue("productConfig") ProductConfig productConfig) {
+      if (callDepth.decrementAndGet() == 0 && productConfig != null) {
+        WebengineHolder.trySetName(productConfig.resolveName());
+        WebengineHolder.trySetVersion(productConfig.resolveVersion());
+      }
     }
   }
 }

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/AppServerTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/AppServerTest.java
@@ -73,7 +73,7 @@ public abstract class AppServerTest extends SmokeTest {
         2,
         traces.countSpansByKind(Span.SpanKind.SPAN_KIND_SERVER),
         "Server spans in the distributed trace");
-    assertMiddlewareAttributesInWebAppTrace(serverAttributes, traces);
+    assertWebengineAttributesInWebAppTrace(serverAttributes, traces);
 
     assertEquals(
         1, traces.countFilteredAttributes("http.url", url), "The span for the initial web request");
@@ -117,16 +117,16 @@ public abstract class AppServerTest extends SmokeTest {
     return 3;
   }
 
-  protected void assertMiddlewareAttributesInWebAppTrace(
+  protected void assertWebengineAttributesInWebAppTrace(
       ExpectedServerAttributes serverAttributes, TraceInspector traces) {
     assertEquals(
         2,
-        traces.countFilteredAttributes("middleware.name", serverAttributes.middlewareName),
-        "Middleware name is present on all server spans");
+        traces.countFilteredAttributes("webengine.name", serverAttributes.webengineName),
+        "Webengine name is present on all server spans");
     assertEquals(
         2,
-        traces.countFilteredAttributes("middleware.version", serverAttributes.middlewareVersion),
-        "Middleware version is present on all server spans");
+        traces.countFilteredAttributes("webengine.version", serverAttributes.webengineVersion),
+        "Webengine version is present on all server spans");
   }
 
   protected void assertServerHandler(ExpectedServerAttributes serverAttributes)
@@ -152,13 +152,13 @@ public abstract class AppServerTest extends SmokeTest {
         "Server span has expected name");
 
     assertEquals(
-        serverAttributes.middlewareName,
-        traces.getServerSpanAttribute("middleware.name"),
-        "Middleware name tag on server span");
+        serverAttributes.webengineName,
+        traces.getServerSpanAttribute("webengine.name"),
+        "Webengine name tag on server span");
     assertEquals(
-        serverAttributes.middlewareVersion,
-        traces.getServerSpanAttribute("middleware.version"),
-        "Middleware version tag on server span");
+        serverAttributes.webengineVersion,
+        traces.getServerSpanAttribute("webengine.version"),
+        "Webengine version tag on server span");
 
     clearTelemetry();
   }
@@ -170,14 +170,14 @@ public abstract class AppServerTest extends SmokeTest {
 
   protected static class ExpectedServerAttributes {
     final String handlerSpanName;
-    final String middlewareName;
-    final String middlewareVersion;
+    final String webengineName;
+    final String webengineVersion;
 
     public ExpectedServerAttributes(
-        String handlerSpanName, String middlewareName, String middlewareVersion) {
+        String handlerSpanName, String webengineName, String webengineVersion) {
       this.handlerSpanName = handlerSpanName;
-      this.middlewareName = middlewareName;
-      this.middlewareVersion = middlewareVersion;
+      this.webengineName = webengineName;
+      this.webengineVersion = webengineVersion;
     }
   }
 

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/WebLogicSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/WebLogicSmokeTest.java
@@ -60,23 +60,23 @@ class WebLogicSmokeTest extends AppServerTest {
   }
 
   @Override
-  protected void assertMiddlewareAttributesInWebAppTrace(
+  protected void assertWebengineAttributesInWebAppTrace(
       ExpectedServerAttributes serverAttributes, TraceInspector traces) {
-    super.assertMiddlewareAttributesInWebAppTrace(serverAttributes, traces);
+    super.assertWebengineAttributesInWebAppTrace(serverAttributes, traces);
 
     Assertions.assertEquals(
         "domain1",
-        traces.getServerSpanAttribute("middleware.weblogic.domain"),
+        traces.getServerSpanAttribute("webengine.weblogic.domain"),
         "WebLogic Domain attribute present");
 
     Assertions.assertEquals(
         "admin-server",
-        traces.getServerSpanAttribute("middleware.weblogic.server"),
+        traces.getServerSpanAttribute("webengine.weblogic.server"),
         "WebLogic Server attribute present");
 
     Assertions.assertEquals(
         "app",
-        traces.getServerSpanAttribute("middleware.weblogic.application"),
+        traces.getServerSpanAttribute("webengine.weblogic.application"),
         "WebLogic Application attribute present");
   }
 }


### PR DESCRIPTION
Just search and replace, no other changes

/cc @theletterf The following documentation (and link to it) should be fixed as well:

https://docs.splunk.com/Observability/gdi/get-data-in/application/java/configuration/java-otel-metrics-attributes.html#middleware-attributes-java-otel