### PR TITLE
Refactor JmxMetricsWatcher and split its responsibilities

### DIFF
--- a/bootstrap/src/main/java/com/splunk/opentelemetry/javaagent/bootstrap/jmx/JmxListener.java
+++ b/bootstrap/src/main/java/com/splunk/opentelemetry/javaagent/bootstrap/jmx/JmxListener.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.javaagent.bootstrap.jmx;
+
+import javax.management.JMException;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+public interface JmxListener {
+  void onRegister(MBeanServer mBeanServer, ObjectName objectName) throws JMException;
+
+  void onUnregister(MBeanServer mBeanServer, ObjectName objectName) throws JMException;
+}

--- a/bootstrap/src/main/java/com/splunk/opentelemetry/javaagent/bootstrap/jmx/JmxQuery.java
+++ b/bootstrap/src/main/java/com/splunk/opentelemetry/javaagent/bootstrap/jmx/JmxQuery.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.splunk.opentelemetry.javaagent.bootstrap.metrics.jmx;
+package com.splunk.opentelemetry.javaagent.bootstrap.jmx;
 
 import static java.util.Collections.singletonMap;
 

--- a/bootstrap/src/main/java/com/splunk/opentelemetry/javaagent/bootstrap/jmx/JmxWatcher.java
+++ b/bootstrap/src/main/java/com/splunk/opentelemetry/javaagent/bootstrap/jmx/JmxWatcher.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.javaagent.bootstrap.jmx;
+
+import static java.util.Arrays.asList;
+
+import java.lang.management.ManagementFactory;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import javax.management.InstanceNotFoundException;
+import javax.management.JMException;
+import javax.management.ListenerNotFoundException;
+import javax.management.MBeanServer;
+import javax.management.MBeanServerDelegate;
+import javax.management.MBeanServerFactory;
+import javax.management.MBeanServerNotification;
+import javax.management.Notification;
+import javax.management.NotificationFilter;
+import javax.management.NotificationListener;
+import javax.management.ObjectName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class JmxWatcher {
+
+  private static final Logger log = LoggerFactory.getLogger(JmxWatcher.class);
+
+  private static final AtomicInteger threadIds = new AtomicInteger();
+  private static final ThreadFactory daemonThreadFactory =
+      r -> {
+        Thread t = new Thread(r, "JmxWatcher-" + threadIds.incrementAndGet());
+        t.setDaemon(true);
+        t.setContextClassLoader(null);
+        return t;
+      };
+
+  private static final Set<String> handledNotificationTypes =
+      new HashSet<>(
+          asList(
+              MBeanServerNotification.REGISTRATION_NOTIFICATION,
+              MBeanServerNotification.UNREGISTRATION_NOTIFICATION));
+
+  // lazy-initialize the MBeanServer to avoid loading JMX classes too early - that could cause JUL
+  // classloading hell in e.g. JBoss deployments
+  private final Supplier<MBeanServer> mBeanServerSupplier;
+  private final ExecutorService executorService;
+  private final JmxQuery query;
+  private final JmxListener listener;
+
+  private volatile MBeanServer mBeanServer;
+  private volatile NotificationListener notificationListener;
+
+  public JmxWatcher(JmxQuery query, JmxListener listener) {
+    this(
+        JmxWatcher::findMBeanServer,
+        Executors.newSingleThreadExecutor(daemonThreadFactory),
+        query,
+        listener);
+  }
+
+  // visible for tests
+  JmxWatcher(
+      Supplier<MBeanServer> mBeanServerSupplier,
+      ExecutorService executorService,
+      JmxQuery query,
+      JmxListener listener) {
+    this.mBeanServerSupplier = mBeanServerSupplier;
+    this.executorService = executorService;
+    this.query = query;
+    this.listener = listener;
+  }
+
+  // copied from micrometer CommonsObjectPool2Metrics class
+  private static MBeanServer findMBeanServer() {
+    List<MBeanServer> mBeanServers = MBeanServerFactory.findMBeanServer(null);
+    return mBeanServers.isEmpty()
+        ? ManagementFactory.getPlatformMBeanServer()
+        : mBeanServers.get(0);
+  }
+
+  public void start() {
+    try {
+      mBeanServer = mBeanServerSupplier.get();
+
+      // get all mbeans matching the query, call the listener for them
+      Set<ObjectName> existingObjects = mBeanServer.queryNames(query.toObjectNameQuery(), null);
+      for (ObjectName existingObject : existingObjects) {
+        listener.onRegister(mBeanServer, existingObject);
+      }
+
+      // register a notification listener that'll call the JmxListener whenever objects matching
+      // JmxQuery get registered/unregistered
+      NotificationFilter filter = this::isNotificationEnabled;
+      notificationListener = this::handleNotificationAsynchronously;
+      mBeanServer.addNotificationListener(
+          MBeanServerDelegate.DELEGATE_NAME, notificationListener, filter, null);
+    } catch (JMException e) {
+      log.warn("Could not start the JmxWatcher", e);
+    }
+  }
+
+  public void stop() {
+    if (notificationListener != null) {
+      try {
+        mBeanServer.removeNotificationListener(
+            MBeanServerDelegate.DELEGATE_NAME, notificationListener);
+        notificationListener = null;
+      } catch (InstanceNotFoundException | ListenerNotFoundException e) {
+        log.warn("Could not remove the NotificationListener from the MBeanServer", e);
+      }
+    }
+
+    executorService.shutdown();
+  }
+
+  private boolean isNotificationEnabled(Notification notification) {
+    if (!handledNotificationTypes.contains(notification.getType())) {
+      return false;
+    }
+    ObjectName objectName = ((MBeanServerNotification) notification).getMBeanName();
+    return query.matches(objectName);
+  }
+
+  private void handleNotificationAsynchronously(Notification notification, Object handback) {
+    // we can't get JMX object attributes in the NotificationListener, so we'll do that
+    // asynchronously on a separate thread
+    executorService.submit(() -> handleNotification(notification));
+  }
+
+  private void handleNotification(Notification notification) {
+    if (!(notification instanceof MBeanServerNotification)) {
+      return;
+    }
+    ObjectName objectName = ((MBeanServerNotification) notification).getMBeanName();
+
+    try {
+      if (MBeanServerNotification.REGISTRATION_NOTIFICATION.equals(notification.getType())) {
+        listener.onRegister(mBeanServer, objectName);
+      } else if (MBeanServerNotification.UNREGISTRATION_NOTIFICATION.equals(
+          notification.getType())) {
+        listener.onUnregister(mBeanServer, objectName);
+      }
+    } catch (JMException e) {
+      log.warn("JMX exception thrown in JmxListener", e);
+    }
+  }
+}

