### PR TITLE
TLAB events are only relevant if enabled in config

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/FilterSortedRecordingFile.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/FilterSortedRecordingFile.java
@@ -29,9 +29,11 @@ import jdk.jfr.consumer.RecordedEvent;
 class FilterSortedRecordingFile implements RecordedEventStream {
 
   private final RecordedEventStream.Factory delegateStreamFactory;
+  private final RelevantEvents relevantEvents;
 
-  FilterSortedRecordingFile(RecordedEventStream.Factory delegateStreamFactory) {
+  FilterSortedRecordingFile(Factory delegateStreamFactory, RelevantEvents relevantEvents) {
     this.delegateStreamFactory = delegateStreamFactory;
+    this.relevantEvents = relevantEvents;
   }
 
   @Override
@@ -39,7 +41,8 @@ class FilterSortedRecordingFile implements RecordedEventStream {
     return delegateStreamFactory
         .get()
         .open(path)
-        .filter(event -> RelevantEvents.EVENT_NAMES.contains(event.getEventType().getName()))
+        .filter(relevantEvents::isRelevant)
         .sorted(Comparator.comparing(RecordedEvent::getStartTime));
   }
+
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/FilterSortedRecordingFile.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/FilterSortedRecordingFile.java
@@ -44,5 +44,4 @@ class FilterSortedRecordingFile implements RecordedEventStream {
         .filter(relevantEvents::isRelevant)
         .sorted(Comparator.comparing(RecordedEvent::getStartTime));
   }
-
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
@@ -88,7 +88,9 @@ public class JfrActivator implements AgentListener {
     Map<String, String> jfrSettings = buildJfrSettings(config);
 
     RecordedEventStream.Factory recordedEventStreamFactory =
-        () -> new FilterSortedRecordingFile(() -> new BasicJfrRecordingFile(JFR.instance), RelevantEvents.create(config));
+        () ->
+            new FilterSortedRecordingFile(
+                () -> new BasicJfrRecordingFile(JFR.instance), RelevantEvents.create(config));
 
     SpanContextualizer spanContextualizer = new SpanContextualizer();
     EventPeriods periods = new EventPeriods(jfrSettings::get);

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
@@ -30,6 +30,7 @@ import com.splunk.opentelemetry.logs.BatchingLogsProcessor;
 import com.splunk.opentelemetry.logs.LogsExporter;
 import com.splunk.opentelemetry.profiler.context.SpanContextualizer;
 import com.splunk.opentelemetry.profiler.events.EventPeriods;
+import com.splunk.opentelemetry.profiler.events.RelevantEvents;
 import com.splunk.opentelemetry.profiler.util.FileDeleter;
 import com.splunk.opentelemetry.profiler.util.HelpfulExecutors;
 import io.opentelemetry.instrumentation.api.config.Config;
@@ -87,7 +88,7 @@ public class JfrActivator implements AgentListener {
     Map<String, String> jfrSettings = buildJfrSettings(config);
 
     RecordedEventStream.Factory recordedEventStreamFactory =
-        () -> new FilterSortedRecordingFile(() -> new BasicJfrRecordingFile(JFR.instance));
+        () -> new FilterSortedRecordingFile(() -> new BasicJfrRecordingFile(JFR.instance), RelevantEvents.create(config));
 
     SpanContextualizer spanContextualizer = new SpanContextualizer();
     EventPeriods periods = new EventPeriods(jfrSettings::get);

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/events/RelevantEvents.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/events/RelevantEvents.java
@@ -16,20 +16,37 @@
 
 package com.splunk.opentelemetry.profiler.events;
 
+import com.splunk.opentelemetry.profiler.Configuration;
 import com.splunk.opentelemetry.profiler.TLABProcessor;
 import com.splunk.opentelemetry.profiler.ThreadDumpProcessor;
+import io.opentelemetry.instrumentation.api.config.Config;
+import jdk.jfr.consumer.RecordedEvent;
+
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
 public class RelevantEvents {
-  public static Set<String> EVENT_NAMES =
-      Collections.unmodifiableSet(
-          new HashSet<>(
-              Arrays.asList(
-                  ThreadDumpProcessor.EVENT_NAME,
-                  ContextAttached.EVENT_NAME,
-                  TLABProcessor.NEW_TLAB_EVENT_NAME,
-                  TLABProcessor.OUTSIDE_TLAB_EVENT_NAME)));
+
+    private final Set<String> eventNames;
+
+    private RelevantEvents(Set<String> eventNames) {
+        this.eventNames = eventNames;
+    }
+
+    public static RelevantEvents create(Config config) {
+        Set<String> eventNames = new HashSet<>(
+                Arrays.asList(
+                        ThreadDumpProcessor.EVENT_NAME,
+                        ContextAttached.EVENT_NAME));
+        if(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED, false)){
+            eventNames.add(TLABProcessor.NEW_TLAB_EVENT_NAME);
+            eventNames.add(TLABProcessor.OUTSIDE_TLAB_EVENT_NAME);
+        }
+        return new RelevantEvents(eventNames);
+    }
+
+    public boolean isRelevant(RecordedEvent event) {
+        return eventNames.contains(event.getEventType().getName());
+    }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/events/RelevantEvents.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/events/RelevantEvents.java
@@ -20,33 +20,30 @@ import com.splunk.opentelemetry.profiler.Configuration;
 import com.splunk.opentelemetry.profiler.TLABProcessor;
 import com.splunk.opentelemetry.profiler.ThreadDumpProcessor;
 import io.opentelemetry.instrumentation.api.config.Config;
-import jdk.jfr.consumer.RecordedEvent;
-
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import jdk.jfr.consumer.RecordedEvent;
 
 public class RelevantEvents {
 
-    private final Set<String> eventNames;
+  private final Set<String> eventNames;
 
-    private RelevantEvents(Set<String> eventNames) {
-        this.eventNames = eventNames;
-    }
+  private RelevantEvents(Set<String> eventNames) {
+    this.eventNames = eventNames;
+  }
 
-    public static RelevantEvents create(Config config) {
-        Set<String> eventNames = new HashSet<>(
-                Arrays.asList(
-                        ThreadDumpProcessor.EVENT_NAME,
-                        ContextAttached.EVENT_NAME));
-        if(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED, false)){
-            eventNames.add(TLABProcessor.NEW_TLAB_EVENT_NAME);
-            eventNames.add(TLABProcessor.OUTSIDE_TLAB_EVENT_NAME);
-        }
-        return new RelevantEvents(eventNames);
+  public static RelevantEvents create(Config config) {
+    Set<String> eventNames =
+        new HashSet<>(Arrays.asList(ThreadDumpProcessor.EVENT_NAME, ContextAttached.EVENT_NAME));
+    if (config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED, false)) {
+      eventNames.add(TLABProcessor.NEW_TLAB_EVENT_NAME);
+      eventNames.add(TLABProcessor.OUTSIDE_TLAB_EVENT_NAME);
     }
+    return new RelevantEvents(eventNames);
+  }
 
-    public boolean isRelevant(RecordedEvent event) {
-        return eventNames.contains(event.getEventType().getName());
-    }
+  public boolean isRelevant(RecordedEvent event) {
+    return eventNames.contains(event.getEventType().getName());
+  }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/FilterSortedRecordingFileTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/FilterSortedRecordingFileTest.java
@@ -28,6 +28,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import com.splunk.opentelemetry.profiler.events.RelevantEvents;
 import jdk.jfr.EventType;
 import jdk.jfr.consumer.RecordedEvent;
 import org.junit.jupiter.api.Test;
@@ -47,9 +49,17 @@ class FilterSortedRecordingFileTest {
     List<RecordedEvent> expected = Arrays.asList(event1, event3, event4, event5);
 
     RecordedEventStream delegate = mock(RecordedEventStream.class);
+    RelevantEvents relevantEvents = mock(RelevantEvents.class);
+
     when(delegate.open(path)).thenReturn(str);
+    when(relevantEvents.isRelevant(event1)).thenReturn(true);
+    when(relevantEvents.isRelevant(event2)).thenReturn(false);
+    when(relevantEvents.isRelevant(event3)).thenReturn(true);
+    when(relevantEvents.isRelevant(event4)).thenReturn(true);
+    when(relevantEvents.isRelevant(event5)).thenReturn(true);
+
     RecordedEventStream.Factory delegateFactory = () -> delegate;
-    FilterSortedRecordingFile recordingFile = new FilterSortedRecordingFile(delegateFactory);
+    FilterSortedRecordingFile recordingFile = new FilterSortedRecordingFile(delegateFactory, relevantEvents);
     List<RecordedEvent> result = recordingFile.open(path).collect(Collectors.toList());
     assertEquals(expected, result);
   }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/FilterSortedRecordingFileTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/FilterSortedRecordingFileTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.splunk.opentelemetry.profiler.events.RelevantEvents;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -28,8 +29,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import com.splunk.opentelemetry.profiler.events.RelevantEvents;
 import jdk.jfr.EventType;
 import jdk.jfr.consumer.RecordedEvent;
 import org.junit.jupiter.api.Test;
@@ -59,7 +58,8 @@ class FilterSortedRecordingFileTest {
     when(relevantEvents.isRelevant(event5)).thenReturn(true);
 
     RecordedEventStream.Factory delegateFactory = () -> delegate;
-    FilterSortedRecordingFile recordingFile = new FilterSortedRecordingFile(delegateFactory, relevantEvents);
+    FilterSortedRecordingFile recordingFile =
+        new FilterSortedRecordingFile(delegateFactory, relevantEvents);
     List<RecordedEvent> result = recordingFile.open(path).collect(Collectors.toList());
     assertEquals(expected, result);
   }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/events/RelevantEventsTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/events/RelevantEventsTest.java
@@ -1,4 +1,24 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.opentelemetry.profiler.events;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.splunk.opentelemetry.profiler.Configuration;
 import com.splunk.opentelemetry.profiler.TLABProcessor;
@@ -9,48 +29,43 @@ import jdk.jfr.consumer.RecordedEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 class RelevantEventsTest {
 
-    RecordedEvent threadDump;
-    RecordedEvent tlab;
+  RecordedEvent threadDump;
+  RecordedEvent tlab;
 
-    @BeforeEach
-    void setup() {
-        threadDump = mock(RecordedEvent.class);
-        tlab = mock(RecordedEvent.class);
-        EventType threadDumpType = type(ThreadDumpProcessor.EVENT_NAME);
-        EventType tlabType = type(TLABProcessor.NEW_TLAB_EVENT_NAME);
+  @BeforeEach
+  void setup() {
+    threadDump = mock(RecordedEvent.class);
+    tlab = mock(RecordedEvent.class);
+    EventType threadDumpType = type(ThreadDumpProcessor.EVENT_NAME);
+    EventType tlabType = type(TLABProcessor.NEW_TLAB_EVENT_NAME);
 
-        when(threadDump.getEventType()).thenReturn(threadDumpType);
-        when(tlab.getEventType()).thenReturn(tlabType);
-    }
+    when(threadDump.getEventType()).thenReturn(threadDumpType);
+    when(tlab.getEventType()).thenReturn(tlabType);
+  }
 
-    private EventType type(String name) {
-        EventType type = mock(EventType.class);
-        when(type.getName()).thenReturn(name);
-        return type;
-    }
+  private EventType type(String name) {
+    EventType type = mock(EventType.class);
+    when(type.getName()).thenReturn(name);
+    return type;
+  }
 
-    @Test
-    void testTlabEnabled() {
-        Config config = mock(Config.class);
-        when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED, false)).thenReturn(true);
-        RelevantEvents relevantEvents = RelevantEvents.create(config);
-        assertTrue(relevantEvents.isRelevant(threadDump));
-        assertTrue(relevantEvents.isRelevant(tlab));
-    }
+  @Test
+  void testTlabEnabled() {
+    Config config = mock(Config.class);
+    when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED, false)).thenReturn(true);
+    RelevantEvents relevantEvents = RelevantEvents.create(config);
+    assertTrue(relevantEvents.isRelevant(threadDump));
+    assertTrue(relevantEvents.isRelevant(tlab));
+  }
 
-    @Test
-    void testTlabNotEnabled() {
-        Config config = mock(Config.class);
-        when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED, false)).thenReturn(false);
-        RelevantEvents relevantEvents = RelevantEvents.create(config);
-        assertTrue(relevantEvents.isRelevant(threadDump));
-        assertFalse(relevantEvents.isRelevant(tlab));
-    }
-
+  @Test
+  void testTlabNotEnabled() {
+    Config config = mock(Config.class);
+    when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED, false)).thenReturn(false);
+    RelevantEvents relevantEvents = RelevantEvents.create(config);
+    assertTrue(relevantEvents.isRelevant(threadDump));
+    assertFalse(relevantEvents.isRelevant(tlab));
+  }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/events/RelevantEventsTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/events/RelevantEventsTest.java
@@ -1,0 +1,56 @@
+package com.splunk.opentelemetry.profiler.events;
+
+import com.splunk.opentelemetry.profiler.Configuration;
+import com.splunk.opentelemetry.profiler.TLABProcessor;
+import com.splunk.opentelemetry.profiler.ThreadDumpProcessor;
+import io.opentelemetry.instrumentation.api.config.Config;
+import jdk.jfr.EventType;
+import jdk.jfr.consumer.RecordedEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RelevantEventsTest {
+
+    RecordedEvent threadDump;
+    RecordedEvent tlab;
+
+    @BeforeEach
+    void setup() {
+        threadDump = mock(RecordedEvent.class);
+        tlab = mock(RecordedEvent.class);
+        EventType threadDumpType = type(ThreadDumpProcessor.EVENT_NAME);
+        EventType tlabType = type(TLABProcessor.NEW_TLAB_EVENT_NAME);
+
+        when(threadDump.getEventType()).thenReturn(threadDumpType);
+        when(tlab.getEventType()).thenReturn(tlabType);
+    }
+
+    private EventType type(String name) {
+        EventType type = mock(EventType.class);
+        when(type.getName()).thenReturn(name);
+        return type;
+    }
+
+    @Test
+    void testTlabEnabled() {
+        Config config = mock(Config.class);
+        when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED, false)).thenReturn(true);
+        RelevantEvents relevantEvents = RelevantEvents.create(config);
+        assertTrue(relevantEvents.isRelevant(threadDump));
+        assertTrue(relevantEvents.isRelevant(tlab));
+    }
+
+    @Test
+    void testTlabNotEnabled() {
+        Config config = mock(Config.class);
+        when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED, false)).thenReturn(false);
+        RelevantEvents relevantEvents = RelevantEvents.create(config);
+        assertTrue(relevantEvents.isRelevant(threadDump));
+        assertFalse(relevantEvents.isRelevant(tlab));
+    }
+
+}


### PR DESCRIPTION
If TLAB events end up in the file (through interference from other recordings, for example), we still don't want to treat them as relevant. This guards it with config.