### PR TITLE
Implement metrics for IBM WebSphere thread pools

### DIFF
--- a/bootstrap/build.gradle.kts
+++ b/bootstrap/build.gradle.kts
@@ -1,4 +1,7 @@
 dependencies {
+  compileOnly("com.google.auto.value:auto-value-annotations")
+  annotationProcessor("com.google.auto.value:auto-value")
+
   // slf4j is included in the otel javaagent, no need to add it here too
   compileOnly("org.slf4j:slf4j-api")
   // required to access OpenTelemetryAgent
@@ -6,6 +9,8 @@ dependencies {
 
   // add micrometer to the bootstrap classloader so that it's available in instrumentations
   implementation("io.micrometer:micrometer-core")
+
+  testImplementation("org.slf4j:slf4j-api")
 }
 
 tasks {

--- a/bootstrap/src/main/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/GaugeSemanticConvention.java
+++ b/bootstrap/src/main/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/GaugeSemanticConvention.java
@@ -20,6 +20,7 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tags;
 import java.util.function.Supplier;
+import java.util.function.ToDoubleFunction;
 
 public final class GaugeSemanticConvention implements MeterSemanticConvention {
   private final String name;
@@ -34,8 +35,16 @@ public final class GaugeSemanticConvention implements MeterSemanticConvention {
     return new GaugeSemanticConvention(name, baseUnit);
   }
 
+  public <T> Gauge create(Tags additionalTags, T obj, ToDoubleFunction<T> function) {
+    return build(Gauge.builder(name, obj, function), additionalTags);
+  }
+
   public Gauge create(Tags additionalTags, Supplier<Number> function) {
-    return Gauge.builder(name, function)
+    return build(Gauge.builder(name, function), additionalTags);
+  }
+
+  private <T> Gauge build(Gauge.Builder<T> builder, Tags additionalTags) {
+    return builder
         .tags(GlobalMetricsTags.get())
         .tags(additionalTags)
         .baseUnit(baseUnit)

--- a/bootstrap/src/main/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/jmx/JmxAttributesHelper.java
+++ b/bootstrap/src/main/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/jmx/JmxAttributesHelper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.javaagent.bootstrap.metrics.jmx;
+
+import java.util.function.ToDoubleFunction;
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+
+public final class JmxAttributesHelper {
+
+  public static ToDoubleFunction<MBeanServer> getNumberAttribute(
+      ObjectName objectName, String attributeName) {
+    return mBeanServer -> {
+      try {
+        Object value = mBeanServer.getAttribute(objectName, attributeName);
+        return value instanceof Number ? ((Number) value).doubleValue() : Double.NaN;
+      } catch (MBeanException
+          | AttributeNotFoundException
+          | InstanceNotFoundException
+          | ReflectionException e) {
+        return Double.NaN;
+      }
+    };
+  }
+
+  private JmxAttributesHelper() {}
+}

--- a/bootstrap/src/main/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/jmx/JmxMetricsWatcher.java
+++ b/bootstrap/src/main/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/jmx/JmxMetricsWatcher.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.javaagent.bootstrap.metrics.jmx;
+
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toSet;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import java.lang.management.ManagementFactory;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.management.InstanceNotFoundException;
+import javax.management.JMException;
+import javax.management.ListenerNotFoundException;
+import javax.management.MBeanServer;
+import javax.management.MBeanServerDelegate;
+import javax.management.MBeanServerFactory;
+import javax.management.MBeanServerNotification;
+import javax.management.Notification;
+import javax.management.NotificationFilter;
+import javax.management.NotificationListener;
+import javax.management.ObjectName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class JmxMetricsWatcher {
+
+  private static final Logger log = LoggerFactory.getLogger(JmxMetricsWatcher.class);
+
+  private static final AtomicInteger threadIds = new AtomicInteger();
+  private static final ThreadFactory daemonThreadFactory =
+      r -> {
+        Thread t = new Thread(r, "JmxMetricsWatcher-" + threadIds.incrementAndGet());
+        t.setDaemon(true);
+        t.setContextClassLoader(null);
+        return t;
+      };
+
+  private static final Set<String> handledNotificationTypes =
+      new HashSet<>(
+          asList(
+              MBeanServerNotification.REGISTRATION_NOTIFICATION,
+              MBeanServerNotification.UNREGISTRATION_NOTIFICATION));
+
+  private final MBeanServer mBeanServer;
+  private final ExecutorService executorService;
+  private final MeterRegistry meterRegistry;
+  private final JmxQuery query;
+  private final MetersFactory metersFactory;
+
+  private final Map<ObjectName, List<Meter>> meters = new ConcurrentHashMap<>();
+  private volatile NotificationListener notificationListener;
+
+  public JmxMetricsWatcher(JmxQuery query, MetersFactory metersFactory) {
+    this(
+        findMBeanServer(),
+        Executors.newSingleThreadExecutor(daemonThreadFactory),
+        Metrics.globalRegistry,
+        query,
+        metersFactory);
+  }
+
+  // visible for tests
+  JmxMetricsWatcher(
+      MBeanServer mBeanServer,
+      ExecutorService executorService,
+      MeterRegistry meterRegistry,
+      JmxQuery query,
+      MetersFactory metersFactory) {
+    this.mBeanServer = mBeanServer;
+    this.executorService = executorService;
+    this.meterRegistry = meterRegistry;
+    this.query = query;
+    this.metersFactory = metersFactory;
+  }
+
+  // copied from micrometer CommonsObjectPool2Metrics class
+  private static MBeanServer findMBeanServer() {
+    List<MBeanServer> mBeanServers = MBeanServerFactory.findMBeanServer(null);
+    if (!mBeanServers.isEmpty()) {
+      return mBeanServers.get(0);
+    }
+    return ManagementFactory.getPlatformMBeanServer();
+  }
+
+  public void start() {
+    try {
+      // get all mbeans matching the query, register meters for them
+      Set<ObjectName> existingObjects = mBeanServer.queryNames(query.toObjectNameQuery(), null);
+      for (ObjectName existingObject : existingObjects) {
+        meters.compute(existingObject, this::computeMeters);
+      }
+
+      // register a notification listener that'll add and remove meters as they come
+      NotificationFilter filter = this::isNotificationEnabled;
+      notificationListener = this::handleNotification;
+      mBeanServer.addNotificationListener(
+          MBeanServerDelegate.DELEGATE_NAME, notificationListener, filter, null);
+    } catch (JMException e) {
+      log.warn("Could not start JMX metrics listener", e);
+    }
+  }
+
+  public void stop() {
+    if (notificationListener != null) {
+      try {
+        mBeanServer.removeNotificationListener(
+            MBeanServerDelegate.DELEGATE_NAME, notificationListener);
+        notificationListener = null;
+      } catch (InstanceNotFoundException | ListenerNotFoundException e) {
+        log.warn("Could not remove JMX metrics listener from the MBeanServer", e);
+      }
+    }
+
+    executorService.shutdown();
+
+    meters.values().stream().flatMap(Collection::stream).forEach(meterRegistry::remove);
+    meters.clear();
+  }
+
+  // visible for tests
+  Set<Meter> getMeters() {
+    return meters.values().stream().flatMap(Collection::stream).collect(toSet());
+  }
+
+  private List<Meter> computeMeters(ObjectName objectName, List<Meter> meters) {
+    if (meters == null) {
+      meters = new CopyOnWriteArrayList<>();
+    }
+    try {
+      meters.addAll(metersFactory.createMeters(mBeanServer, objectName));
+    } catch (JMException e) {
+      throw new IllegalStateException(
+          "Could not create meters for JMX object; most likely a programming error", e);
+    }
+    return meters;
+  }
+
+  private boolean isNotificationEnabled(Notification notification) {
+    if (!handledNotificationTypes.contains(notification.getType())) {
+      return false;
+    }
+    ObjectName objectName = ((MBeanServerNotification) notification).getMBeanName();
+    return query.matches(objectName);
+  }
+
+  private void handleNotification(Notification notification, Object handback) {
+    // we can't get JMX object attributes in the NotificationListener, so we'll do that
+    // asynchronously on a separate thread
+    executorService.submit(() -> handleNotificationAsync(notification));
+  }
+
+  private void handleNotificationAsync(Notification notification) {
+    if (!(notification instanceof MBeanServerNotification)) {
+      return;
+    }
+    ObjectName objectName = ((MBeanServerNotification) notification).getMBeanName();
+
+    if (MBeanServerNotification.REGISTRATION_NOTIFICATION.equals(notification.getType())) {
+      meters.compute(objectName, this::computeMeters);
+    } else if (MBeanServerNotification.UNREGISTRATION_NOTIFICATION.equals(notification.getType())) {
+      List<Meter> metersToRemove = meters.remove(objectName);
+      for (Meter meter : metersToRemove) {
+        meterRegistry.remove(meter);
+      }
+    }
+  }
+}

--- a/bootstrap/src/main/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/jmx/JmxQuery.java
+++ b/bootstrap/src/main/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/jmx/JmxQuery.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.javaagent.bootstrap.metrics.jmx;
+
+import static java.util.Collections.singletonMap;
+
+import com.google.auto.value.AutoValue;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+@AutoValue
+public abstract class JmxQuery {
+
+  public static JmxQuery create(String domain, String propertyKey, String propertyValue) {
+    return create(domain, singletonMap(propertyKey, propertyValue));
+  }
+
+  public static JmxQuery create(String domain, Map<String, String> properties) {
+    return new AutoValue_JmxQuery(domain, properties);
+  }
+
+  abstract String domain();
+
+  abstract Map<String, String> properties();
+
+  ObjectName toObjectNameQuery() throws MalformedObjectNameException {
+    String propertiesStr =
+        properties().entrySet().stream()
+            .map(e -> e.getKey() + "=" + e.getValue())
+            .collect(Collectors.joining(","));
+    if (!propertiesStr.isEmpty()) {
+      propertiesStr += ",";
+    }
+    return new ObjectName(domain() + ":" + propertiesStr + "*");
+  }
+
+  boolean matches(ObjectName objectName) {
+    if (!objectName.getDomain().equals(domain())) {
+      return false;
+    }
+    for (Map.Entry<String, String> e : properties().entrySet()) {
+      if (!objectName.getKeyProperty(e.getKey()).equals(e.getValue())) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/bootstrap/src/main/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/jmx/MetersFactory.java
+++ b/bootstrap/src/main/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/jmx/MetersFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.javaagent.bootstrap.metrics.jmx;
+
+import io.micrometer.core.instrument.Meter;
+import java.util.List;
+import javax.management.JMException;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+@FunctionalInterface
+public interface MetersFactory {
+  List<Meter> createMeters(MBeanServer mBeanServer, ObjectName objectName) throws JMException;
+}

--- a/bootstrap/src/test/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/jmx/JmxMetricsWatcherIntegrationTest.java
+++ b/bootstrap/src/test/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/jmx/JmxMetricsWatcherIntegrationTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.javaagent.bootstrap.metrics.jmx;
+
+import static com.splunk.opentelemetry.javaagent.bootstrap.metrics.jmx.JmxAttributesHelper.getNumberAttribute;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.search.Search;
+import java.lang.management.ManagementFactory;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import org.junit.jupiter.api.Test;
+
+class JmxMetricsWatcherIntegrationTest {
+  @Test
+  void test() throws Exception {
+    var objectName1 = new ObjectName("com.splunk.test:type=Test,name=fgsfds");
+    ManagementFactory.getPlatformMBeanServer().registerMBean(new TestClass(12), objectName1);
+
+    var watcher =
+        new JmxMetricsWatcher(
+            JmxQuery.create("com.splunk.test", Map.of("type", "Test")),
+            JmxMetricsWatcherIntegrationTest::createMeters);
+    watcher.start();
+
+    var objectName2 = new ObjectName("com.splunk.test:type=Test,name=asdf");
+    ManagementFactory.getPlatformMBeanServer().registerMBean(new TestClass(42), objectName2);
+
+    await().atMost(5, SECONDS).untilAsserted(() -> assertEquals(2, getTestMeters().size()));
+
+    ManagementFactory.getPlatformMBeanServer().unregisterMBean(objectName2);
+
+    await().atMost(5, SECONDS).untilAsserted(() -> assertEquals(1, getTestMeters().size()));
+
+    watcher.stop();
+
+    await().atMost(5, SECONDS).untilAsserted(() -> assertTrue(getTestMeters().isEmpty()));
+  }
+
+  private static List<Meter> createMeters(MBeanServer mBeanServer, ObjectName objectName) {
+    Gauge gauge =
+        Gauge.builder("test_gauge", mBeanServer, getNumberAttribute(objectName, "foo"))
+            .tags("name", objectName.getKeyProperty("name"))
+            .register(Metrics.globalRegistry);
+    return List.of(gauge);
+  }
+
+  private Collection<Meter> getTestMeters() {
+    return Search.in(Metrics.globalRegistry).name("test_gauge").meters();
+  }
+}

--- a/bootstrap/src/test/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/jmx/JmxMetricsWatcherTest.java
+++ b/bootstrap/src/test/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/jmx/JmxMetricsWatcherTest.java
@@ -18,7 +18,7 @@ package com.splunk.opentelemetry.javaagent.bootstrap.metrics.jmx;
 
 import static javax.management.MBeanServerNotification.REGISTRATION_NOTIFICATION;
 import static javax.management.MBeanServerNotification.UNREGISTRATION_NOTIFICATION;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -67,7 +67,8 @@ class JmxMetricsWatcherTest {
   @BeforeEach
   void setUp() {
     underTest =
-        new JmxMetricsWatcher(mBeanServer, executorService, meterRegistry, query, metersFactory);
+        new JmxMetricsWatcher(
+            () -> mBeanServer, executorService, meterRegistry, query, metersFactory);
   }
 
   @Test
@@ -88,7 +89,7 @@ class JmxMetricsWatcherTest {
     underTest.start();
 
     // then
-    assertEquals(Set.of(meter1, meter2), underTest.getMeters());
+    assertThat(underTest.getAllMeters()).containsExactlyInAnyOrder(meter1, meter2);
   }
 
   @Test
@@ -148,7 +149,7 @@ class JmxMetricsWatcherTest {
     runnableCaptor.getValue().run();
 
     // then
-    assertEquals(Set.of(meter1, meter2), underTest.getMeters());
+    assertThat(underTest.getAllMeters()).containsExactlyInAnyOrder(meter1, meter2);
   }
 
   @Test
@@ -178,7 +179,7 @@ class JmxMetricsWatcherTest {
     runnableCaptor.getValue().run();
 
     // then
-    assertTrue(underTest.getMeters().isEmpty());
+    assertThat(underTest.getAllMeters()).isEmpty();
   }
 
   @Test
@@ -198,7 +199,7 @@ class JmxMetricsWatcherTest {
             notificationListenerCaptor.capture(),
             any(),
             isNull());
-    assertFalse(underTest.getMeters().isEmpty());
+    assertThat(underTest.getAllMeters()).isNotEmpty();
 
     // when
     underTest.stop();
@@ -208,7 +209,7 @@ class JmxMetricsWatcherTest {
         .removeNotificationListener(
             MBeanServerDelegate.DELEGATE_NAME, notificationListenerCaptor.getValue());
     verify(executorService).shutdown();
-    assertTrue(underTest.getMeters().isEmpty());
+    assertThat(underTest.getAllMeters()).isEmpty();
   }
 
   private static Notification notification(String type, ObjectName objectName) {

--- a/bootstrap/src/test/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/jmx/JmxMetricsWatcherTest.java
+++ b/bootstrap/src/test/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/jmx/JmxMetricsWatcherTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.javaagent.bootstrap.metrics.jmx;
+
+import static javax.management.MBeanServerNotification.REGISTRATION_NOTIFICATION;
+import static javax.management.MBeanServerNotification.UNREGISTRATION_NOTIFICATION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import javax.management.MBeanServer;
+import javax.management.MBeanServerDelegate;
+import javax.management.MBeanServerNotification;
+import javax.management.Notification;
+import javax.management.NotificationFilter;
+import javax.management.NotificationListener;
+import javax.management.ObjectName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class JmxMetricsWatcherTest {
+
+  @Mock MBeanServer mBeanServer;
+  @Mock ExecutorService executorService;
+  @Mock MeterRegistry meterRegistry;
+  @Mock MetersFactory metersFactory;
+
+  JmxQuery query = JmxQuery.create("com.splunk.test", "type", "TestType");
+
+  JmxMetricsWatcher underTest;
+
+  @Captor ArgumentCaptor<NotificationFilter> notificationFilterCaptor;
+  @Captor ArgumentCaptor<NotificationListener> notificationListenerCaptor;
+  @Captor ArgumentCaptor<Runnable> runnableCaptor;
+
+  @BeforeEach
+  void setUp() {
+    underTest =
+        new JmxMetricsWatcher(mBeanServer, executorService, meterRegistry, query, metersFactory);
+  }
+
+  @Test
+  void shouldRegisterMetersForAlreadyExistingJmxObjects() throws Exception {
+    // given
+    var objectName1 = new ObjectName("com.splunk.test:type=TestType,name=test1");
+    var objectName2 = new ObjectName("com.splunk.test:type=TestType,name=test2");
+
+    when(mBeanServer.queryNames(query.toObjectNameQuery(), null))
+        .thenReturn(Set.of(objectName1, objectName2));
+
+    var meter1 = mock(Meter.class);
+    var meter2 = mock(Meter.class);
+    when(metersFactory.createMeters(mBeanServer, objectName1)).thenReturn(List.of(meter1));
+    when(metersFactory.createMeters(mBeanServer, objectName2)).thenReturn(List.of(meter2));
+
+    // when
+    underTest.start();
+
+    // then
+    assertEquals(Set.of(meter1, meter2), underTest.getMeters());
+  }
+
+  @Test
+  void shouldFilterNotifications() throws Exception {
+    // given
+    when(mBeanServer.queryNames(query.toObjectNameQuery(), null)).thenReturn(Set.of());
+
+    underTest.start();
+    verify(mBeanServer)
+        .addNotificationListener(
+            eq(MBeanServerDelegate.DELEGATE_NAME),
+            any(NotificationListener.class),
+            notificationFilterCaptor.capture(),
+            isNull());
+
+    NotificationFilter filter = notificationFilterCaptor.getValue();
+
+    var wrongObjectName = new ObjectName("com.splunk.wrong_object_name:type=WrongType");
+    var correctObjectName = new ObjectName("com.splunk.test:type=TestType");
+
+    // when-then
+    assertFalse(filter.isNotificationEnabled(notification("some custom type", correctObjectName)));
+    assertFalse(
+        filter.isNotificationEnabled(notification(REGISTRATION_NOTIFICATION, wrongObjectName)));
+    assertFalse(
+        filter.isNotificationEnabled(notification(UNREGISTRATION_NOTIFICATION, wrongObjectName)));
+    assertTrue(
+        filter.isNotificationEnabled(notification(REGISTRATION_NOTIFICATION, correctObjectName)));
+    assertTrue(
+        filter.isNotificationEnabled(notification(UNREGISTRATION_NOTIFICATION, correctObjectName)));
+  }
+
+  @Test
+  void shouldHandleRegisterNotification() throws Exception {
+    // given
+    when(mBeanServer.queryNames(query.toObjectNameQuery(), null)).thenReturn(Set.of());
+
+    underTest.start();
+    verify(mBeanServer)
+        .addNotificationListener(
+            eq(MBeanServerDelegate.DELEGATE_NAME),
+            notificationListenerCaptor.capture(),
+            any(),
+            isNull());
+
+    NotificationListener listener = notificationListenerCaptor.getValue();
+
+    var objectName = new ObjectName("com.splunk.test:type=TestType,name=test");
+    var meter1 = mock(Meter.class);
+    var meter2 = mock(Meter.class);
+    when(metersFactory.createMeters(mBeanServer, objectName)).thenReturn(List.of(meter1, meter2));
+
+    // when
+    listener.handleNotification(notification(REGISTRATION_NOTIFICATION, objectName), null);
+    // capture and immediately run async listener method
+    verify(executorService).submit(runnableCaptor.capture());
+    runnableCaptor.getValue().run();
+
+    // then
+    assertEquals(Set.of(meter1, meter2), underTest.getMeters());
+  }
+
+  @Test
+  void shouldHandleUnregisterNotification() throws Exception {
+    // given
+    var objectName = new ObjectName("com.splunk.test:type=TestType,name=test");
+    when(mBeanServer.queryNames(query.toObjectNameQuery(), null)).thenReturn(Set.of(objectName));
+
+    var meter1 = mock(Meter.class);
+    var meter2 = mock(Meter.class);
+    when(metersFactory.createMeters(mBeanServer, objectName)).thenReturn(List.of(meter1, meter2));
+
+    underTest.start();
+    verify(mBeanServer)
+        .addNotificationListener(
+            eq(MBeanServerDelegate.DELEGATE_NAME),
+            notificationListenerCaptor.capture(),
+            any(),
+            isNull());
+
+    NotificationListener listener = notificationListenerCaptor.getValue();
+
+    // when
+    listener.handleNotification(notification(UNREGISTRATION_NOTIFICATION, objectName), null);
+    // capture and immediately run async listener method
+    verify(executorService).submit(runnableCaptor.capture());
+    runnableCaptor.getValue().run();
+
+    // then
+    assertTrue(underTest.getMeters().isEmpty());
+  }
+
+  @Test
+  void shouldStop() throws Exception {
+    // given
+    var objectName = new ObjectName("com.splunk.test:type=TestType,name=test");
+    when(mBeanServer.queryNames(query.toObjectNameQuery(), null)).thenReturn(Set.of(objectName));
+
+    var meter1 = mock(Meter.class);
+    var meter2 = mock(Meter.class);
+    when(metersFactory.createMeters(mBeanServer, objectName)).thenReturn(List.of(meter1, meter2));
+
+    underTest.start();
+    verify(mBeanServer)
+        .addNotificationListener(
+            eq(MBeanServerDelegate.DELEGATE_NAME),
+            notificationListenerCaptor.capture(),
+            any(),
+            isNull());
+    assertFalse(underTest.getMeters().isEmpty());
+
+    // when
+    underTest.stop();
+
+    // then
+    verify(mBeanServer)
+        .removeNotificationListener(
+            MBeanServerDelegate.DELEGATE_NAME, notificationListenerCaptor.getValue());
+    verify(executorService).shutdown();
+    assertTrue(underTest.getMeters().isEmpty());
+  }
+
+  private static Notification notification(String type, ObjectName objectName) {
+    return new MBeanServerNotification(type, new Object(), 0, objectName);
+  }
+}

--- a/bootstrap/src/test/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/jmx/JmxQueryTest.java
+++ b/bootstrap/src/test/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/jmx/JmxQueryTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.javaagent.bootstrap.metrics.jmx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import org.junit.jupiter.api.Test;
+
+class JmxQueryTest {
+  @Test
+  void shouldConvertToObjectName() throws MalformedObjectNameException {
+    var query = JmxQuery.create("com.splunk.test", Map.of("key", "value", "key2", "value2"));
+
+    assertEquals(
+        new ObjectName("com.splunk.test:key=value,key2=value2,*"), query.toObjectNameQuery());
+  }
+
+  @Test
+  void shouldConvertToObjectName_noKeyPropertiesCriteria() throws MalformedObjectNameException {
+    var query = JmxQuery.create("com.splunk.test", Map.of());
+
+    assertEquals(new ObjectName("com.splunk.test:*"), query.toObjectNameQuery());
+  }
+
+  @Test
+  void shouldNotMatchDifferentDomain() throws MalformedObjectNameException {
+    var query = JmxQuery.create("com.splunk.test", "type", "Test");
+    var objectName = new ObjectName("com.splunk.anotherDomain:type=Test");
+
+    assertFalse(query.matches(objectName));
+  }
+
+  @Test
+  void shouldNotMatchDifferentKeyProperties() throws MalformedObjectNameException {
+    var query = JmxQuery.create("com.splunk.test", "type", "Test");
+    var objectName = new ObjectName("com.splunk.test:type=AnotherType");
+
+    assertFalse(query.matches(objectName));
+  }
+
+  @Test
+  void shouldMatchObjectName() throws MalformedObjectNameException {
+    var query = JmxQuery.create("com.splunk.test", "type", "Test");
+    var objectName = new ObjectName("com.splunk.test:type=Test");
+
+    assertTrue(query.matches(objectName));
+  }
+}

--- a/bootstrap/src/test/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/jmx/TestClass.java
+++ b/bootstrap/src/test/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/jmx/TestClass.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.javaagent.bootstrap.metrics.jmx;
+
+public class TestClass implements TestClassMBean {
+  private final int value;
+
+  public TestClass(int value) {
+    this.value = value;
+  }
+
+  @Override
+  public int getValue() {
+    return value;
+  }
+}

--- a/bootstrap/src/test/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/jmx/TestClassMBean.java
+++ b/bootstrap/src/test/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/jmx/TestClassMBean.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.javaagent.bootstrap.metrics.jmx;
+
+public interface TestClassMBean {
+  int getValue();
+}

--- a/buildSrc/src/main/kotlin/splunk.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.java-conventions.gradle.kts
@@ -46,6 +46,10 @@ extensions.configure<DependencyManagementExtension>("dependencyManagement") {
       entry("slf4j-api")
       entry("slf4j-simple")
     }
+    dependencySet("com.google.auto.value:1.8.1") {
+      entry("auto-value")
+      entry("auto-value-annotations")
+    }
 
     // otel-java-instrumentation
     dependency("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:${otelInstrumentationAlphaVersion}")

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -121,6 +121,7 @@ All connection pool metrics have the following tags:
 Splunk Distribution of OpenTelemetry Java instruments several thread pool implementations:
 
 * [Tomcat connector thread pools](https://tomcat.apache.org/tomcat-8.5-doc/index.html)
+* [WebSphere Liberty web request thread pool](https://www.ibm.com/docs/en/was-liberty/base?topic=10-threadpool-monitoring)
 
 Each of the supported connection pools reports a subset of the following metrics:
 
@@ -139,4 +140,4 @@ All thread pool metrics have the following tags:
 | Tag name        | Tag value |
 | --------------- | --------- |
 | `executor.name` | The name of the thread pool.
-| `executor.type` | The type/implementation of the thread pool: e.g. `tomcat`.
+| `executor.type` | The type/implementation of the thread pool: e.g. `tomcat`, `liberty`.

--- a/instrumentation/liberty/src/main/java/com/splunk/opentelemetry/instrumentation/liberty/LibertyMetricsInstaller.java
+++ b/instrumentation/liberty/src/main/java/com/splunk/opentelemetry/instrumentation/liberty/LibertyMetricsInstaller.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.instrumentation.liberty;
+
+import static com.splunk.opentelemetry.javaagent.bootstrap.metrics.ThreadPoolSemanticConventions.EXECUTOR_NAME;
+import static com.splunk.opentelemetry.javaagent.bootstrap.metrics.ThreadPoolSemanticConventions.EXECUTOR_TYPE;
+import static com.splunk.opentelemetry.javaagent.bootstrap.metrics.ThreadPoolSemanticConventions.THREADS_ACTIVE;
+import static com.splunk.opentelemetry.javaagent.bootstrap.metrics.ThreadPoolSemanticConventions.THREADS_CURRENT;
+import static com.splunk.opentelemetry.javaagent.bootstrap.metrics.jmx.JmxAttributesHelper.getNumberAttribute;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
+
+import com.google.auto.service.AutoService;
+import com.splunk.opentelemetry.javaagent.bootstrap.metrics.jmx.JmxMetricsWatcher;
+import com.splunk.opentelemetry.javaagent.bootstrap.metrics.jmx.JmxQuery;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.opentelemetry.instrumentation.api.config.Config;
+import io.opentelemetry.javaagent.extension.AgentListener;
+import java.util.List;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+@AutoService(AgentListener.class)
+public class LibertyMetricsInstaller implements AgentListener {
+
+  private final JmxMetricsWatcher jmxMetricsWatcher =
+      new JmxMetricsWatcher(
+          JmxQuery.create("WebSphere", "type", "ThreadPoolStats"), this::createMeters);
+
+  @Override
+  public void afterAgent(Config config) {
+    boolean metricsRegistryPresent = !Metrics.globalRegistry.getRegistries().isEmpty();
+    if (!config.isInstrumentationEnabled(singleton("liberty"), metricsRegistryPresent)) {
+      return;
+    }
+    jmxMetricsWatcher.start();
+  }
+
+  private List<Meter> createMeters(MBeanServer mBeanServer, ObjectName objectName) {
+    Tags tags = executorTags(objectName);
+    return asList(
+        THREADS_CURRENT.create(tags, mBeanServer, getNumberAttribute(objectName, "PoolSize")),
+        THREADS_ACTIVE.create(tags, mBeanServer, getNumberAttribute(objectName, "ActiveThreads")));
+  }
+
+  private static Tags executorTags(ObjectName objectName) {
+    // use the "name" property if available
+    String name = objectName.getKeyProperty("name");
+    // if its unavailable just use the whole mbean name
+    if (name == null) {
+      name = objectName.toString();
+    }
+    return Tags.of(Tag.of(EXECUTOR_TYPE, "liberty"), Tag.of(EXECUTOR_NAME, name));
+  }
+}

--- a/instrumentation/liberty/src/main/java/com/splunk/opentelemetry/instrumentation/liberty/metrics/LauncherDelegateImplInstrumentation.java
+++ b/instrumentation/liberty/src/main/java/com/splunk/opentelemetry/instrumentation/liberty/metrics/LauncherDelegateImplInstrumentation.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.instrumentation.liberty.metrics;
+
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+final class LauncherDelegateImplInstrumentation implements TypeInstrumentation {
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("com.ibm.ws.kernel.launch.internal.LauncherDelegateImpl");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        named("launchFramework").and(isPublic()).and(takesArguments(0)),
+        this.getClass().getName() + "$LaunchFrameworkAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class LaunchFrameworkAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter() {
+      ThreadPoolMetrics.initialize();
+    }
+  }
+}

--- a/instrumentation/liberty/src/main/java/com/splunk/opentelemetry/instrumentation/liberty/metrics/LibertyMetricsInstrumentationModule.java
+++ b/instrumentation/liberty/src/main/java/com/splunk/opentelemetry/instrumentation/liberty/metrics/LibertyMetricsInstrumentationModule.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.instrumentation.liberty.metrics;
+
+import static java.util.Collections.singletonList;
+
+import com.google.auto.service.AutoService;
+import io.micrometer.core.instrument.Metrics;
+import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import java.util.List;
+
+// metrics are still experimental and can't be enabled by default - that's why we need a separate
+// InstrumentationModule for them
+@AutoService(InstrumentationModule.class)
+public class LibertyMetricsInstrumentationModule extends InstrumentationModule {
+  public LibertyMetricsInstrumentationModule() {
+    super("liberty", "liberty-metrics");
+  }
+
+  @Override
+  protected boolean defaultEnabled() {
+    boolean metricsRegistryPresent = !Metrics.globalRegistry.getRegistries().isEmpty();
+    return metricsRegistryPresent && super.defaultEnabled();
+  }
+
+  @Override
+  public boolean isHelperClass(String className) {
+    return className.startsWith("com.splunk.opentelemetry.instrumentation");
+  }
+
+  @Override
+  public List<TypeInstrumentation> typeInstrumentations() {
+    return singletonList(new LauncherDelegateImplInstrumentation());
+  }
+}

--- a/instrumentation/liberty/src/main/java/com/splunk/opentelemetry/instrumentation/liberty/webengine/LibertyAttributesInstrumentationModule.java
+++ b/instrumentation/liberty/src/main/java/com/splunk/opentelemetry/instrumentation/liberty/webengine/LibertyAttributesInstrumentationModule.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.splunk.opentelemetry.instrumentation.liberty;
+package com.splunk.opentelemetry.instrumentation.liberty.webengine;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/LibertySmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/LibertySmokeTest.java
@@ -50,7 +50,11 @@ public class LibertySmokeTest extends AppServerTest {
 
     assertServerHandler(expectedServerAttributes);
     assertWebAppTrace(expectedServerAttributes);
-    assertMetrics(waitForMetrics());
+
+    // TODO: Windows collector image cannot accept signalfx metrics right now, don't assert them
+    if (!image.isWindows()) {
+      assertMetrics(waitForMetrics());
+    }
 
     stopTarget();
   }

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/LibertySmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/LibertySmokeTest.java
@@ -16,8 +16,11 @@
 
 package com.splunk.opentelemetry;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.splunk.opentelemetry.helper.TestImage;
 import java.io.IOException;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -35,6 +38,10 @@ public class LibertySmokeTest extends AppServerTest {
         .stream();
   }
 
+  protected Map<String, String> getExtraResources() {
+    return Map.of("liberty-with-monitor.xml", "/config/server.xml");
+  }
+
   @ParameterizedTest(name = "[{index}] {0}")
   @MethodSource("supportedConfigurations")
   void libertySmokeTest(TestImage image, ExpectedServerAttributes expectedServerAttributes)
@@ -43,8 +50,15 @@ public class LibertySmokeTest extends AppServerTest {
 
     assertServerHandler(expectedServerAttributes);
     assertWebAppTrace(expectedServerAttributes);
+    assertMetrics(waitForMetrics());
 
     stopTarget();
+  }
+
+  private void assertMetrics(MetricsInspector metrics) {
+    var expectedAttrs = Map.of("executor_type", "liberty");
+    assertTrue(metrics.hasGaugeWithAttributes("executor.threads", expectedAttrs));
+    assertTrue(metrics.hasGaugeWithAttributes("executor.threads.active", expectedAttrs));
   }
 
   public static class LibertyAttributes extends ExpectedServerAttributes {

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/SmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/SmokeTest.java
@@ -43,8 +43,15 @@ public abstract class SmokeTest {
 
   private TelemetryRetriever telemetryRetriever;
 
-  /** Subclasses can override this method to customise target application's environment */
+  /** Subclasses can override this method to customise target application's environment. */
   protected Map<String, String> getExtraEnv() {
+    return Collections.emptyMap();
+  }
+
+  /**
+   * Subclasses can override this method to copy some extra resource files to the target container.
+   */
+  protected Map<String, String> getExtraResources() {
     return Collections.emptyMap();
   }
 
@@ -81,7 +88,8 @@ public abstract class SmokeTest {
       assumeTrue(containerManager.isImagePresent(image), "Proprietary image is present: " + image);
     }
 
-    containerManager.startTarget(image.imageName, agentPath, getExtraEnv(), getWaitStrategy());
+    containerManager.startTarget(
+        image.imageName, agentPath, getExtraEnv(), getExtraResources(), getWaitStrategy());
   }
 
   protected TargetWaitStrategy getWaitStrategy() {

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/LinuxTestContainerManager.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/LinuxTestContainerManager.java
@@ -110,6 +110,7 @@ public class LinuxTestContainerManager extends AbstractTestContainerManager {
       String targetImageName,
       String agentPath,
       Map<String, String> extraEnv,
+      Map<String, String> extraResources,
       TargetWaitStrategy waitStrategy) {
     target =
         new GenericContainer<>(DockerImageName.parse(targetImageName))
@@ -121,6 +122,11 @@ public class LinuxTestContainerManager extends AbstractTestContainerManager {
                 MountableFile.forHostPath(agentPath), "/" + TARGET_AGENT_FILENAME)
             .withEnv(getAgentEnvironment())
             .withEnv(extraEnv);
+
+    extraResources.forEach(
+        (file, path) ->
+            target.withCopyFileToContainer(MountableFile.forClasspathResource(file), path));
+
     if (waitStrategy != null) {
       if (waitStrategy instanceof TargetWaitStrategy.Log) {
         target =

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/TestContainerManager.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/TestContainerManager.java
@@ -35,6 +35,7 @@ public interface TestContainerManager {
       String targetImageName,
       String agentPath,
       Map<String, String> extraEnv,
+      Map<String, String> extraResources,
       TargetWaitStrategy waitStrategy);
 
   void stopTarget();

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/TestImage.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/TestImage.java
@@ -44,6 +44,10 @@ public class TestImage {
     return new TestImage(Platform.WINDOWS_X86_64, imageName, false);
   }
 
+  public boolean isWindows() {
+    return platform == Platform.WINDOWS_X86_64;
+  }
+
   public enum Platform {
     WINDOWS_X86_64,
     LINUX_X86_64,

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/windows/WindowsTestContainerManager.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/windows/WindowsTestContainerManager.java
@@ -189,6 +189,7 @@ public class WindowsTestContainerManager extends AbstractTestContainerManager {
       String targetImageName,
       String agentPath,
       Map<String, String> extraEnv,
+      Map<String, String> extraResources,
       TargetWaitStrategy waitStrategy) {
     stopTarget();
 
@@ -221,6 +222,10 @@ public class WindowsTestContainerManager extends AbstractTestContainerManager {
               try (InputStream agentFileStream = new FileInputStream(agentPath)) {
                 copyFileToContainer(
                     containerId, IOUtils.toByteArray(agentFileStream), "/" + TARGET_AGENT_FILENAME);
+
+                for (Map.Entry<String, String> e : extraResources.entrySet()) {
+                  copyResourceToContainer(containerId, e.getKey(), e.getValue());
+                }
               } catch (Exception e) {
                 throw new RuntimeException(e);
               }
@@ -251,6 +256,14 @@ public class WindowsTestContainerManager extends AbstractTestContainerManager {
       return true;
     } catch (Exception e) {
       return false;
+    }
+  }
+
+  private void copyResourceToContainer(
+      String containerId, String resourcePath, String containerPath) throws IOException {
+    try (InputStream is =
+        Thread.currentThread().getContextClassLoader().getResourceAsStream(resourcePath)) {
+      copyFileToContainer(containerId, IOUtils.toByteArray(is), containerPath);
     }
   }
 

--- a/smoke-tests/src/test/resources/liberty-with-monitor.xml
+++ b/smoke-tests/src/test/resources/liberty-with-monitor.xml
@@ -1,0 +1,13 @@
+<server description="Sample Liberty server">
+    <variable name="default.http.port" defaultValue="8080"/>
+
+    <featureManager>
+        <feature>javaee-8.0</feature>
+        <feature>monitor-1.0</feature>
+    </featureManager>
+
+    <webApplication location="app.war" contextRoot="/app" />
+    <mpMetrics authentication="false"/>
+
+    <httpEndpoint host="*" httpPort="${default.http.port}" id="defaultHttpEndpoint"/>
+</server>


### PR DESCRIPTION
I couldn't really test those metrics in this PR, because the OTel Liberty image does not have the `monitor-1.0` feature enabled and it doesn't register the thread pool mbean.