--- a/bootstrap/src/test/java/com/splunk/opentelemetry/javaagent/bootstrap/jmx/JmxQueryTest.java
+++ b/bootstrap/src/test/java/com/splunk/opentelemetry/javaagent/bootstrap/jmx/JmxQueryTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.splunk.opentelemetry.javaagent.bootstrap.metrics.jmx;
+package com.splunk.opentelemetry.javaagent.bootstrap.jmx;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/bootstrap/src/test/java/com/splunk/opentelemetry/javaagent/bootstrap/jmx/JmxWatcherTest.java
+++ b/bootstrap/src/test/java/com/splunk/opentelemetry/javaagent/bootstrap/jmx/JmxWatcherTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.javaagent.bootstrap.jmx;
+
+import static javax.management.MBeanServerNotification.REGISTRATION_NOTIFICATION;
+import static javax.management.MBeanServerNotification.UNREGISTRATION_NOTIFICATION;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import javax.management.MBeanServer;
+import javax.management.MBeanServerDelegate;
+import javax.management.MBeanServerNotification;
+import javax.management.Notification;
+import javax.management.NotificationFilter;
+import javax.management.NotificationListener;
+import javax.management.ObjectName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class JmxWatcherTest {
+
+  @Mock MBeanServer mBeanServer;
+  @Mock ExecutorService executorService;
+  @Mock JmxListener listener;
+
+  JmxQuery query = JmxQuery.create("com.splunk.test", "type", "TestType");
+
+  JmxWatcher underTest;
+
+  @Captor ArgumentCaptor<NotificationFilter> notificationFilterCaptor;
+  @Captor ArgumentCaptor<NotificationListener> notificationListenerCaptor;
+  @Captor ArgumentCaptor<Runnable> runnableCaptor;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new JmxWatcher(() -> mBeanServer, executorService, query, listener);
+  }
+
+  @Test
+  void shouldRegisterMetersForAlreadyExistingJmxObjects() throws Exception {
+    // given
+    var objectName1 = new ObjectName("com.splunk.test:type=TestType,name=test1");
+    var objectName2 = new ObjectName("com.splunk.test:type=TestType,name=test2");
+
+    when(mBeanServer.queryNames(query.toObjectNameQuery(), null))
+        .thenReturn(Set.of(objectName1, objectName2));
+
+    // when
+    underTest.start();
+
+    // then
+    verify(listener).onRegister(mBeanServer, objectName1);
+    verify(listener).onRegister(mBeanServer, objectName2);
+  }
+
+  @Test
+  void shouldFilterNotifications() throws Exception {
+    // given
+    when(mBeanServer.queryNames(query.toObjectNameQuery(), null)).thenReturn(Set.of());
+
+    underTest.start();
+    verify(mBeanServer)
+        .addNotificationListener(
+            eq(MBeanServerDelegate.DELEGATE_NAME),
+            any(NotificationListener.class),
+            notificationFilterCaptor.capture(),
+            isNull());
+
+    NotificationFilter filter = notificationFilterCaptor.getValue();
+
+    var wrongObjectName = new ObjectName("com.splunk.wrong_object_name:type=WrongType");
+    var correctObjectName = new ObjectName("com.splunk.test:type=TestType");
+
+    // when-then
+    assertFalse(filter.isNotificationEnabled(notification("some custom type", correctObjectName)));
+    assertFalse(
+        filter.isNotificationEnabled(notification(REGISTRATION_NOTIFICATION, wrongObjectName)));
+    assertFalse(
+        filter.isNotificationEnabled(notification(UNREGISTRATION_NOTIFICATION, wrongObjectName)));
+    assertTrue(
+        filter.isNotificationEnabled(notification(REGISTRATION_NOTIFICATION, correctObjectName)));
+    assertTrue(
+        filter.isNotificationEnabled(notification(UNREGISTRATION_NOTIFICATION, correctObjectName)));
+  }
+
+  @Test
+  void shouldHandleRegisterNotification() throws Exception {
+    // given
+    when(mBeanServer.queryNames(query.toObjectNameQuery(), null)).thenReturn(Set.of());
+
+    underTest.start();
+    verify(mBeanServer)
+        .addNotificationListener(
+            eq(MBeanServerDelegate.DELEGATE_NAME),
+            notificationListenerCaptor.capture(),
+            any(),
+            isNull());
+
+    NotificationListener notificationListener = notificationListenerCaptor.getValue();
+
+    // when
+    var objectName = new ObjectName("com.splunk.test:type=TestType,name=test");
+    notificationListener.handleNotification(
+        notification(REGISTRATION_NOTIFICATION, objectName), null);
+    // capture and immediately run async listener method
+    verify(executorService).submit(runnableCaptor.capture());
+    runnableCaptor.getValue().run();
+
+    // then
+    verify(listener).onRegister(mBeanServer, objectName);
+  }
+
+  @Test
+  void shouldHandleUnregisterNotification() throws Exception {
+    // given
+    when(mBeanServer.queryNames(query.toObjectNameQuery(), null)).thenReturn(Set.of());
+
+    underTest.start();
+    verify(mBeanServer)
+        .addNotificationListener(
+            eq(MBeanServerDelegate.DELEGATE_NAME),
+            notificationListenerCaptor.capture(),
+            any(),
+            isNull());
+
+    NotificationListener notificationListener = notificationListenerCaptor.getValue();
+
+    // when
+    var objectName = new ObjectName("com.splunk.test:type=TestType,name=test");
+    notificationListener.handleNotification(
+        notification(UNREGISTRATION_NOTIFICATION, objectName), null);
+    // capture and immediately run async listener method
+    verify(executorService).submit(runnableCaptor.capture());
+    runnableCaptor.getValue().run();
+
+    // then
+    verify(listener).onUnregister(mBeanServer, objectName);
+  }
+
+  @Test
+  void shouldStop() throws Exception {
+    // given
+    when(mBeanServer.queryNames(query.toObjectNameQuery(), null)).thenReturn(Set.of());
+
+    underTest.start();
+    verify(mBeanServer)
+        .addNotificationListener(
+            eq(MBeanServerDelegate.DELEGATE_NAME),
+            notificationListenerCaptor.capture(),
+            any(),
+            isNull());
+
+    // when
+    underTest.stop();
+
+    // then
+    verify(mBeanServer)
+        .removeNotificationListener(
+            MBeanServerDelegate.DELEGATE_NAME, notificationListenerCaptor.getValue());
+    verify(executorService).shutdown();
+  }
+
+  private static Notification notification(String type, ObjectName objectName) {
+    return new MBeanServerNotification(type, new Object(), 0, objectName);
+  }
+}

