### PR TITLE
Safer JFR availability checks

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JFR.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JFR.java
@@ -29,7 +29,12 @@ class JFR {
   public static final JFR instance = new JFR();
 
   public boolean isAvailable() {
-    return FlightRecorder.isAvailable();
+    try {
+      JFR.class.getClassLoader().loadClass("jdk.jfr.FlightRecorder");
+      return FlightRecorder.isAvailable();
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
   }
 
   public Recording takeSnapshot() {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JFR.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JFR.java
@@ -27,14 +27,19 @@ import jdk.jfr.consumer.RecordingFile;
 class JFR {
 
   public static final JFR instance = new JFR();
+  private static final boolean jfrAvailable = checkJfr();
 
-  public boolean isAvailable() {
+  private static boolean checkJfr() {
     try {
       JFR.class.getClassLoader().loadClass("jdk.jfr.FlightRecorder");
       return FlightRecorder.isAvailable();
     } catch (ClassNotFoundException e) {
       return false;
     }
+  }
+
+  public boolean isAvailable() {
+    return jfrAvailable;
   }
 
   public Recording takeSnapshot() {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
@@ -61,7 +61,8 @@ public class JfrActivator implements AgentListener {
       return;
     }
     if (!JFR.instance.isAvailable()) {
-      logger.warn("Java Flight Recorder (JFR) is not available in this JVM. Profiling is disabled.");
+      logger.warn(
+          "Java Flight Recorder (JFR) is not available in this JVM. Profiling is disabled.");
       return;
     }
     configurationLogger.log(config);

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
@@ -61,7 +61,7 @@ public class JfrActivator implements AgentListener {
       return;
     }
     if (!JFR.instance.isAvailable()) {
-      logger.warn("Java Flight Recorder is not available in this JVM. Profiling is disabled.");
+      logger.warn("Java Flight Recorder (JFR) is not available in this JVM. Profiling is disabled.");
       return;
     }
     configurationLogger.log(config);

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/SdkCustomizer.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/SdkCustomizer.java
@@ -33,9 +33,17 @@ public class SdkCustomizer implements SdkTracerProviderConfigurer {
 
   @Override
   public void configure(SdkTracerProviderBuilder tracerProvider) {
-    if (Config.get().getBoolean(CONFIG_KEY_ENABLE_PROFILER, false)) {
+    if (jfrIsAvailable() && jfrIsEnabledInConfig()) {
       logger.info("Enabling JfrContextStorage");
       ContextStorage.addWrapper(JfrContextStorage::new);
     }
+  }
+
+  private boolean jfrIsAvailable() {
+    return JFR.instance.isAvailable();
+  }
+
+  private boolean jfrIsEnabledInConfig() {
+    return Config.get().getBoolean(CONFIG_KEY_ENABLE_PROFILER, false);
   }
 }


### PR DESCRIPTION
Tested on 8u212 and sure enough, there were some exceptions in the logs about unknown JFR classes. I added some additional preventions here and confirmed that the exceptions no longer happen. Also confirmed that JFR still works on newer JVMs.