### PR TITLE
Profiler omits some agent internal threads

### DIFF
--- a/profiler/README.md
+++ b/profiler/README.md
@@ -12,6 +12,6 @@ It should be considered experimental and is completely unsupported.
 |`splunk.profiler.recording.duration`      | 20s                    | recording unit duration                   |
 |`splunk.profiler.keep-files`              | false                  | leave JFR files on disk id `true`         |
 |`splunk.profiler.logs-endpoint`           | `otel.exporter.otlp.endpoint` or http://localhost:4317  | where to send OTLP logs                   |
-|`splunk.profiler.period.{eventName}`      | n/a                    | customize period (in ms) for a specific jfr event. For example, to set the ThreadDump frequency to 1s (100ms): `-Dsplunk.profiler.period.threaddump=1000` |
+|`splunk.profiler.period.{eventName}`      | n/a                    | customize period (in ms) for a specific jfr event. For example, to set the ThreadDump frequency to 1s (1000ms): `-Dsplunk.profiler.period.threaddump=1000` |
 |`splunk.profiler.tlab.enabled`            | false                  | set to `false` to disable TLAB memory events |
 |`splunk.profiler.include.agent.internals` | false                  | set to `true` to include agent internal call stacks |

--- a/profiler/README.md
+++ b/profiler/README.md
@@ -5,12 +5,13 @@ It should be considered experimental and is completely unsupported.
 
 # configuration
 
