### PR TITLE
Disable lychee checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,26 +11,27 @@ on:
       - main
 
 jobs:
-  check-links:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+  # TODO: lycheeverse/lychee:latest on which this job depends is broken, temporarily turning it off
+  #check-links:
+  #  runs-on: ubuntu-20.04
+  #  steps:
+  #    - uses: actions/checkout@v2
+  #      with:
+  #        fetch-depth: 0
 
-      - name: Check all links in *.md files
-        id: lychee
-        uses: lycheeverse/lychee-action@v1.0.8
-        with:
-          args: >-
-            -v -n "*.md" "**/*.md"
-            --exclude "https://developers.redhat.com/download-manager/file/jboss-eap-.*.zip"
-            --exclude "http://yourendpoint.*"
-            --exclude "https://ingest.us0.signalfx.com.*"
-            --exclude "http://localhost*"
+  #    - name: Check all links in *.md files
+  #      id: lychee
+  #      uses: lycheeverse/lychee-action@v1.0.8
+  #      with:
+  #        args: >-
+  #          -v -n "*.md" "**/*.md"
+  #          --exclude "https://developers.redhat.com/download-manager/file/jboss-eap-.*.zip"
+  #          --exclude "http://yourendpoint.*"
+  #          --exclude "https://ingest.us0.signalfx.com.*"
+  #          --exclude "http://localhost*"
 
-      - name: Fail if there were link errors
-        run: exit ${{ steps.lychee.outputs.exit_code }}
+  #    - name: Fail if there were link errors
+  #      run: exit ${{ steps.lychee.outputs.exit_code }}
 
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,26 +8,27 @@ on:
   pull_request:
 
 jobs:
-  check-links:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+  # TODO: lycheeverse/lychee:latest on which this job depends is broken, temporarily turning it off
+  #check-links:
+  #  runs-on: ubuntu-20.04
+  #  steps:
+  #    - uses: actions/checkout@v2
+  #      with:
+  #        fetch-depth: 0
 
-      - name: Check all links in *.md files
-        id: lychee
-        uses: lycheeverse/lychee-action@v1.0.8
-        with:
-          args: >-
-            -v -n "*.md" "**/*.md"
-            --exclude "https://developers.redhat.com/download-manager/file/jboss-eap-.*.zip"
-            --exclude "http://yourendpoint.*"
-            --exclude "https://ingest.us0.signalfx.com.*"
-            --exclude "http://localhost*"
+  #    - name: Check all links in *.md files
+  #      id: lychee
+  #      uses: lycheeverse/lychee-action@v1.0.8
+  #      with:
+  #        args: >-
+  #          -v -n "*.md" "**/*.md"
+  #          --exclude "https://developers.redhat.com/download-manager/file/jboss-eap-.*.zip"
+  #          --exclude "http://yourendpoint.*"
+  #          --exclude "https://ingest.us0.signalfx.com.*"
+  #          --exclude "http://localhost*"
 
-      - name: Fail if there were link errors
-        run: exit ${{ steps.lychee.outputs.exit_code }}
+  #    - name: Fail if there were link errors
+  #      run: exit ${{ steps.lychee.outputs.exit_code }}
 
   build:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
A new `lycheeverse/lychee:latest` tag was pushed ~9 hours ago, and it's completely broken - it fails with the following error

```
standard_init_linux.go:228: exec user process caused: no such file or directory
```

Anyway, I find it REALLY BAD that a concrete `lycheeverse/lychee-action@v1.0.8` version depends on a "latest" tag of some other image.