### PR TITLE
Add java server instrumentation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,13 @@ The agent works with Java runtimes version 8 and higher. For the full list of re
 
 ## Get started
 
-Follow these steps to automatically instrument your application using the Java (or JVM) agent.
+Follow these steps to automatically instrument your application using the Java (or JVM) agent:
 
 1.  Check that you meet the [requirements](#requirements).
 
 2.  Make sure that the collector you set up to receive trace data is installed and configured.
 
-3.  Download the JAR file for the latest version of the agent.
+3.  Download the JAR file for the latest version of the agent:
 
     -   On Linux, run:
 
@@ -111,7 +111,7 @@ Follow these steps to automatically instrument your application using the Java (
         Invoke-WebRequest -Uri https://github.com/signalfx/splunk-otel-java/releases/latest/download/splunk-otel-javaagent-all.jar -OutFile splunk-otel-javaagent.jar
         ```
 
-4.  Set the `OTEL_SERVICE_NAME` environment variable.
+4.  Set the `OTEL_SERVICE_NAME` environment variable:
 
     -   On Linux, run:
 
@@ -125,7 +125,7 @@ Follow these steps to automatically instrument your application using the Java (
         $env:OTEL_SERVICE_NAME=<yourServiceName>
         ```
 
-5.  Enable the Java agent.
+5.  Enable the Java agent:
 
     ```bash
     java -javaagent:./splunk-otel-javaagent.jar \
@@ -134,8 +134,9 @@ Follow these steps to automatically instrument your application using the Java (
 
     Insert the `-javaagent` flag before the `-jar` file, adding it as a JVM option, not as an application argument.
 
-> To generate a snippet that includes all the basic install commands for your environment and service, open the Observability Cloud
-wizard in **Data Setup > APM Instrumentation > Java > Add Connection**.
+> **Note**: Supported java servers may require different steps to add the path to the JVM agent to their configuration. See [Add the JVM agent to Java servers](./docs/server-instructions.md).
+
+> **Tip**: To generate a snippet that includes all the basic install commands for your environment and service, open the Observability Cloud wizard in **Data Setup > APM Instrumentation > Java > Add Connection**.
 
 When you run your application with the Java agent, trace data goes to Observability Cloud through the Splunk OTel connector. If no data
 appears in **Observability > APM**, see [Troubleshooting](#troubleshooting).

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The agent works with Java runtimes version 8 and higher. For the full list of re
 
 ## Get started
 
-Follow these steps to automatically instrument your application using the Java (or JVM) agent:
+Follow these steps to automatically instrument your application using the Java agent:
 
 1.  Check that you meet the [requirements](#requirements).
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Follow these steps to automatically instrument your application using the Java (
 
 > **Note**: Supported java servers may require different steps to add the path to the JVM agent to their configuration. See [Add the JVM agent to Java servers](./docs/server-instructions.md).
 
-> **Tip**: To generate a snippet that includes all the basic install commands for your environment and service, open the Observability Cloud wizard in **Data Setup > APM Instrumentation > Java > Add Connection**.
+> **Tip**: To generate a snippet that includes all the basic install commands for your environment and service, open the Splunk Observability Cloud wizard in **Data Setup > APM Instrumentation > Java > Add Connection**.
 
 When you run your application with the Java agent, trace data goes to Observability Cloud through the Splunk OTel connector. If no data
 appears in **Observability > APM**, see [Troubleshooting](#troubleshooting).

--- a/docs/server-instructions.md
+++ b/docs/server-instructions.md
@@ -25,7 +25,7 @@ java -javaagent:/path/to/splunk-otel-javaagent.jar -jar start.jar
 
 Alternatively you can add `-javaagent` argument to your `jetty.sh` or `start.ini` files:
 
--  If you use the `jetty.sh` file, add the `javaagent` argument:
+-  If you use the `jetty.sh` file to start jetty, add the following line to `<jetty_home>/bin/jetty.sh`:
    ```
    JAVA_OPTIONS="${JAVA_OPTIONS} -javaagent:/path/to/splunk-otel-javaagent.jar"
    ```

--- a/docs/server-instructions.md
+++ b/docs/server-instructions.md
@@ -75,7 +75,7 @@ Add the path to the JVM agent to your Tomcat/TomEE startup script:
 
 Add the path to the JVM agent to your Weblogic domain startup script:
 
-- On Linux and macOS, add the following line to the `bin/startWebLogic.sh` file:
+- On Linux and macOS, add the following line to the `<domain_home>bin/startWebLogic.sh` file:
    ```
    export JAVA_OPTIONS="$JAVA_OPTIONS -javaagent:/path/to/splunk-otel-javaagent.jar"
    ```

--- a/docs/server-instructions.md
+++ b/docs/server-instructions.md
@@ -97,8 +97,8 @@ Add the path to the JVM agent to your Weblogic domain startup script:
 Add the path to the JVM agent to the `jvm.options` file:
 
 - Open the `jvm.options` file:
-   - For a single server, create or open `${server.config.dir}/jvm.options`.
-   - For all servers, open the common configuration in `${wlp.install.dir}/etc/jvm.options`
+   - For a single server, create or edit the `${server.config.dir}/jvm.options` file.
+   - For all servers, create or edit the `${wlp.install.dir}/etc/jvm.options` file.
 - Add the following line:
    ```
    -javaagent:/path/to/splunk-otel-javaagent.jar

--- a/docs/server-instructions.md
+++ b/docs/server-instructions.md
@@ -17,8 +17,18 @@ Add the `javaagent` argument to the `standalone` configuration file:
 
 ## Jetty
 
-Configure the path to the JVM agent either in `start.ini` or in `jetty.sh`:
+Add the path to the JVM agent using the `-javaagent` argument:
 
+```
+java -javaagent:/path/to/splunk-otel-javaagent.jar -jar start.jar
+```
+
+(Optional) You can also edit your `jetty.sh` and `start.ini` files:
+
+-  In the `jetty.sh` file, add the `javaagent` argument:
+   ```
+   JAVA_OPTIONS="${JAVA_OPTIONS} -javaagent:/path/to/splunk-otel-javaagent.jar"
+   ```
 - In the `start.ini` file, add the `javaagent` argument right below the `--exec` option:
    ```
    #===========================================================
@@ -26,10 +36,6 @@ Configure the path to the JVM agent either in `start.ini` or in `jetty.sh`:
    #-----------------------------------------------------------
    --exec
    -javaagent:/path/to/splunk-otel-javaagent.jar
-   ```
--  In the `jetty.sh` file, add the `javaagent` argument:
-   ```
-   JAVA_OPTIONS="${JAVA_OPTIONS} -javaagent:/path/to/splunk-otel-javaagent.jar"
    ```
 
 ## Glassfish / Payara

--- a/docs/server-instructions.md
+++ b/docs/server-instructions.md
@@ -66,7 +66,7 @@ Add the path to the JVM agent to your Tomcat/TomEE startup script:
    ```
    CATALINA_OPTS="$CATALINA_OPTS -javaagent:/path/to/splunk-otel-javaagent.jar"
    ```
-- On Windows, add the following line to `%CATALINA_BASE%\bin\setenv.bat`:
+- On Windows, add the following line to ``<tomcat_home>\bin\setenv.bat`:
    ```
    set CATALINA_OPTS=%CATALINA_OPTS% -javaagent:"<Drive>:\path\to\splunk-otel-javaagent.jar"
    ```

--- a/docs/server-instructions.md
+++ b/docs/server-instructions.md
@@ -23,7 +23,7 @@ Add the path to the JVM agent using the `-javaagent` argument:
 java -javaagent:/path/to/splunk-otel-javaagent.jar -jar start.jar
 ```
 
-Alternatively, depending on how you define JVM arguments, you can edit your `jetty.sh` or `start.ini` files, :
+Alternatively you can add `-javaagent` argument to your `jetty.sh` or `start.ini` files:
 
 -  If you use the `jetty.sh` file, add the `javaagent` argument:
    ```

--- a/docs/server-instructions.md
+++ b/docs/server-instructions.md
@@ -1,6 +1,6 @@
 # Add the JVM agent to Java servers
 
-The following sections show how to add the path to the Splunk OTel agent for Java using the [supported servers](/supported-libraries.md#application-servers).
+The following sections show how to add the path to the Splunk OTel agent for Java using the [supported servers](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/supported-libraries.md#application-servers).
 
 ## JBoss EAP / WildFly
 

--- a/docs/server-instructions.md
+++ b/docs/server-instructions.md
@@ -45,7 +45,7 @@ Add the path to the JVM agent to the settings using the `asadmin` command-line t
    <server_install_dir>\bin\asadmin.bat create-jvm-options '-javaagent:<Drive>:\path\to\splunk-otel-javaagent.jar'
    ```
 
-You can also instrument your application from the Admin Console:
+You can also add the `-javaagent` argument from the Admin Console:
 
 1. Open the GlassFish Admin Console at http://localhost:4848
 2. Go to **Configurations > server-config > JVM Settings**.
@@ -91,7 +91,7 @@ Add the path to the JVM agent to your Weblogic domain startup script:
 Add the path to the JVM agent to the `jvm.options` file:
 
 - Open the `jvm.options` file:
-   - For a single server, open the server configuration `${server.config.dir}/jvm.options`.
+   - For a single server, create or open `${server.config.dir}/jvm.options`.
    - For all servers, open the common configuration in `${wlp.install.dir}/etc/jvm.options`
 - Add the following line:
    ```

--- a/docs/server-instructions.md
+++ b/docs/server-instructions.md
@@ -66,7 +66,7 @@ Add the path to the JVM agent to your Tomcat/TomEE startup script:
    ```
    CATALINA_OPTS="$CATALINA_OPTS -javaagent:/path/to/splunk-otel-javaagent.jar"
    ```
-- On Windows, add the following line to ``<tomcat_home>\bin\setenv.bat`:
+- On Windows, add the following line to `<tomcat_home>\bin\setenv.bat`:
    ```
    set CATALINA_OPTS=%CATALINA_OPTS% -javaagent:"<Drive>:\path\to\splunk-otel-javaagent.jar"
    ```

--- a/docs/server-instructions.md
+++ b/docs/server-instructions.md
@@ -10,7 +10,7 @@ Add the `javaagent` argument to the `standalone` configuration file:
    ```
    JAVA_OPTS="$JAVA_OPTS -javaagent:/path/to/splunk-otel-javaagent.jar"
    ```
-- On Windows, dd the following line at the end of the `standalone.conf.bat` file:
+- On Windows, add the following line at the end of the `standalone.conf.bat` file:
    ```
    set "JAVA_OPTS=%JAVA_OPTS% -javaagent:<Drive>:\path\to\splunk-otel-javaagent.jar"
    ```

--- a/docs/server-instructions.md
+++ b/docs/server-instructions.md
@@ -29,7 +29,7 @@ Alternatively you can add `-javaagent` argument to your `jetty.sh` or `start.ini
    ```
    JAVA_OPTIONS="${JAVA_OPTIONS} -javaagent:/path/to/splunk-otel-javaagent.jar"
    ```
-- If you use the `start.ini` file, add the `javaagent` argument right below the `--exec` option:
+- If you use the `start.ini` file to define JVM arguments, add the `javaagent` argument right below the `--exec` option:
    ```
    #===========================================================
    # Sample Jetty start.ini file

--- a/docs/server-instructions.md
+++ b/docs/server-instructions.md
@@ -1,0 +1,102 @@
+# Add the JVM agent to Java servers
+
+The following sections show how to add the path to the Splunk OTel agent for Java using the [supported servers](/supported-libraries.md#application-servers).
+
+## JBoss EAP / WildFly
+
+Add the `javaagent` argument to the `standalone` configuration file:
+
+- On Linux and macOS, add the following line at the end of the `standalone.conf` file:
+   ```
+   JAVA_OPTS="$JAVA_OPTS -javaagent:/path/to/splunk-otel-javaagent.jar"
+   ```
+- On Windows, dd the following line at the end of the `standalone.conf.bat` file:
+   ```
+   set "JAVA_OPTS=%JAVA_OPTS% -javaagent:<Drive>:\path\to\splunk-otel-javaagent.jar"
+   ```
+
+## Jetty
+
+Configure the path to the JVM agent either in `start.ini` or in `jetty.sh`:
+
+- In the `start.ini` file, add the `javaagent` argument right below the `--exec` option:
+   ```
+   #===========================================================
+   # Sample Jetty start.ini file
+   #-----------------------------------------------------------
+   --exec
+   -javaagent:/path/to/splunk-otel-javaagent.jar
+   -Xmx512m
+   ...
+   ```
+-  In the `jetty.sh` file, add the `javaagent` argument inside `:
+   ```
+   JAVA_OPTIONS="${JAVA_OPTIONS} -javaagent\:/path/to/splunk-otel-javaagent.jar"
+   ```
+
+## Glassfish / Payara
+
+Add the path to the JVM agent to the settings using the `asadmin` command-line tool:
+
+- On Linux, enter the following command:
+   ```
+   <server_install_dir>/bin/asadmin create-jvm-options "-javaagent\:/path/to/splunk-otel-javaagent.jar" 
+   ```
+- On Windows, enter the following command:
+   ```
+   <server_install_dir>\bin\asadmin.bat create-jvm-options '-javaagent:<Drive>:\path\to\splunk-otel-javaagent.jar'
+   ```
+
+You can also instrument your application from the Admin Console:
+
+1. Open the GlassFish Admin Console at http://localhost:4848
+2. Go to **Configurations > server-config > JVM Settings**.
+3. Select **JVM Options** and click **Add JVM Option**.
+4. In the blank field, enter the path to `splunk-otel-javaagent.jar`:
+
+   `-javaagent:/path/to/splunk-otel-javaagent.jar`
+
+5. Click **Save** and restart the GlassFish server.
+
+> Tip: Check that the `domain.xml` file in your domain directory contains a `<jmv-options>` entry for the agent.
+
+## Tomcat / TomEE
+
+Add the path to the JVM agent to your Tomcat/TomEE startup script:
+
+- On Linux, add the following line to `<tomcat_home>/bin/setenv.sh`:
+   ```
+   CATALINA_OPTS="$CATALINA_OPTS -javaagent:/path/to/splunk-otel-javaagent.jar"
+   ```
+- On Windows, add the following line to `%CATALINA_BASE%\bin\setenv.bat`:
+   ```
+   set CATALINA_OPTS=%CATALINA_OPTS% -javaagent:"<Drive>:\path\to\splunk-otel-javaagent.jar"
+   ```
+
+## Weblogic
+
+Add the path to the JVM agent to the `startWebLogic` file of your administration server:
+
+- On Linux and macOS, add the following line to the `bin/startWebLogic.sh` file:
+   ```
+   export JAVA_OPTIONS="$JAVA_OPTIONS -javaagent:/path/to/splunk-otel-javaagent.jar"
+   ```
+- On Windows, add the following line to the `<install_dir>/<config>/<domain_name>/startWebLogic.cmd` file:
+   ```
+   set JAVA_OPTIONS=%JAVA_OPTIONS% -javaagent:"<Drive>:\path\to\splunk-otel-javaagent.jar"
+   ```
+
+> For managed server instances, add the `javaagent` argument using the admin console.
+
+## Websphere Liberty Profile
+
+Add the path to the JVM agent to the `jvm.options` file:
+
+- Open the `jvm.options` file:
+   - For a single server, open the server configuration `${server.config.dir}/jvm.options`.
+   - For all servers, open the common configuration in `${wlp.install.dir}/etc/jvm.options`
+- Add the following line:
+   ```
+   -javaagent:/path/to/splunk-otel-javaagent.jar
+   ```
+- Save the file and restart the server.

--- a/docs/server-instructions.md
+++ b/docs/server-instructions.md
@@ -26,10 +26,8 @@ Configure the path to the JVM agent either in `start.ini` or in `jetty.sh`:
    #-----------------------------------------------------------
    --exec
    -javaagent:/path/to/splunk-otel-javaagent.jar
-   -Xmx512m
-   ...
    ```
--  In the `jetty.sh` file, add the `javaagent` argument inside `:
+-  In the `jetty.sh` file, add the `javaagent` argument:
    ```
    JAVA_OPTIONS="${JAVA_OPTIONS} -javaagent\:/path/to/splunk-otel-javaagent.jar"
    ```

--- a/docs/server-instructions.md
+++ b/docs/server-instructions.md
@@ -81,7 +81,7 @@ Add the path to the JVM agent to your Tomcat/TomEE startup script:
 
 Add the path to the JVM agent to your Weblogic domain startup script:
 
-- On Linux and macOS, add the following line to the `<domain_home>bin/startWebLogic.sh` file:
+- On Linux and macOS, add the following line to the `<domain_home>/bin/startWebLogic.sh` file:
    ```
    export JAVA_OPTIONS="$JAVA_OPTIONS -javaagent:/path/to/splunk-otel-javaagent.jar"
    ```

--- a/docs/server-instructions.md
+++ b/docs/server-instructions.md
@@ -79,7 +79,7 @@ Add the path to the JVM agent to your Weblogic domain startup script:
    ```
    export JAVA_OPTIONS="$JAVA_OPTIONS -javaagent:/path/to/splunk-otel-javaagent.jar"
    ```
-- On Windows, add the following line to the `<install_dir>/<config>/<domain_name>/startWebLogic.cmd` file:
+- On Windows, add the following line to the `<domain_home>\bin\startWebLogic.cmd` file:
    ```
    set JAVA_OPTIONS=%JAVA_OPTIONS% -javaagent:"<Drive>:\path\to\splunk-otel-javaagent.jar"
    ```

--- a/docs/server-instructions.md
+++ b/docs/server-instructions.md
@@ -48,7 +48,7 @@ Add the path to the JVM agent to the settings using the `asadmin` command-line t
    ```
 - On Windows, enter the following command:
    ```
-   <server_install_dir>\bin\asadmin.bat create-jvm-options '-javaagent:<Drive>:\path\to\splunk-otel-javaagent.jar'
+   <server_install_dir>\bin\asadmin.bat create-jvm-options '-javaagent\:<Drive>\:\\path\\to\\splunk-otel-javaagent.jar'
    ```
 
 You can also add the `-javaagent` argument from the Admin Console:

--- a/docs/server-instructions.md
+++ b/docs/server-instructions.md
@@ -73,7 +73,7 @@ Add the path to the JVM agent to your Tomcat/TomEE startup script:
 
 ## Weblogic
 
-Add the path to the JVM agent to the `startWebLogic` file of your administration server:
+Add the path to the JVM agent to your Weblogic domain startup script:
 
 - On Linux and macOS, add the following line to the `bin/startWebLogic.sh` file:
    ```

--- a/docs/server-instructions.md
+++ b/docs/server-instructions.md
@@ -84,7 +84,7 @@ Add the path to the JVM agent to your Weblogic domain startup script:
    set JAVA_OPTIONS=%JAVA_OPTIONS% -javaagent:"<Drive>:\path\to\splunk-otel-javaagent.jar"
    ```
 
-> For managed server instances, add the `javaagent` argument using the admin console.
+> For managed server instances, add the `-javaagent` argument using the admin console.
 
 ## Websphere Liberty Profile
 

--- a/docs/server-instructions.md
+++ b/docs/server-instructions.md
@@ -29,7 +29,7 @@ Configure the path to the JVM agent either in `start.ini` or in `jetty.sh`:
    ```
 -  In the `jetty.sh` file, add the `javaagent` argument:
    ```
-   JAVA_OPTIONS="${JAVA_OPTIONS} -javaagent\:/path/to/splunk-otel-javaagent.jar"
+   JAVA_OPTIONS="${JAVA_OPTIONS} -javaagent:/path/to/splunk-otel-javaagent.jar"
    ```
 
 ## Glassfish / Payara

--- a/docs/server-instructions.md
+++ b/docs/server-instructions.md
@@ -23,13 +23,13 @@ Add the path to the JVM agent using the `-javaagent` argument:
 java -javaagent:/path/to/splunk-otel-javaagent.jar -jar start.jar
 ```
 
-(Optional) You can also edit your `jetty.sh` and `start.ini` files:
+Alternatively, depending on how you define JVM arguments, you can edit your `jetty.sh` or `start.ini` files, :
 
--  In the `jetty.sh` file, add the `javaagent` argument:
+-  If you use the `jetty.sh` file, add the `javaagent` argument:
    ```
    JAVA_OPTIONS="${JAVA_OPTIONS} -javaagent:/path/to/splunk-otel-javaagent.jar"
    ```
-- In the `start.ini` file, add the `javaagent` argument right below the `--exec` option:
+- If you use the `start.ini` file, add the `javaagent` argument right below the `--exec` option:
    ```
    #===========================================================
    # Sample Jetty start.ini file


### PR DESCRIPTION
Our current Java instrumentation docs lack specific instructions for hooking up the -javaaagent with the startup scripts of the application servers such as Tomcat or Weblogic. This is a know issue; each server requires separate instructions.

This PR adds instructions for the supported Java servers.