-| name                                | default                | description                               |
-|-------------------------------------|------------------------|-------------------------------------------|
-|`splunk.profiler.enabled`            | false                  | set to true to enable the profiler        |
-|`splunk.profiler.directory`          | "."                    | location of jfr files                     |
-|`splunk.profiler.recording.duration` | 20s                    | recording unit duration                   |
-|`splunk.profiler.keep-files`         | false                  | leave JFR files on disk id `true`         |
-|`splunk.profiler.logs-endpoint`      | `otel.exporter.otlp.endpoint` or http://localhost:4317  | where to send OTLP logs                   |
-|`splunk.profiler.period.{eventName}` | n/a                    | customize period (in ms) for a specific jfr event. For example, to set the ThreadDump frequency to 1s (100ms): `-Dsplunk.profiler.period.threaddump=1000` |
-|`splunk.profiler.tlab.enabled`       | false                  | set to `false` to disable TLAB memory events |
+| name                                     | default                | description                               |
+|------------------------------------------|------------------------|-------------------------------------------|
+|`splunk.profiler.enabled`                 | false                  | set to true to enable the profiler        |
+|`splunk.profiler.directory`               | "."                    | location of jfr files                     |
+|`splunk.profiler.recording.duration`      | 20s                    | recording unit duration                   |
+|`splunk.profiler.keep-files`              | false                  | leave JFR files on disk id `true`         |
+|`splunk.profiler.logs-endpoint`           | `otel.exporter.otlp.endpoint` or http://localhost:4317  | where to send OTLP logs                   |
+|`splunk.profiler.period.{eventName}`      | n/a                    | customize period (in ms) for a specific jfr event. For example, to set the ThreadDump frequency to 1s (100ms): `-Dsplunk.profiler.period.threaddump=1000` |
+|`splunk.profiler.tlab.enabled`            | false                  | set to `false` to disable TLAB memory events |
+|`splunk.profiler.include.agent.internals` | false                  | set to `true` to include agent internal call stacks |

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/AgentInternalsFilter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/AgentInternalsFilter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import java.util.Arrays;
+import java.util.function.Predicate;
+
+public class AgentInternalsFilter implements Predicate<String> {
+
+  private static final String[] UNWANTED_PREFIXES =
+      new String[] {
+        "\"Batched Logs Exporter\"",
+        "\"BatchSpanProcessor_WorkerThread-",
+        "\"JFR Recorder Thread\"",
+        "\"JFR Periodic Tasks\"",
+        "\"JFR Recording Scheduler\"",
+        "\"JFR Recording Sequencer\""
+      };
+
+  @Override
+  public boolean test(String stack) {
+    if (Arrays.stream(UNWANTED_PREFIXES).anyMatch(stack::startsWith)) {
+      return false;
+    }
+    if (stack.indexOf('\n') == -1) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
@@ -35,6 +35,8 @@ public class Configuration implements ConfigPropertySource {
   public static final String CONFIG_KEY_OTEL_OTLP_URL = "otel.exporter.otlp.endpoint";
   public static final String CONFIG_KEY_PERIOD_PREFIX = "splunk.profiler.period";
   public static final String CONFIG_KEY_TLAB_ENABLED = "splunk.profiler.tlab.enabled";
+  public static final String CONFIG_KEY_INCLUDE_INTERNALS =
+      "splunk.profiler.include.agent.internals";
 
   @Override
   public Map<String, String> getProperties() {

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/AgentInternalsFilterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/AgentInternalsFilterTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class AgentInternalsFilterTest {
+
+  @Test
+  void testOneLiners() {
+    AgentInternalsFilter filter = new AgentInternalsFilter();
+    String stack =
+        "\"GC Thread#1\" os_prio=0 cpu=1285.69ms elapsed=11333.59s tid=0x00007f43e0001000 nid=0xd0 runnable";
+    assertFalse(filter.test(stack));
+  }
+
+  @Test
+  void testRegularStack() {
+    String stack =
+        "\"http-nio-8080-BlockPoller\" #31 daemon prio=5 os_prio=0 cpu=1475.30ms elapsed=11327.18s tid=0x00007f4411ca8000 nid=0xe8 runnable  [0x00007f43c9691000]\n"
+            + "   java.lang.Thread.State: RUNNABLE\n"
+            + "\tat sun.nio.ch.EPoll.wait(java.base@11.0.12/Native Method)\n"
+            + "\tat sun.nio.ch.EPollSelectorImpl.doSelect(java.base@11.0.12/EPollSelectorImpl.java:120)\n"
+            + "\t[...]";
+    AgentInternalsFilter filter = new AgentInternalsFilter();
+    assertTrue(filter.test(stack));
+  }
+
+  @Test
+  void testBatchedLogsExporter() {
+    String stack =
+        "\"Batched Logs Exporter\" #15 daemon prio=5 os_prio=0 cpu=267.95ms elapsed=436.16s tid=0x00007f5194044800 nid=0xd9 waiting on condition  [0x00007f51d0467000]\n"
+            + "   java.lang.Thread.State: TIMED_WAITING (parking)\n"
+            + "        at jdk.internal.misc.Unsafe.park(java.base@11.0.12/Native Method)\n"
+            + "        - parking to wait for  <0x00000000c3a14ba8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)\n"
+            + "        at java.util.concurrent.locks.LockSupport.parkNanos(java.base@11.0.12/LockSupport.java:234)\n"
+            + "        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(java.base@11.0.12/AbstractQueuedSynchronizer.java:2123)\n"
+            + "        [...]";
+    AgentInternalsFilter filter = new AgentInternalsFilter();
+    assertFalse(filter.test(stack));
+  }
+
+  @Test
+  void testBatchSpanProcessor() {
+    String stack =
+        "\"BatchSpanProcessor_WorkerThread-1\" #12 daemon prio=5 os_prio=0 cpu=21.68ms elapsed=437.90s tid=0x00007f5200a8f000 nid=0xd4 waiting on condition  [0x00007f51d12ab000]\n"
+            + "   java.lang.Thread.State: TIMED_WAITING (parking)\n"
+            + "        at jdk.internal.misc.Unsafe.park(java.base@11.0.12/Native Method)\n"
+            + "        - parking to wait for  <0x00000000c3401f88> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)\n"
+            + "        [...]";
+    AgentInternalsFilter filter = new AgentInternalsFilter();
+    assertFalse(filter.test(stack));
+  }
+
+  @Test
+  void testJFRThreads() {
+    String stack =
+        "\"JFR Recorder Thread\" #16 daemon prio=5 os_prio=0 cpu=75.99ms elapsed=436.13s tid=0x00007f5194e83800 nid=0xda waiting on condition  [0x0000000000000000]\n"
+            + "   java.lang.Thread.State: RUNNABLE\n";
+    AgentInternalsFilter filter = new AgentInternalsFilter();
+    assertFalse(filter.test(stack));
+    stack =
+        "\"JFR Periodic Tasks\" #17 daemon prio=5 os_prio=0 cpu=171.78ms elapsed=435.78s tid=0x00007f5194ecd800 nid=0xdb in Object.wait()  [0x00007f5187dfe000]\n"
+            + "   java.lang.Thread.State: TIMED_WAITING (on object monitor)\n"
+            + "        at java.lang.Object.wait(java.base@11.0.12/Native Method)\n"
+            + "        [...]";
+    assertFalse(filter.test(stack));
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ThreadDumpProcessorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ThreadDumpProcessorTest.java
@@ -28,6 +28,7 @@ import com.splunk.opentelemetry.profiler.events.ContextAttached;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import jdk.jfr.EventType;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordedThread;
@@ -41,6 +42,7 @@ class ThreadDumpProcessorTest {
     String spanId = "xxxxxxyyyyyyyzyzzz";
     SpanContextualizer contextualizer = new SpanContextualizer();
     long idOfThreadRunningTheSpan = 3L;
+    Predicate<String> agentInternalsFilter = x -> true;
 
     RecordedEvent event = mock(RecordedEvent.class);
     RecordedEvent threadStartingSpan = mock(RecordedEvent.class);
@@ -60,7 +62,8 @@ class ThreadDumpProcessorTest {
 
     List<StackToSpanLinkage> results = new ArrayList<>();
     Consumer<StackToSpanLinkage> exportProcessor = results::add;
-    ThreadDumpProcessor processor = new ThreadDumpProcessor(contextualizer, exportProcessor);
+    ThreadDumpProcessor processor =
+        new ThreadDumpProcessor(contextualizer, exportProcessor, agentInternalsFilter);
 
     processor.accept(event);
     assertEquals(3, results.size());

--- a/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/profiler/ProfilerSmokeTest.java
+++ b/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/profiler/ProfilerSmokeTest.java
@@ -163,7 +163,7 @@ public class ProfilerSmokeTest {
 
     Optional<LogRecord> jfrThread =
         logs.stream()
-            .filter(log -> log.getBody().getStringValue().startsWith("\"JFR Recording Scheduler\""))
+            .filter(log -> log.getBody().getStringValue().startsWith("\"Catalina-utility-1\""))
             .findFirst();
     assertThat(jfrThread).isNotEmpty();
     Optional<LogRecord> mainThread =


### PR DESCRIPTION
Most users will find little value in these and probably won't want to pay for ingest/collection, so let's omit them.

This is a first-pass. It is expected that we will iterate on the list of things being dropped.