### PR TITLE
replace colons with underscores to support windows

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordingFileNamingConvention.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordingFileNamingConvention.java
@@ -28,7 +28,7 @@ class RecordingFileNamingConvention {
   private static final String PREFIX = "otel-profiler";
   // ISO_DATE_TIME format is like 2021-12-03T10:15:30
   private final Pattern filenamePattern =
-      Pattern.compile("^" + PREFIX + "-\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.jfr$");
+      Pattern.compile("^" + PREFIX + "-\\d{4}-\\d{2}-\\d{2}T\\d{2}_\\d{2}_\\d{2}\\.jfr$");
   private final Path outputDir;
 
   RecordingFileNamingConvention(Path outputDir) {
@@ -51,7 +51,7 @@ class RecordingFileNamingConvention {
   private Path buildRecordingName(LocalDateTime dateTime) {
     String timestamp =
         DateTimeFormatter.ISO_DATE_TIME.format(dateTime.truncatedTo(ChronoUnit.SECONDS));
-    return Paths.get(PREFIX + "-" + timestamp + ".jfr");
+    return Paths.get(PREFIX + "-" + timestamp.replace(':', '_') + ".jfr");
   }
 
   /** Determines if the path represents a file that we would have recorded to. */

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/RecordingFileNamingConventionTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/RecordingFileNamingConventionTest.java
@@ -34,7 +34,7 @@ class RecordingFileNamingConventionTest {
   void testNewPath() {
     RecordingFileNamingConvention convention = new RecordingFileNamingConvention(outputDir);
     LocalDateTime now = LocalDateTime.of(1999, Month.FEBRUARY, 12, 17, 3, 21);
-    Path expected = Paths.get("/path/to/outdir/otel-profiler-1999-02-12T17:03:21.jfr");
+    Path expected = Paths.get("/path/to/outdir/otel-profiler-1999-02-12T17_03_21.jfr");
 
     Path path = convention.newOutputPath(now);
 
@@ -45,9 +45,9 @@ class RecordingFileNamingConventionTest {
   void testMatches() {
     RecordingFileNamingConvention convention = new RecordingFileNamingConvention(outputDir);
     LocalDateTime now = LocalDateTime.of(1999, Month.FEBRUARY, 12, 17, 3, 21);
-    Path doesMatch = Paths.get("/path/to/outdir/otel-profiler-1999-02-12T17:03:21.jfr");
-    Path differentDir = Paths.get("/no/way/out/otel-profiler-1999-02-12T17:03:21.jfr");
-    Path badFilename = Paths.get("/path/to/outdir/tugboat-1999-02-12T17:03:21.jfr");
+    Path doesMatch = Paths.get("/path/to/outdir/otel-profiler-1999-02-12T17_03_21.jfr");
+    Path differentDir = Paths.get("/no/way/out/otel-profiler-1999-02-12T17_03_21.jfr");
+    Path badFilename = Paths.get("/path/to/outdir/tugboat-1999-02-12T17_03_21.jfr");
 
     assertTrue(convention.matches(doesMatch));
     assertFalse(convention.matches(differentDir));


### PR DESCRIPTION
This resolves #366.

Colons are not allowed in filenames in Windows. 😎 