### PR TITLE
Fix profiler NPE

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordingSequencer.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordingSequencer.java
@@ -54,18 +54,22 @@ class RecordingSequencer {
 
   @VisibleForTesting
   void handleInterval() {
-    if (!recordingEscapeHatch.jfrCanContinue()) {
-      logger.warn("JFR recordings cannot proceed.");
-      if (recorder.isStarted()) {
-        recorder.stop();
+    try {
+      if (!recordingEscapeHatch.jfrCanContinue()) {
+        logger.warn("JFR recordings cannot proceed.");
+        if (recorder.isStarted()) {
+          recorder.stop();
+        }
+        return;
       }
-      return;
+      if (!recorder.isStarted()) {
+        recorder.start();
+        return;
+      }
+      recorder.flushSnapshot();
+    } catch (Throwable throwable) {
+      logger.error("Profiler periodic task failed.", throwable);
     }
-    if (!recorder.isStarted()) {
-      recorder.start();
-      return;
-    }
-    recorder.flushSnapshot();
   }
 
   public static Builder builder() {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/util/StackSerializer.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/util/StackSerializer.java
@@ -46,10 +46,13 @@ public class StackSerializer {
   }
 
   private StringBuilder serializeFrame(StringBuilder sb, RecordedFrame frame) {
+    RecordedMethod method = frame.getMethod();
+    if (method == null) {
+      return sb;
+    }
     if (sb.length() > 0) {
       sb.append("\n");
     }
-    RecordedMethod method = frame.getMethod();
     String className = method.getType().getName();
     String methodName = method.getName();
     int lineNumber = frame.getInt("lineNumber");

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/util/StackSerializerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/util/StackSerializerTest.java
@@ -34,6 +34,7 @@ class StackSerializerTest {
   RecordedFrame frame2 = makeFrame("io.test.MyClass", "silver", 456);
   RecordedFrame frame3 = makeFrame("io.test.Framewerk", "root", 66);
   List<RecordedFrame> frames = Arrays.asList(frame1, frame2, frame3);
+  List<RecordedFrame> framesWithNullMethod = Arrays.asList(frame1, makeFrameWithNullMethod("io.test.MyClass", 456), frame3);
 
   @Test
   void serialize() {
@@ -47,6 +48,20 @@ class StackSerializerTest {
         "io.test.MyClass.action:123\n"
             + "io.test.MyClass.silver:456\n"
             + "io.test.Framewerk.root:66";
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void serializeWithNullMethod() {
+    StackSerializer serializer = new StackSerializer();
+    RecordedStackTrace stack = mock(RecordedStackTrace.class);
+
+    when(stack.getFrames()).thenReturn(framesWithNullMethod);
+
+    String result = serializer.serialize(stack);
+    String expected =
+            "io.test.MyClass.action:123\n"
+                    + "io.test.Framewerk.root:66";
     assertEquals(expected, result);
   }
 
@@ -69,6 +84,15 @@ class StackSerializerTest {
     when(method.getType()).thenReturn(type);
     when(frame.getMethod()).thenReturn(method);
     when(method.getName()).thenReturn(methodName);
+    when(frame.getInt("lineNumber")).thenReturn(line);
+    when(type.getName()).thenReturn(typeName);
+    return frame;
+  }
+
+  private RecordedFrame makeFrameWithNullMethod(String typeName, int line) {
+    RecordedFrame frame = mock(RecordedFrame.class);
+    RecordedClass type = mock(RecordedClass.class);
+    when(frame.getMethod()).thenReturn(null);
     when(frame.getInt("lineNumber")).thenReturn(line);
     when(type.getName()).thenReturn(typeName);
     return frame;

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/util/StackSerializerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/util/StackSerializerTest.java
@@ -34,7 +34,8 @@ class StackSerializerTest {
   RecordedFrame frame2 = makeFrame("io.test.MyClass", "silver", 456);
   RecordedFrame frame3 = makeFrame("io.test.Framewerk", "root", 66);
   List<RecordedFrame> frames = Arrays.asList(frame1, frame2, frame3);
-  List<RecordedFrame> framesWithNullMethod = Arrays.asList(frame1, makeFrameWithNullMethod("io.test.MyClass", 456), frame3);
+  List<RecordedFrame> framesWithNullMethod =
+      Arrays.asList(frame1, makeFrameWithNullMethod("io.test.MyClass", 456), frame3);
 
   @Test
   void serialize() {
@@ -59,9 +60,7 @@ class StackSerializerTest {
     when(stack.getFrames()).thenReturn(framesWithNullMethod);
 
     String result = serializer.serialize(stack);
-    String expected =
-            "io.test.MyClass.action:123\n"
-                    + "io.test.Framewerk.root:66";
+    String expected = "io.test.MyClass.action:123\n" + "io.test.Framewerk.root:66";
     assertEquals(expected, result);
   }
 


### PR DESCRIPTION
Apparently stack frames can have null methods although javadoc https://docs.oracle.com/javase/9/docs/api/jdk/jfr/consumer/RecordedFrame.html#getMethod-- states otherwise.  I discovered this while investigating why test added in https://github.com/signalfx/splunk-otel-java/pull/436 is flaky.
This pr also adds catching all exceptions to `RecordingSequencer. handleInterval`. This method is invoked periodically by `ScheduledExecutorService` if it fails it will not be invoked again so we should not let it fail.