--- a/bootstrap/src/test/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/jmx/JmxMetricsWatcherIntegrationTest.java
+++ b/bootstrap/src/test/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/jmx/JmxMetricsWatcherIntegrationTest.java
@@ -22,6 +22,7 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.splunk.opentelemetry.javaagent.bootstrap.jmx.JmxQuery;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Metrics;
@@ -45,6 +46,8 @@ class JmxMetricsWatcherIntegrationTest {
             JmxQuery.create("com.splunk.test", Map.of("type", "Test")),
             JmxMetricsWatcherIntegrationTest::createMeters);
     watcher.start();
+
+    await().atMost(5, SECONDS).untilAsserted(() -> assertEquals(1, getTestMeters().size()));
 
     var objectName2 = new ObjectName("com.splunk.test:type=Test,name=asdf");
     ManagementFactory.getPlatformMBeanServer().registerMBean(new TestClass(42), objectName2);

--- a/bootstrap/src/test/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/jmx/JmxMetricsWatcherTest.java
+++ b/bootstrap/src/test/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/jmx/JmxMetricsWatcherTest.java
@@ -16,203 +16,94 @@
 
 package com.splunk.opentelemetry.javaagent.bootstrap.metrics.jmx;
 
-import static javax.management.MBeanServerNotification.REGISTRATION_NOTIFICATION;
-import static javax.management.MBeanServerNotification.UNREGISTRATION_NOTIFICATION;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.splunk.opentelemetry.javaagent.bootstrap.jmx.JmxWatcher;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.List;
-import java.util.Set;
-import java.util.concurrent.ExecutorService;
 import javax.management.MBeanServer;
