### PR TITLE
Temporary change to make debugging hikari easier

### DIFF
--- a/instrumentation/hikaricp/build.gradle.kts
+++ b/instrumentation/hikaricp/build.gradle.kts
@@ -21,5 +21,8 @@ dependencies {
 tasks {
   test {
     jvmArgs("-Dsplunk.metrics.enabled=true")
+
+    // FIXME: temporary change to make debugging hikari tests on CI easier
+    testLogging.showStandardStreams = true
   }
 }


### PR DESCRIPTION
I've noticed that sometimes, completely randomly, hikari instrumentation tests fail with an instrumentation error. I tried running it tens of times locally, couldn't reproduce. On the CI there's nothing in logs, no assertion message - so I configured gradle to print out everything to stdout, maybe that'll help with pinpointing the problem. 