### PR TITLE
log the profiler config at agent start.

### DIFF
--- a/profiler/build.gradle.kts
+++ b/profiler/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
   testImplementation("io.opentelemetry:opentelemetry-proto")
   testImplementation("io.opentelemetry:opentelemetry-semconv")
   testImplementation("io.opentelemetry:opentelemetry-sdk")
+  testImplementation("io.github.netmikey.logunit:logunit-logback:1.1.0")
 }
 
 tasks {

--- a/profiler/build.gradle.kts
+++ b/profiler/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
   annotationProcessor("com.google.auto.service:auto-service")
   compileOnly("com.google.auto.service:auto-service")
 
+  testCompileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api")
   testImplementation("org.slf4j:slf4j-api")
   testImplementation("io.grpc:grpc-netty")
   testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling")

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
@@ -17,12 +17,15 @@
 package com.splunk.opentelemetry.profiler;
 
 import com.google.auto.service.AutoService;
+import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.javaagent.extension.config.ConfigPropertySource;
 import java.util.HashMap;
 import java.util.Map;
 
 @AutoService(ConfigPropertySource.class)
 public class Configuration implements ConfigPropertySource {
+
+  private static final String DEFAULT_RECORDING_DURATION = "20s";
 
   public static final String CONFIG_KEY_ENABLE_PROFILER = "splunk.profiler.enabled";
   public static final String CONFIG_KEY_PROFILER_DIRECTORY = "splunk.profiler.directory";
@@ -37,7 +40,18 @@ public class Configuration implements ConfigPropertySource {
   public Map<String, String> getProperties() {
     HashMap<String, String> config = new HashMap<>();
     config.put(CONFIG_KEY_ENABLE_PROFILER, "false");
+    config.put(CONFIG_KEY_PROFILER_DIRECTORY, ".");
+    config.put(CONFIG_KEY_RECORDING_DURATION, DEFAULT_RECORDING_DURATION);
     config.put(CONFIG_KEY_KEEP_FILES, "false");
+    config.put(CONFIG_KEY_TLAB_ENABLED, "false");
     return config;
+  }
+
+  public static String getConfigUrl(Config config) {
+    String ingestUrl = config.getString(CONFIG_KEY_INGEST_URL);
+    if (ingestUrl == null) {
+      return config.getString(CONFIG_KEY_OTEL_OTLP_URL);
+    }
+    return ingestUrl;
   }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/ConfigurationLogger.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/ConfigurationLogger.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_ENABLE_PROFILER;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_INGEST_URL;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_KEEP_FILES;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_OTEL_OTLP_URL;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PERIOD_PREFIX;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PROFILER_DIRECTORY;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_RECORDING_DURATION;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_TLAB_ENABLED;
+
+import io.opentelemetry.instrumentation.api.config.Config;
+import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** This class logs the active profiler configuration for debug/troubleshooting purposes. */
+public class ConfigurationLogger {
+
+  private static final Logger configurationLogger = LoggerFactory.getLogger(ConfigurationLogger.class);
+
+  private final Logger logger;
+
+  public ConfigurationLogger() {
+    this(configurationLogger);
+  }
+
+  // Exists for testing
+  ConfigurationLogger(Logger logger) {
+    this.logger = logger;
+  }
+
+  public void log(Config config) {
+    logger.info("-----------------------");
+    logger.info("Profiler configuration:");
+    log(CONFIG_KEY_ENABLE_PROFILER, config::getBoolean);
+    log(CONFIG_KEY_PROFILER_DIRECTORY, config::getString);
+    log(CONFIG_KEY_RECORDING_DURATION, config::getString);
+    log(CONFIG_KEY_KEEP_FILES, config::getBoolean);
+    log(CONFIG_KEY_INGEST_URL, config::getString);
+    log(CONFIG_KEY_OTEL_OTLP_URL, config::getString);
+    log(CONFIG_KEY_TLAB_ENABLED, config::getBoolean);
+    log(CONFIG_KEY_PERIOD_PREFIX + "." + "jdk.threaddump", config::getString);
+    logger.info("-----------------------");
+  }
+
+  private void log(String key, Function<String, Object> getter) {
+    logger.info(" {} : {}", pad(key), getter.apply(key));
+  }
+
+  private String pad(String str) {
+    return String.format("%38s", str);
+  }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/ConfigurationLogger.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/ConfigurationLogger.java
@@ -33,18 +33,7 @@ import org.slf4j.LoggerFactory;
 /** This class logs the active profiler configuration for debug/troubleshooting purposes. */
 public class ConfigurationLogger {
 
-  private static final Logger configurationLogger = LoggerFactory.getLogger(ConfigurationLogger.class);
-
-  private final Logger logger;
-
-  public ConfigurationLogger() {
-    this(configurationLogger);
-  }
-
-  // Exists for testing
-  ConfigurationLogger(Logger logger) {
-    this.logger = logger;
-  }
+  private static final Logger logger = LoggerFactory.getLogger(ConfigurationLogger.class);
 
   public void log(Config config) {
     logger.info("-----------------------");

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
@@ -49,8 +49,8 @@ public class JfrActivator implements AgentListener {
   private static final Logger logger = LoggerFactory.getLogger(JfrActivator.class);
   private static final int MAX_BATCH_SIZE = 250;
   private static final Duration MAX_TIME_BETWEEN_BATCHES = Duration.ofSeconds(10);
-  private static final Duration DEFAULT_RECORDING_DURATION = Duration.ofSeconds(20);
   private final ExecutorService executor = HelpfulExecutors.newSingleThreadExecutor("JFR Profiler");
+  private final ConfigurationLogger configurationLogger = new ConfigurationLogger(logger);
 
   @Override
   public void afterAgent(Config config) {
@@ -64,15 +64,15 @@ public class JfrActivator implements AgentListener {
       logger.warn("Java Flight Recorder is not available in this JVM. Profiling is disabled.");
       return;
     }
+    configurationLogger.log(config);
     logger.info("JFR profiler is active.");
     executor.submit(logUncaught(() -> activateJfrAndRunForever(config)));
   }
 
   private void activateJfrAndRunForever(Config config) {
-    Duration recordingDuration =
-        config.getDuration(CONFIG_KEY_RECORDING_DURATION, DEFAULT_RECORDING_DURATION);
+    Duration recordingDuration = config.getDuration(CONFIG_KEY_RECORDING_DURATION);
 
-    Path outputDir = Paths.get(config.getString(CONFIG_KEY_PROFILER_DIRECTORY, "."));
+    Path outputDir = Paths.get(config.getString(CONFIG_KEY_PROFILER_DIRECTORY));
     RecordingFileNamingConvention namingConvention = new RecordingFileNamingConvention(outputDir);
 
     RecordingEscapeHatch recordingEscapeHatch =
@@ -160,6 +160,6 @@ public class JfrActivator implements AgentListener {
   }
 
   private boolean keepFiles(Config config) {
-    return config.getBoolean(CONFIG_KEY_KEEP_FILES, false);
+    return config.getBoolean(CONFIG_KEY_KEEP_FILES);
   }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
@@ -50,7 +50,7 @@ public class JfrActivator implements AgentListener {
   private static final int MAX_BATCH_SIZE = 250;
   private static final Duration MAX_TIME_BETWEEN_BATCHES = Duration.ofSeconds(10);
   private final ExecutorService executor = HelpfulExecutors.newSingleThreadExecutor("JFR Profiler");
-  private final ConfigurationLogger configurationLogger = new ConfigurationLogger(logger);
+  private final ConfigurationLogger configurationLogger = new ConfigurationLogger();
 
   @Override
   public void afterAgent(Config config) {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrSettingsOverrides.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrSettingsOverrides.java
@@ -61,7 +61,7 @@ class JfrSettingsOverrides {
   }
 
   private Map<String, String> maybeEnableTLABs(Map<String, String> settings) {
-    if (config.getBoolean(CONFIG_KEY_TLAB_ENABLED, false)) {
+    if (config.getBoolean(CONFIG_KEY_TLAB_ENABLED)) {
       settings.put("jdk.ObjectAllocationInNewTLAB#enabled", "true");
       settings.put("jdk.ObjectAllocationOutsideTLAB#enabled", "true");
     }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/LogsExporterBuilder.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/LogsExporterBuilder.java
@@ -16,9 +16,6 @@
 
 package com.splunk.opentelemetry.profiler;
 
-import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_INGEST_URL;
-import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_OTEL_OTLP_URL;
-
 import com.splunk.opentelemetry.logs.InstrumentationLibraryLogsAdapter;
 import com.splunk.opentelemetry.logs.LogEntryAdapter;
 import com.splunk.opentelemetry.logs.LogsExporter;
@@ -43,10 +40,7 @@ class LogsExporterBuilder {
             .setAdapter(adapter)
             .addHeader("Extra-Content-Type", "otel-profiling-stacktraces");
 
-    String ingestUrl = config.getString(CONFIG_KEY_INGEST_URL);
-    if (ingestUrl == null) {
-      ingestUrl = config.getString(CONFIG_KEY_OTEL_OTLP_URL);
-    }
+    String ingestUrl = Configuration.getConfigUrl(config);
     if (ingestUrl != null) {
       builder.setEndpoint(ingestUrl);
     }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationLoggerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationLoggerTest.java
@@ -1,0 +1,61 @@
+package com.splunk.opentelemetry.profiler;
+
+import io.opentelemetry.instrumentation.api.config.Config;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.slf4j.Logger;
+
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_ENABLE_PROFILER;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_INGEST_URL;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_KEEP_FILES;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_OTEL_OTLP_URL;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PERIOD_PREFIX;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PROFILER_DIRECTORY;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_RECORDING_DURATION;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_TLAB_ENABLED;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+class ConfigurationLoggerTest {
+
+    @Test
+    void testLog() {
+        Logger log = mock(Logger.class);
+        Config config = mock(Config.class);
+
+        when(config.getBoolean(CONFIG_KEY_ENABLE_PROFILER)).thenReturn(true);
+        when(config.getString(CONFIG_KEY_PROFILER_DIRECTORY)).thenReturn("somedir");
+        when(config.getString(CONFIG_KEY_RECORDING_DURATION)).thenReturn("33m");
+        when(config.getBoolean(CONFIG_KEY_KEEP_FILES)).thenReturn(true);
+        when(config.getString(CONFIG_KEY_INGEST_URL)).thenReturn("http://example.com");
+        when(config.getString(CONFIG_KEY_OTEL_OTLP_URL)).thenReturn("http://otel.example.com");
+        when(config.getBoolean(CONFIG_KEY_TLAB_ENABLED)).thenReturn(false);
+        when(config.getString(CONFIG_KEY_PERIOD_PREFIX + ".jdk.threaddump")).thenReturn("500ms");
+
+        ConfigurationLogger configurationLogger = new ConfigurationLogger(log);
+
+        configurationLogger.log(config);
+
+        InOrder inOrder = inOrder(log);
+        inOrder.verify(log).info("-----------------------");
+        inOrder.verify(log).info("Profiler configuration:");
+        inOrder.verify(log).info(" {} : {}", "               splunk.profiler.enabled", true);
+        inOrder.verify(log).info(" {} : {}", "             splunk.profiler.directory", "somedir");
+        inOrder.verify(log).info(" {} : {}", "    splunk.profiler.recording.duration", "33m");
+        inOrder.verify(log).info(" {} : {}", "            splunk.profiler.keep-files", true);
+        inOrder.verify(log).info(" {} : {}", "         splunk.profiler.logs-endpoint", "http://example.com");
+        inOrder.verify(log).info(" {} : {}", "           otel.exporter.otlp.endpoint", "http://otel.example.com");
+        inOrder.verify(log).info(" {} : {}", "          splunk.profiler.tlab.enabled", false);
+        inOrder.verify(log).info(" {} : {}", " splunk.profiler.period.jdk.threaddump", "500ms");
+        inOrder.verify(log).info("-----------------------");
+        verifyNoMoreInteractions(log);
+    }
+
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationLoggerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationLoggerTest.java
@@ -1,11 +1,20 @@
-package com.splunk.opentelemetry.profiler;
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import io.opentelemetry.instrumentation.api.config.Config;
-import org.junit.jupiter.api.Test;
-import org.mockito.InOrder;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
-import org.slf4j.Logger;
+package com.splunk.opentelemetry.profiler;
 
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_ENABLE_PROFILER;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_INGEST_URL;
@@ -15,47 +24,45 @@ import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PERIOD_
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PROFILER_DIRECTORY;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_RECORDING_DURATION;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_TLAB_ENABLED;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+
+import io.github.netmikey.logunit.api.LogCapturer;
+import io.opentelemetry.instrumentation.api.config.Config;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 class ConfigurationLoggerTest {
 
-    @Test
-    void testLog() {
-        Logger log = mock(Logger.class);
-        Config config = mock(Config.class);
+  @RegisterExtension
+  LogCapturer log = LogCapturer.create().captureForType(ConfigurationLogger.class);
 
-        when(config.getBoolean(CONFIG_KEY_ENABLE_PROFILER)).thenReturn(true);
-        when(config.getString(CONFIG_KEY_PROFILER_DIRECTORY)).thenReturn("somedir");
-        when(config.getString(CONFIG_KEY_RECORDING_DURATION)).thenReturn("33m");
-        when(config.getBoolean(CONFIG_KEY_KEEP_FILES)).thenReturn(true);
-        when(config.getString(CONFIG_KEY_INGEST_URL)).thenReturn("http://example.com");
-        when(config.getString(CONFIG_KEY_OTEL_OTLP_URL)).thenReturn("http://otel.example.com");
-        when(config.getBoolean(CONFIG_KEY_TLAB_ENABLED)).thenReturn(false);
-        when(config.getString(CONFIG_KEY_PERIOD_PREFIX + ".jdk.threaddump")).thenReturn("500ms");
+  @Test
+  void testLog() {
+    Config config = mock(Config.class);
 
-        ConfigurationLogger configurationLogger = new ConfigurationLogger(log);
+    when(config.getBoolean(CONFIG_KEY_ENABLE_PROFILER)).thenReturn(true);
+    when(config.getString(CONFIG_KEY_PROFILER_DIRECTORY)).thenReturn("somedir");
+    when(config.getString(CONFIG_KEY_RECORDING_DURATION)).thenReturn("33m");
+    when(config.getBoolean(CONFIG_KEY_KEEP_FILES)).thenReturn(true);
+    when(config.getString(CONFIG_KEY_INGEST_URL)).thenReturn("http://example.com");
+    when(config.getString(CONFIG_KEY_OTEL_OTLP_URL)).thenReturn("http://otel.example.com");
+    when(config.getBoolean(CONFIG_KEY_TLAB_ENABLED)).thenReturn(false);
+    when(config.getString(CONFIG_KEY_PERIOD_PREFIX + ".jdk.threaddump")).thenReturn("500ms");
 
-        configurationLogger.log(config);
+    ConfigurationLogger configurationLogger = new ConfigurationLogger();
 
-        InOrder inOrder = inOrder(log);
-        inOrder.verify(log).info("-----------------------");
-        inOrder.verify(log).info("Profiler configuration:");
-        inOrder.verify(log).info(" {} : {}", "               splunk.profiler.enabled", true);
-        inOrder.verify(log).info(" {} : {}", "             splunk.profiler.directory", "somedir");
-        inOrder.verify(log).info(" {} : {}", "    splunk.profiler.recording.duration", "33m");
-        inOrder.verify(log).info(" {} : {}", "            splunk.profiler.keep-files", true);
-        inOrder.verify(log).info(" {} : {}", "         splunk.profiler.logs-endpoint", "http://example.com");
-        inOrder.verify(log).info(" {} : {}", "           otel.exporter.otlp.endpoint", "http://otel.example.com");
-        inOrder.verify(log).info(" {} : {}", "          splunk.profiler.tlab.enabled", false);
-        inOrder.verify(log).info(" {} : {}", " splunk.profiler.period.jdk.threaddump", "500ms");
-        inOrder.verify(log).info("-----------------------");
-        verifyNoMoreInteractions(log);
-    }
+    configurationLogger.log(config);
 
+    log.assertContains("-----------------------");
+    log.assertContains("Profiler configuration:");
+    log.assertContains("                splunk.profiler.enabled : true");
+    log.assertContains("              splunk.profiler.directory : somedir");
+    log.assertContains("     splunk.profiler.recording.duration : 33m");
+    log.assertContains("             splunk.profiler.keep-files : true");
+    log.assertContains("          splunk.profiler.logs-endpoint : http://example.com");
+    log.assertContains("            otel.exporter.otlp.endpoint : http://otel.example.com");
+    log.assertContains("           splunk.profiler.tlab.enabled : false");
+    log.assertContains("  splunk.profiler.period.jdk.threaddump : 500ms");
+  }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationTest.java
@@ -1,0 +1,41 @@
+package com.splunk.opentelemetry.profiler;
+
+import io.opentelemetry.instrumentation.api.config.Config;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ConfigurationTest {
+
+    String logsEndpoint = "http://logs.example.com";
+    String otelEndpoint = "http://otel.example.com";
+
+    @Test
+    void getConfigUrl_endpointDefined() {
+        Config config = mock(Config.class);
+        when(config.getString(Configuration.CONFIG_KEY_INGEST_URL)).thenReturn(logsEndpoint);
+        when(config.getString(Configuration.CONFIG_KEY_OTEL_OTLP_URL)).thenReturn(otelEndpoint);
+        String result = Configuration.getConfigUrl(config);
+        assertEquals(result, logsEndpoint);
+    }
+
+    @Test
+    void getConfigUrl_endpointNotDefined() {
+        Config config = mock(Config.class);
+        when(config.getString(Configuration.CONFIG_KEY_INGEST_URL)).thenReturn(null);
+        when(config.getString(Configuration.CONFIG_KEY_OTEL_OTLP_URL)).thenReturn(otelEndpoint);
+        String result = Configuration.getConfigUrl(config);
+        assertEquals(result, otelEndpoint);
+    }
+
+    @Test
+    void getConfigUrlNull() {
+        Config config = mock(Config.class);
+        when(config.getString(Configuration.CONFIG_KEY_INGEST_URL)).thenReturn(null);
+        when(config.getString(Configuration.CONFIG_KEY_OTEL_OTLP_URL)).thenReturn(null);
+        String result = Configuration.getConfigUrl(config);
+        assertNull(result);
+    }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationTest.java
@@ -1,41 +1,57 @@
-package com.splunk.opentelemetry.profiler;
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import io.opentelemetry.instrumentation.api.config.Config;
-import org.junit.jupiter.api.Test;
+package com.splunk.opentelemetry.profiler;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.opentelemetry.instrumentation.api.config.Config;
+import org.junit.jupiter.api.Test;
+
 class ConfigurationTest {
 
-    String logsEndpoint = "http://logs.example.com";
-    String otelEndpoint = "http://otel.example.com";
+  String logsEndpoint = "http://logs.example.com";
+  String otelEndpoint = "http://otel.example.com";
 
-    @Test
-    void getConfigUrl_endpointDefined() {
-        Config config = mock(Config.class);
-        when(config.getString(Configuration.CONFIG_KEY_INGEST_URL)).thenReturn(logsEndpoint);
-        when(config.getString(Configuration.CONFIG_KEY_OTEL_OTLP_URL)).thenReturn(otelEndpoint);
-        String result = Configuration.getConfigUrl(config);
-        assertEquals(result, logsEndpoint);
-    }
+  @Test
+  void getConfigUrl_endpointDefined() {
+    Config config = mock(Config.class);
+    when(config.getString(Configuration.CONFIG_KEY_INGEST_URL)).thenReturn(logsEndpoint);
+    when(config.getString(Configuration.CONFIG_KEY_OTEL_OTLP_URL)).thenReturn(otelEndpoint);
+    String result = Configuration.getConfigUrl(config);
+    assertEquals(result, logsEndpoint);
+  }
 
-    @Test
-    void getConfigUrl_endpointNotDefined() {
-        Config config = mock(Config.class);
-        when(config.getString(Configuration.CONFIG_KEY_INGEST_URL)).thenReturn(null);
-        when(config.getString(Configuration.CONFIG_KEY_OTEL_OTLP_URL)).thenReturn(otelEndpoint);
-        String result = Configuration.getConfigUrl(config);
-        assertEquals(result, otelEndpoint);
-    }
+  @Test
+  void getConfigUrl_endpointNotDefined() {
+    Config config = mock(Config.class);
+    when(config.getString(Configuration.CONFIG_KEY_INGEST_URL)).thenReturn(null);
+    when(config.getString(Configuration.CONFIG_KEY_OTEL_OTLP_URL)).thenReturn(otelEndpoint);
+    String result = Configuration.getConfigUrl(config);
+    assertEquals(result, otelEndpoint);
+  }
 
-    @Test
-    void getConfigUrlNull() {
-        Config config = mock(Config.class);
-        when(config.getString(Configuration.CONFIG_KEY_INGEST_URL)).thenReturn(null);
-        when(config.getString(Configuration.CONFIG_KEY_OTEL_OTLP_URL)).thenReturn(null);
-        String result = Configuration.getConfigUrl(config);
-        assertNull(result);
-    }
+  @Test
+  void getConfigUrlNull() {
+    Config config = mock(Config.class);
+    when(config.getString(Configuration.CONFIG_KEY_INGEST_URL)).thenReturn(null);
+    when(config.getString(Configuration.CONFIG_KEY_OTEL_OTLP_URL)).thenReturn(null);
+    String result = Configuration.getConfigUrl(config);
+    assertNull(result);
+  }
 }


### PR DESCRIPTION
This helps us to do troubleshooting and provide additional support.