-import javax.management.MBeanServerDelegate;
-import javax.management.MBeanServerNotification;
-import javax.management.Notification;
-import javax.management.NotificationFilter;
-import javax.management.NotificationListener;
 import javax.management.ObjectName;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class JmxMetricsWatcherTest {
-
-  @Mock MBeanServer mBeanServer;
-  @Mock ExecutorService executorService;
+  @Mock JmxWatcher jmxWatcher;
   @Mock MeterRegistry meterRegistry;
   @Mock MetersFactory metersFactory;
+  @Mock MBeanServer mBeanServer;
 
-  JmxQuery query = JmxQuery.create("com.splunk.test", "type", "TestType");
+  @InjectMocks JmxMetricsWatcher underTest;
 
-  JmxMetricsWatcher underTest;
+  @Test
+  void shouldAddMetersOnJmxRegister() throws Exception {
+    // given
+    var objectName = new ObjectName("com.splunk.test:type=Test");
+    var meter1 = mock(Meter.class);
+    var meter2 = mock(Meter.class);
+    when(metersFactory.createMeters(mBeanServer, objectName)).thenReturn(List.of(meter1, meter2));
 
-  @Captor ArgumentCaptor<NotificationFilter> notificationFilterCaptor;
-  @Captor ArgumentCaptor<NotificationListener> notificationListenerCaptor;
-  @Captor ArgumentCaptor<Runnable> runnableCaptor;
+    // when
+    underTest.onRegister(mBeanServer, objectName);
 
-  @BeforeEach
-  void setUp() {
-    underTest =
-        new JmxMetricsWatcher(
-            () -> mBeanServer, executorService, meterRegistry, query, metersFactory);
+    // then
+    assertThat(underTest.getAllMeters()).containsExactlyInAnyOrder(meter1, meter2);
   }
 
   @Test
-  void shouldRegisterMetersForAlreadyExistingJmxObjects() throws Exception {
+  void shouldRemoveMetersOnJmxUnregister() throws Exception {
     // given
-    var objectName1 = new ObjectName("com.splunk.test:type=TestType,name=test1");
-    var objectName2 = new ObjectName("com.splunk.test:type=TestType,name=test2");
-
-    when(mBeanServer.queryNames(query.toObjectNameQuery(), null))
-        .thenReturn(Set.of(objectName1, objectName2));
-
+    var objectName1 = new ObjectName("com.splunk.test:type=Test,name=1");
+    var objectName2 = new ObjectName("com.splunk.test:type=Test,name=2");
     var meter1 = mock(Meter.class);
     var meter2 = mock(Meter.class);
     when(metersFactory.createMeters(mBeanServer, objectName1)).thenReturn(List.of(meter1));
     when(metersFactory.createMeters(mBeanServer, objectName2)).thenReturn(List.of(meter2));
 
-    // when
-    underTest.start();
+    underTest.onRegister(mBeanServer, objectName1);
+    underTest.onRegister(mBeanServer, objectName2);
 
-    // then
     assertThat(underTest.getAllMeters()).containsExactlyInAnyOrder(meter1, meter2);
-  }
-
-  @Test
-  void shouldFilterNotifications() throws Exception {
-    // given
-    when(mBeanServer.queryNames(query.toObjectNameQuery(), null)).thenReturn(Set.of());
-
-    underTest.start();
-    verify(mBeanServer)
-        .addNotificationListener(
-            eq(MBeanServerDelegate.DELEGATE_NAME),
-            any(NotificationListener.class),
-            notificationFilterCaptor.capture(),
-            isNull());
-
-    NotificationFilter filter = notificationFilterCaptor.getValue();
-
-    var wrongObjectName = new ObjectName("com.splunk.wrong_object_name:type=WrongType");
-    var correctObjectName = new ObjectName("com.splunk.test:type=TestType");
-
-    // when-then
-    assertFalse(filter.isNotificationEnabled(notification("some custom type", correctObjectName)));
-    assertFalse(
-        filter.isNotificationEnabled(notification(REGISTRATION_NOTIFICATION, wrongObjectName)));
-    assertFalse(
-        filter.isNotificationEnabled(notification(UNREGISTRATION_NOTIFICATION, wrongObjectName)));
-    assertTrue(
-        filter.isNotificationEnabled(notification(REGISTRATION_NOTIFICATION, correctObjectName)));
-    assertTrue(
-        filter.isNotificationEnabled(notification(UNREGISTRATION_NOTIFICATION, correctObjectName)));
-  }
-
-  @Test
-  void shouldHandleRegisterNotification() throws Exception {
-    // given
-    when(mBeanServer.queryNames(query.toObjectNameQuery(), null)).thenReturn(Set.of());
-
-    underTest.start();
-    verify(mBeanServer)
-        .addNotificationListener(
-            eq(MBeanServerDelegate.DELEGATE_NAME),
-            notificationListenerCaptor.capture(),
-            any(),
-            isNull());
-
-    NotificationListener listener = notificationListenerCaptor.getValue();
-
-    var objectName = new ObjectName("com.splunk.test:type=TestType,name=test");
-    var meter1 = mock(Meter.class);
-    var meter2 = mock(Meter.class);
-    when(metersFactory.createMeters(mBeanServer, objectName)).thenReturn(List.of(meter1, meter2));
 
     // when
-    listener.handleNotification(notification(REGISTRATION_NOTIFICATION, objectName), null);
-    // capture and immediately run async listener method
-    verify(executorService).submit(runnableCaptor.capture());
-    runnableCaptor.getValue().run();
+    underTest.onUnregister(mBeanServer, objectName1);
 
     // then
+    verify(meterRegistry).remove(meter1);
+
+    assertThat(underTest.getAllMeters()).contains(meter2);
+  }
+
+  @Test
+  void shouldRemoveAllMetersOnStop() throws Exception {
+    // given
+    var objectName1 = new ObjectName("com.splunk.test:type=Test,name=1");
+    var objectName2 = new ObjectName("com.splunk.test:type=Test,name=2");
+    var meter1 = mock(Meter.class);
+    var meter2 = mock(Meter.class);
+    when(metersFactory.createMeters(mBeanServer, objectName1)).thenReturn(List.of(meter1));
+    when(metersFactory.createMeters(mBeanServer, objectName2)).thenReturn(List.of(meter2));
+
+    underTest.onRegister(mBeanServer, objectName1);
+    underTest.onRegister(mBeanServer, objectName2);
+
     assertThat(underTest.getAllMeters()).containsExactlyInAnyOrder(meter1, meter2);
-  }
-
-  @Test
-  void shouldHandleUnregisterNotification() throws Exception {
-    // given
-    var objectName = new ObjectName("com.splunk.test:type=TestType,name=test");
-    when(mBeanServer.queryNames(query.toObjectNameQuery(), null)).thenReturn(Set.of(objectName));
-
-    var meter1 = mock(Meter.class);
-    var meter2 = mock(Meter.class);
-    when(metersFactory.createMeters(mBeanServer, objectName)).thenReturn(List.of(meter1, meter2));
-
-    underTest.start();
-    verify(mBeanServer)
-        .addNotificationListener(
-            eq(MBeanServerDelegate.DELEGATE_NAME),
-            notificationListenerCaptor.capture(),
-            any(),
-            isNull());
-
-    NotificationListener listener = notificationListenerCaptor.getValue();
-
-    // when
-    listener.handleNotification(notification(UNREGISTRATION_NOTIFICATION, objectName), null);
-    // capture and immediately run async listener method
-    verify(executorService).submit(runnableCaptor.capture());
-    runnableCaptor.getValue().run();
-
-    // then
-    assertThat(underTest.getAllMeters()).isEmpty();
-  }
-
-  @Test
-  void shouldStop() throws Exception {
-    // given
-    var objectName = new ObjectName("com.splunk.test:type=TestType,name=test");
-    when(mBeanServer.queryNames(query.toObjectNameQuery(), null)).thenReturn(Set.of(objectName));
-
-    var meter1 = mock(Meter.class);
-    var meter2 = mock(Meter.class);
-    when(metersFactory.createMeters(mBeanServer, objectName)).thenReturn(List.of(meter1, meter2));
-
-    underTest.start();
-    verify(mBeanServer)
-        .addNotificationListener(
-            eq(MBeanServerDelegate.DELEGATE_NAME),
-            notificationListenerCaptor.capture(),
-            any(),
-            isNull());
-    assertThat(underTest.getAllMeters()).isNotEmpty();
 
     // when
     underTest.stop();
 
     // then
-    verify(mBeanServer)
-        .removeNotificationListener(
-            MBeanServerDelegate.DELEGATE_NAME, notificationListenerCaptor.getValue());
-    verify(executorService).shutdown();
-    assertThat(underTest.getAllMeters()).isEmpty();
-  }
+    verify(jmxWatcher).stop();
+    verify(meterRegistry).remove(meter1);
+    verify(meterRegistry).remove(meter2);
 
-  private static Notification notification(String type, ObjectName objectName) {
-    return new MBeanServerNotification(type, new Object(), 0, objectName);
+    assertThat(underTest.getAllMeters()).isEmpty();
   }
 }

--- a/bootstrap/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/bootstrap/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/instrumentation/liberty/src/main/java/com/splunk/opentelemetry/instrumentation/liberty/metrics/ThreadPoolMetrics.java
+++ b/instrumentation/liberty/src/main/java/com/splunk/opentelemetry/instrumentation/liberty/metrics/ThreadPoolMetrics.java
@@ -23,8 +23,8 @@ import static com.splunk.opentelemetry.javaagent.bootstrap.metrics.ThreadPoolSem
 import static com.splunk.opentelemetry.javaagent.bootstrap.metrics.jmx.JmxAttributesHelper.getNumberAttribute;
 import static java.util.Arrays.asList;
 
+import com.splunk.opentelemetry.javaagent.bootstrap.jmx.JmxQuery;
 import com.splunk.opentelemetry.javaagent.bootstrap.metrics.jmx.JmxMetricsWatcher;
-import com.splunk.opentelemetry.javaagent.bootstrap.metrics.jmx.JmxQuery;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;


### PR DESCRIPTION
All the JMX-related logic went into `JmxWatcher`, everything metrics was left in `JmxMetricsWatcher`. The aim of this PR (besides making the code a bit nicer) is to make it possible to use `JmxWatcher` for general purpose debugging and ad-hoc testing