### PR TITLE
profiler TLABs :: readme was wrong

### DIFF
--- a/profiler/README.md
+++ b/profiler/README.md
@@ -13,4 +13,4 @@ It should be considered experimental and is completely unsupported.
 |`splunk.profiler.keep-files`         | false                  | leave JFR files on disk id `true`         |
 |`splunk.profiler.logs-endpoint`      | `otel.exporter.otlp.endpoint` or http://localhost:4317  | where to send OTLP logs                   |
 |`splunk.profiler.period.{eventName}` | n/a                    | customize period (in ms) for a specific jfr event. For example, to set the ThreadDump frequency to 1s (100ms): `-Dsplunk.profiler.period.threaddump=1000` |
-|`splunk.profiler.tlab.enabled`       | true                   | set to `false` to disable TLAB memory events |
+|`splunk.profiler.tlab.enabled`       | false                  | set to `false` to disable TLAB memory events |


### PR DESCRIPTION
As part of #406 we flipped to disabled by default but the readme didn't get updated.