### PR TITLE
Default endpoint to otlp endpoint

### DIFF
--- a/profiler/README.md
+++ b/profiler/README.md
@@ -11,5 +11,5 @@ It should be considered experimental and is completely unsupported.
 |`splunk.profiler.directory`          | "."                    | location of jfr files                     |
 |`splunk.profiler.recording.duration` | 20000                  | number of milliseconds per recording unit |
 |`splunk.profiler.keep-files`         | false                  | leave JFR files on disk id `true`         |
-|`splunk.profiler.logs-endpoint`      | http://localhost:4317  | where to send OTLP logs                   |
+|`splunk.profiler.logs-endpoint`      | `otel.exporter.otlp.endpoint` or http://localhost:4317  | where to send OTLP logs                   |
 |`splunk.profiler.period.{eventName}` | n/a                    | customize period (in ms) for a specific jfr event. For example, to set the ThreadDump frequency to 1s (100ms): `-Dsplunk.profiler.period.threaddump=1000` |

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
@@ -30,6 +30,7 @@ public class Configuration implements ConfigPropertySource {
       "splunk.profiler.recording.duration";
   public static final String CONFIG_KEY_KEEP_FILES = "splunk.profiler.keep-files";
   public static final String CONFIG_KEY_INGEST_URL = "splunk.profiler.logs-endpoint";
+  public static final String CONFIG_KEY_OTEL_OTLP_URL = "otel.exporter.otlp.endpoint";
   public static final String CONFIG_KEY_PERIOD_PREFIX = "splunk.profiler.period";
 
   @Override

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/LogsExporterBuilder.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/LogsExporterBuilder.java
@@ -17,6 +17,7 @@
 package com.splunk.opentelemetry.profiler;
 
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_INGEST_URL;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_OTEL_OTLP_URL;
 
 import com.splunk.opentelemetry.logs.InstrumentationLibraryLogsAdapter;
 import com.splunk.opentelemetry.logs.LogEntryAdapter;
@@ -42,6 +43,9 @@ class LogsExporterBuilder {
             .addHeader("Extra-Content-Type", "otel-profiling-stacktraces");
 
     String ingestUrl = config.getProperty(CONFIG_KEY_INGEST_URL);
+    if (ingestUrl == null) {
+      ingestUrl = config.getProperty(CONFIG_KEY_OTEL_OTLP_URL);
+    }
     if (ingestUrl != null) {
       builder.setEndpoint(ingestUrl);
     }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/LogsExporterBuilderTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/LogsExporterBuilderTest.java
@@ -46,4 +46,15 @@ class LogsExporterBuilderTest {
     assertEquals("example.com:9122", endpoint);
     assertNotNull(exporter.getAdapter());
   }
+
+  @Test
+  void defaultEndpoint() {
+    Config config = mock(Config.class);
+    when(config.getProperty(Configuration.CONFIG_KEY_OTEL_OTLP_URL))
+        .thenReturn("http://mycollector.com:4312/");
+    OtlpLogsExporter exporter = (OtlpLogsExporter) LogsExporterBuilder.fromConfig(config);
+    String endpoint = exporter.getEndpoint();
+    assertEquals("mycollector.com:4312", endpoint);
+    assertNotNull(exporter.getAdapter());
+  }
 }


### PR DESCRIPTION
While we like the flexibility of having the ability to point profiling to a different ingest endpoint, we want to make it as easy as possible and minimize user effort. So now, if the user does not specify `splunk.profiler.logs-endpoint` but they do have `otel.exporter.otlp.endpoint` (like for traces/metrics), we will use that as a fallback default.