### PR TITLE
Allow mapping resource to multiple container paths in smoke tests

### DIFF
--- a/smoke-tests/build.gradle.kts
+++ b/smoke-tests/build.gradle.kts
@@ -5,6 +5,9 @@ plugins {
 }
 
 dependencies {
+  testCompileOnly("com.google.auto.value:auto-value-annotations")
+  testAnnotationProcessor("com.google.auto.value:auto-value")
+
   testImplementation("org.testcontainers:testcontainers")
   testImplementation("com.fasterxml.jackson.core:jackson-databind:2.12.4")
   testImplementation("com.google.protobuf:protobuf-java-util")

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/LibertySmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/LibertySmokeTest.java
@@ -18,8 +18,10 @@ package com.splunk.opentelemetry;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.splunk.opentelemetry.helper.ResourceMapping;
 import com.splunk.opentelemetry.helper.TestImage;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -38,8 +40,13 @@ public class LibertySmokeTest extends AppServerTest {
         .stream();
   }
 
-  protected Map<String, String> getExtraResources() {
-    return Map.of("liberty-with-monitor.xml", "/config/server.xml");
+  protected List<ResourceMapping> getExtraResources() {
+    return List.of(
+        // server.xml path on linux containers
+        ResourceMapping.of("liberty-with-monitor.xml", "/config/server.xml"),
+        // server.xml path on windows containers
+        ResourceMapping.of(
+            "liberty-with-monitor.xml", "/server/usr/servers/defaultServer/server.xml"));
   }
 
   @ParameterizedTest(name = "[{index}] {0}")

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/SmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/SmokeTest.java
@@ -19,12 +19,14 @@ package com.splunk.opentelemetry;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.splunk.opentelemetry.helper.LinuxTestContainerManager;
+import com.splunk.opentelemetry.helper.ResourceMapping;
 import com.splunk.opentelemetry.helper.TargetWaitStrategy;
 import com.splunk.opentelemetry.helper.TestContainerManager;
 import com.splunk.opentelemetry.helper.TestImage;
 import com.splunk.opentelemetry.helper.windows.WindowsTestContainerManager;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
@@ -51,8 +53,8 @@ public abstract class SmokeTest {
   /**
    * Subclasses can override this method to copy some extra resource files to the target container.
    */
-  protected Map<String, String> getExtraResources() {
-    return Collections.emptyMap();
+  protected List<ResourceMapping> getExtraResources() {
+    return List.of();
   }
 
   @BeforeAll

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/LinuxTestContainerManager.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/LinuxTestContainerManager.java
@@ -17,6 +17,7 @@
 package com.splunk.opentelemetry.helper;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -110,7 +111,7 @@ public class LinuxTestContainerManager extends AbstractTestContainerManager {
       String targetImageName,
       String agentPath,
       Map<String, String> extraEnv,
-      Map<String, String> extraResources,
+      List<ResourceMapping> extraResources,
       TargetWaitStrategy waitStrategy) {
     target =
         new GenericContainer<>(DockerImageName.parse(targetImageName))
@@ -123,9 +124,10 @@ public class LinuxTestContainerManager extends AbstractTestContainerManager {
             .withEnv(getAgentEnvironment())
             .withEnv(extraEnv);
 
-    extraResources.forEach(
-        (file, path) ->
-            target.withCopyFileToContainer(MountableFile.forClasspathResource(file), path));
+    for (ResourceMapping resource : extraResources) {
+      target.withCopyFileToContainer(
+          MountableFile.forClasspathResource(resource.resourcePath()), resource.containerPath());
+    }
 
     if (waitStrategy != null) {
       if (waitStrategy instanceof TargetWaitStrategy.Log) {

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/ResourceMapping.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/ResourceMapping.java
@@ -1,6 +1,17 @@
 /*
- * Copyright The OpenTelemetry Authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.splunk.opentelemetry.helper;

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/ResourceMapping.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/ResourceMapping.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.splunk.opentelemetry.helper;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class ResourceMapping {
+  public static ResourceMapping of(String resourcePath, String containerPath) {
+    return new AutoValue_ResourceMapping(resourcePath, containerPath);
+  }
+
+  public abstract String resourcePath();
+
+  public abstract String containerPath();
+}

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/TestContainerManager.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/TestContainerManager.java
@@ -16,6 +16,7 @@
 
 package com.splunk.opentelemetry.helper;
 
+import java.util.List;
 import java.util.Map;
 
 public interface TestContainerManager {
@@ -35,7 +36,7 @@ public interface TestContainerManager {
       String targetImageName,
       String agentPath,
       Map<String, String> extraEnv,
-      Map<String, String> extraResources,
+      List<ResourceMapping> extraResources,
       TargetWaitStrategy waitStrategy);
 
   void stopTarget();

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/windows/WindowsTestContainerManager.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/windows/WindowsTestContainerManager.java
@@ -29,6 +29,7 @@ import com.github.dockerjava.core.DefaultDockerClientConfig;
 import com.github.dockerjava.core.DockerClientImpl;
 import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
 import com.splunk.opentelemetry.helper.AbstractTestContainerManager;
+import com.splunk.opentelemetry.helper.ResourceMapping;
 import com.splunk.opentelemetry.helper.TargetWaitStrategy;
 import com.splunk.opentelemetry.helper.TestImage;
 import java.io.ByteArrayInputStream;
@@ -189,7 +190,7 @@ public class WindowsTestContainerManager extends AbstractTestContainerManager {
       String targetImageName,
       String agentPath,
       Map<String, String> extraEnv,
-      Map<String, String> extraResources,
+      List<ResourceMapping> extraResources,
       TargetWaitStrategy waitStrategy) {
     stopTarget();
 
@@ -223,8 +224,9 @@ public class WindowsTestContainerManager extends AbstractTestContainerManager {
                 copyFileToContainer(
                     containerId, IOUtils.toByteArray(agentFileStream), "/" + TARGET_AGENT_FILENAME);
 
-                for (Map.Entry<String, String> e : extraResources.entrySet()) {
-                  copyResourceToContainer(containerId, e.getKey(), e.getValue());
+                for (ResourceMapping resource : extraResources) {
+                  copyResourceToContainer(
+                      containerId, resource.resourcePath(), resource.containerPath());
                 }
               } catch (Exception e) {
                 throw new RuntimeException(e);


### PR DESCRIPTION
Copied from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/3868