### PR TITLE
Improve jdk.ThreadDump content parsing

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
@@ -108,7 +108,7 @@ public class JfrActivator implements AgentListener {
         new StackToSpanLinkageProcessor(logEntryCreator, batchingLogsProcessor);
 
     ThreadDumpToStacks threadDumpToStacks =
-        new ThreadDumpToStacks(buildAgentInternalsFilter(config));
+        new ThreadDumpToStacks(buildStackTraceFilter(config));
 
     ThreadDumpProcessor threadDumpProcessor =
         buildThreadDumpProcessor(spanContextualizer, processor, threadDumpToStacks);
@@ -162,7 +162,7 @@ public class JfrActivator implements AgentListener {
   }
 
   /** May filter out agent internal call stacks based on the config. */
-  private StackTraceFilter buildAgentInternalsFilter(Config config) {
+  private StackTraceFilter buildStackTraceFilter(Config config) {
     return new StackTraceFilter(config.getBoolean(CONFIG_KEY_INCLUDE_INTERNALS, false));
   }
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
@@ -41,7 +41,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,8 +107,11 @@ public class JfrActivator implements AgentListener {
     StackToSpanLinkageProcessor processor =
         new StackToSpanLinkageProcessor(logEntryCreator, batchingLogsProcessor);
 
+    ThreadDumpToStacks threadDumpToStacks =
+        new ThreadDumpToStacks(buildAgentInternalsFilter(config));
+
     ThreadDumpProcessor threadDumpProcessor =
-        buildThreadDumpProcessor(config, spanContextualizer, processor);
+        buildThreadDumpProcessor(spanContextualizer, processor, threadDumpToStacks);
     TLABProcessor tlabProcessor =
         new TLABProcessor(config, batchingLogsProcessor, commonAttributes);
     EventProcessingChain eventProcessingChain =
@@ -149,17 +151,19 @@ public class JfrActivator implements AgentListener {
   }
 
   private ThreadDumpProcessor buildThreadDumpProcessor(
-      Config config, SpanContextualizer spanContextualizer, StackToSpanLinkageProcessor processor) {
-    Predicate<String> agentInternalsFilter = buildAgentInternalsFilter(config);
-    return new ThreadDumpProcessor(spanContextualizer, processor, agentInternalsFilter);
+      SpanContextualizer spanContextualizer,
+      StackToSpanLinkageProcessor processor,
+      ThreadDumpToStacks threadDumpToStacks) {
+    return ThreadDumpProcessor.builder()
+        .spanContextualizer(spanContextualizer)
+        .processor(processor)
+        .threadDumpToStacks(threadDumpToStacks)
+        .build();
   }
 
   /** May filter out agent internal call stacks based on the config. */
-  private Predicate<String> buildAgentInternalsFilter(Config config) {
-    if (config.getBoolean(CONFIG_KEY_INCLUDE_INTERNALS, false)) {
-      return x -> true;
-    }
-    return new AgentInternalsFilter();
+  private AgentInternalsFilter buildAgentInternalsFilter(Config config) {
+    return new AgentInternalsFilter(config.getBoolean(CONFIG_KEY_INCLUDE_INTERNALS, false));
   }
 
   private Map<String, String> buildJfrSettings(Config config) {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
@@ -162,8 +162,8 @@ public class JfrActivator implements AgentListener {
   }
 
   /** May filter out agent internal call stacks based on the config. */
-  private AgentInternalsFilter buildAgentInternalsFilter(Config config) {
-    return new AgentInternalsFilter(config.getBoolean(CONFIG_KEY_INCLUDE_INTERNALS, false));
+  private StackTraceFilter buildAgentInternalsFilter(Config config) {
+    return new StackTraceFilter(config.getBoolean(CONFIG_KEY_INCLUDE_INTERNALS, false));
   }
 
   private Map<String, String> buildJfrSettings(Config config) {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
@@ -110,7 +110,8 @@ public class JfrActivator implements AgentListener {
 
     ThreadDumpProcessor threadDumpProcessor =
         buildThreadDumpProcessor(config, spanContextualizer, processor);
-    TLABProcessor tlabProcessor = new TLABProcessor(batchingLogsProcessor, commonAttributes);
+    TLABProcessor tlabProcessor =
+        new TLABProcessor(config, batchingLogsProcessor, commonAttributes);
     EventProcessingChain eventProcessingChain =
         new EventProcessingChain(spanContextualizer, threadDumpProcessor, tlabProcessor);
     Consumer<Path> deleter = buildFileDeleter(config);

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
@@ -107,8 +107,7 @@ public class JfrActivator implements AgentListener {
     StackToSpanLinkageProcessor processor =
         new StackToSpanLinkageProcessor(logEntryCreator, batchingLogsProcessor);
 
-    ThreadDumpToStacks threadDumpToStacks =
-        new ThreadDumpToStacks(buildStackTraceFilter(config));
+    ThreadDumpToStacks threadDumpToStacks = new ThreadDumpToStacks(buildStackTraceFilter(config));
 
     ThreadDumpProcessor threadDumpProcessor =
         buildThreadDumpProcessor(spanContextualizer, processor, threadDumpToStacks);

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/StackTraceFilter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/StackTraceFilter.java
@@ -40,7 +40,7 @@ public class StackTraceFilter {
   }
 
   public boolean test(String wallOfStacks, int startIndex, int lastIndex) {
-    if ((lastIndex == -1) || (lastIndex >= wallOfStacks.length())){
+    if ((lastIndex == -1) || (lastIndex >= wallOfStacks.length())) {
       return false;
     }
     // Must start with a quote for the thread name

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/StackTraceFilter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/StackTraceFilter.java
@@ -40,7 +40,7 @@ public class StackTraceFilter {
   }
 
   public boolean test(String wallOfStacks, int startIndex, int lastIndex) {
-    if (lastIndex == -1) {
+    if ((lastIndex == -1) || (lastIndex >= wallOfStacks.length())){
       return false;
     }
     // Must start with a quote for the thread name

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/StackTraceFilter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/StackTraceFilter.java
@@ -18,7 +18,7 @@ package com.splunk.opentelemetry.profiler;
 
 import java.util.stream.Stream;
 
-public class AgentInternalsFilter {
+public class StackTraceFilter {
 
   static final String[] UNWANTED_PREFIXES =
       new String[] {
@@ -35,7 +35,7 @@ public class AgentInternalsFilter {
       };
   private final boolean includeAgentInternals;
 
-  public AgentInternalsFilter(boolean includeAgentInternals) {
+  public StackTraceFilter(boolean includeAgentInternals) {
     this.includeAgentInternals = includeAgentInternals;
   }
 
@@ -60,7 +60,7 @@ public class AgentInternalsFilter {
     if (includeAgentInternals) {
       return true;
     }
-    return Stream.of(AgentInternalsFilter.UNWANTED_PREFIXES)
+    return Stream.of(StackTraceFilter.UNWANTED_PREFIXES)
         .noneMatch(prefix -> wallOfStacks.regionMatches(startIndex, prefix, 0, prefix.length()));
   }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/ThreadDumpProcessor.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/ThreadDumpProcessor.java
@@ -30,7 +30,7 @@ public class ThreadDumpProcessor {
   private final Consumer<StackToSpanLinkage> processor;
   private final ThreadDumpToStacks threadDumpToStacks;
 
-  public ThreadDumpProcessor(Builder builder) {
+  private ThreadDumpProcessor(Builder builder) {
     this.contextualizer = builder.contextualizer;
     this.processor = builder.processor;
     this.threadDumpToStacks = builder.threadDumpToStacks;

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/ThreadDumpProcessor.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/ThreadDumpProcessor.java
@@ -19,9 +19,6 @@ package com.splunk.opentelemetry.profiler;
 import com.splunk.opentelemetry.profiler.context.SpanContextualizer;
 import com.splunk.opentelemetry.profiler.context.StackToSpanLinkage;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
-import java.util.regex.Pattern;
-import java.util.stream.Stream;
 import jdk.jfr.consumer.RecordedEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,30 +26,52 @@ import org.slf4j.LoggerFactory;
 public class ThreadDumpProcessor {
   public static final String EVENT_NAME = "jdk.ThreadDump";
   private static final Logger logger = LoggerFactory.getLogger(ThreadDumpProcessor.class);
-  private final Pattern stackSeparator = Pattern.compile("\n\n");
   private final SpanContextualizer contextualizer;
   private final Consumer<StackToSpanLinkage> processor;
-  private final Predicate<String> agentInternalsFilter;
+  private final ThreadDumpToStacks threadDumpToStacks;
 
-  public ThreadDumpProcessor(
-      SpanContextualizer contextualizer,
-      Consumer<StackToSpanLinkage> processor,
-      Predicate<String> agentInternalsFilter) {
-    this.contextualizer = contextualizer;
-    this.processor = processor;
-    this.agentInternalsFilter = agentInternalsFilter;
+  public ThreadDumpProcessor(Builder builder) {
+    this.contextualizer = builder.contextualizer;
+    this.processor = builder.processor;
+    this.threadDumpToStacks = builder.threadDumpToStacks;
   }
 
   public void accept(RecordedEvent event) {
     String eventName = event.getEventType().getName();
     logger.debug("Processing JFR event {}", eventName);
     String wallOfStacks = event.getString("result");
-    String[] stacks = stackSeparator.split(wallOfStacks);
-    // TODO: Filter out all the VM and GC entries without real stack traces?
-    Stream.of(stacks)
-        .filter(stack -> stack.charAt(0) == '"') // omit non-stack entries
-        .filter(agentInternalsFilter)
+    threadDumpToStacks
+        .toStream(wallOfStacks)
         .map(stack -> contextualizer.link(event.getStartTime(), stack, event))
         .forEach(processor);
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private SpanContextualizer contextualizer;
+    private Consumer<StackToSpanLinkage> processor;
+    private ThreadDumpToStacks threadDumpToStacks;
+
+    public Builder spanContextualizer(SpanContextualizer contextualizer) {
+      this.contextualizer = contextualizer;
+      return this;
+    }
+
+    public Builder processor(Consumer<StackToSpanLinkage> consumer) {
+      this.processor = consumer;
+      return this;
+    }
+
+    public Builder threadDumpToStacks(ThreadDumpToStacks threadDumpToStacks) {
+      this.threadDumpToStacks = threadDumpToStacks;
+      return this;
+    }
+
+    public ThreadDumpProcessor build() {
+      return new ThreadDumpProcessor(this);
+    }
   }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/ThreadDumpToStacks.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/ThreadDumpToStacks.java
@@ -91,7 +91,7 @@ public class ThreadDumpToStacks {
       if (next >= wallOfStacks.length() - 2) {
         done = true;
       }
-      start = next + 2;
+      start = next + 2; // next chunk starts after the "\n\n"
       next = start;
       return result;
     }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/ThreadDumpToStacks.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/ThreadDumpToStacks.java
@@ -29,28 +29,28 @@ import java.util.stream.StreamSupport;
  */
 public class ThreadDumpToStacks {
 
-  private final AgentInternalsFilter agentInternalsFilter;
+  private final StackTraceFilter stackTraceFilter;
 
-  public ThreadDumpToStacks(AgentInternalsFilter agentInternalsFilter) {
-    this.agentInternalsFilter = agentInternalsFilter;
+  public ThreadDumpToStacks(StackTraceFilter stackTraceFilter) {
+    this.stackTraceFilter = stackTraceFilter;
   }
 
   public Stream<String> toStream(String wallOfStacks) {
-    Spliterator<String> spliterator = new StackSpliterator(wallOfStacks, agentInternalsFilter);
+    Spliterator<String> spliterator = new StackSpliterator(wallOfStacks, stackTraceFilter);
     return StreamSupport.stream(spliterator, false);
   }
 
   private static class StackSpliterator extends Spliterators.AbstractSpliterator<String> {
     private final String wallOfStacks;
-    private final AgentInternalsFilter agentInternalsFilter;
+    private final StackTraceFilter stackTraceFilter;
     private int start = 0;
     private int next = 0;
     private boolean done = false;
 
-    public StackSpliterator(String wallOfStacks, AgentInternalsFilter agentInternalsFilter) {
+    public StackSpliterator(String wallOfStacks, StackTraceFilter stackTraceFilter) {
       super(Long.MAX_VALUE, Spliterator.IMMUTABLE | Spliterator.ORDERED);
       this.wallOfStacks = wallOfStacks;
-      this.agentInternalsFilter = agentInternalsFilter;
+      this.stackTraceFilter = stackTraceFilter;
     }
 
     @Override
@@ -71,7 +71,7 @@ public class ThreadDumpToStacks {
         if (next < start) {
           next = wallOfStacks.length() - 1;
         }
-        if (agentInternalsFilter.test(wallOfStacks, start, next)) {
+        if (stackTraceFilter.test(wallOfStacks, start, next)) {
           action.accept(advanceNextStack());
           return true;
         }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/ThreadDumpToStacks.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/ThreadDumpToStacks.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * This class turns the "wall of stacks" from the jdk.ThreadDump event
+ * into Stream<String>, where each String in the Stream is a stack trace.
+ * It purposefully avoids String.split("\n\n") in order to help reduce
+ * allocations, especially for filtered stacks.
+ */
+public class ThreadDumpToStacks {
+
+  private final AgentInternalsFilter agentInternalsFilter;
+
+  public ThreadDumpToStacks(AgentInternalsFilter agentInternalsFilter) {
+    this.agentInternalsFilter = agentInternalsFilter;
+  }
+
+  public Stream<String> toStream(String wallOfStacks) {
+    Spliterator<String> spliterator = new StackSpliterator(wallOfStacks, agentInternalsFilter);
+    return StreamSupport.stream(spliterator, false);
+  }
+
+  private static class StackSpliterator extends Spliterators.AbstractSpliterator<String> {
+    private final String wallOfStacks;
+    private final AgentInternalsFilter agentInternalsFilter;
+    private int start = 0;
+    private int next = 0;
+    private boolean done = false;
+
+    public StackSpliterator(String wallOfStacks, AgentInternalsFilter agentInternalsFilter) {
+      super(Long.MAX_VALUE, Spliterator.IMMUTABLE | Spliterator.ORDERED);
+      this.wallOfStacks = wallOfStacks;
+      this.agentInternalsFilter = agentInternalsFilter;
+    }
+
+    @Override
+    public boolean tryAdvance(Consumer<? super String> action) {
+      while (true) {
+        if (done) {
+          return false;
+        }
+        next = wallOfStacks.indexOf("\n\n", start);
+        if (next == -1) {
+          next = wallOfStacks.lastIndexOf('\n', start);
+        }
+        if (next == -1) {
+          done = true;
+          return false;
+        }
+        // Reached the end of the wall, so just set next to the end
+        if (next < start) {
+          next = wallOfStacks.length() - 1;
+        }
+        if (agentInternalsFilter.test(wallOfStacks, start, next)) {
+          action.accept(advanceNextStack());
+          return true;
+        }
+        start = next + 1;
+        while ((start < wallOfStacks.length()) && (wallOfStacks.charAt(start) == '\n')) {
+          start++;
+        }
+        if (start >= wallOfStacks.length()) {
+          done = true;
+          return false;
+        }
+      }
+    }
+
+    private String advanceNextStack() {
+      String result = wallOfStacks.substring(start, next);
+      if (next >= wallOfStacks.length() - 2) {
+        done = true;
+      }
+      start = next + 2;
+      next = start;
+      return result;
+    }
+  }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/ThreadDumpToStacks.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/ThreadDumpToStacks.java
@@ -23,10 +23,9 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 /**
- * This class turns the "wall of stacks" from the jdk.ThreadDump event
- * into Stream<String>, where each String in the Stream is a stack trace.
- * It purposefully avoids String.split("\n\n") in order to help reduce
- * allocations, especially for filtered stacks.
+ * This class turns the "wall of stacks" from the jdk.ThreadDump event into Stream<String>, where
+ * each String in the Stream is a stack trace. It purposefully avoids String.split("\n\n") in order
+ * to help reduce allocations, especially for filtered stacks.
  */
 public class ThreadDumpToStacks {
 

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/AgentInternalsFilterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/AgentInternalsFilterTest.java
@@ -24,10 +24,10 @@ class AgentInternalsFilterTest {
 
   @Test
   void testOneLiners() {
-    AgentInternalsFilter filter = new AgentInternalsFilter();
+    AgentInternalsFilter filter = new AgentInternalsFilter(false);
     String stack =
         "\"GC Thread#1\" os_prio=0 cpu=1285.69ms elapsed=11333.59s tid=0x00007f43e0001000 nid=0xd0 runnable";
-    assertFalse(filter.test(stack));
+    assertFalse(filter.test(stack, 0, stack.length()));
   }
 
   @Test
@@ -38,8 +38,8 @@ class AgentInternalsFilterTest {
             + "\tat sun.nio.ch.EPoll.wait(java.base@11.0.12/Native Method)\n"
             + "\tat sun.nio.ch.EPollSelectorImpl.doSelect(java.base@11.0.12/EPollSelectorImpl.java:120)\n"
             + "\t[...]";
-    AgentInternalsFilter filter = new AgentInternalsFilter();
-    assertTrue(filter.test(stack));
+    AgentInternalsFilter filter = new AgentInternalsFilter(false);
+    assertTrue(filter.test(stack, 0, stack.length()));
   }
 
   @Test
@@ -52,8 +52,8 @@ class AgentInternalsFilterTest {
             + "        at java.util.concurrent.locks.LockSupport.parkNanos(java.base@11.0.12/LockSupport.java:234)\n"
             + "        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(java.base@11.0.12/AbstractQueuedSynchronizer.java:2123)\n"
             + "        [...]";
-    AgentInternalsFilter filter = new AgentInternalsFilter();
-    assertFalse(filter.test(stack));
+    AgentInternalsFilter filter = new AgentInternalsFilter(false);
+    assertFalse(filter.test(stack, 0, stack.length()));
   }
 
   @Test
@@ -64,8 +64,8 @@ class AgentInternalsFilterTest {
             + "        at jdk.internal.misc.Unsafe.park(java.base@11.0.12/Native Method)\n"
             + "        - parking to wait for  <0x00000000c3401f88> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)\n"
             + "        [...]";
-    AgentInternalsFilter filter = new AgentInternalsFilter();
-    assertFalse(filter.test(stack));
+    AgentInternalsFilter filter = new AgentInternalsFilter(false);
+    assertFalse(filter.test(stack, 0, stack.length()));
   }
 
   @Test
@@ -73,13 +73,13 @@ class AgentInternalsFilterTest {
     String stack =
         "\"JFR Recorder Thread\" #16 daemon prio=5 os_prio=0 cpu=75.99ms elapsed=436.13s tid=0x00007f5194e83800 nid=0xda waiting on condition  [0x0000000000000000]\n"
             + "   java.lang.Thread.State: RUNNABLE\n";
-    AgentInternalsFilter filter = new AgentInternalsFilter();
-    assertFalse(filter.test(stack));
+    AgentInternalsFilter filter = new AgentInternalsFilter(false);
+    assertFalse(filter.test(stack, 0, stack.length()));
     stack =
         "\"JFR Periodic Tasks\" #17 daemon prio=5 os_prio=0 cpu=171.78ms elapsed=435.78s tid=0x00007f5194ecd800 nid=0xdb in Object.wait()  [0x00007f5187dfe000]\n"
             + "   java.lang.Thread.State: TIMED_WAITING (on object monitor)\n"
             + "        at java.lang.Object.wait(java.base@11.0.12/Native Method)\n"
             + "        [...]";
-    assertFalse(filter.test(stack));
+    assertFalse(filter.test(stack, 0, stack.length()));
   }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 class StackTraceFilterTest {
 
   @Test
-  void testOneLiners() {
+  void oneLiners() {
     StackTraceFilter filter = new StackTraceFilter(false);
     String stack =
         "\"GC Thread#1\" os_prio=0 cpu=1285.69ms elapsed=11333.59s tid=0x00007f43e0001000 nid=0xd0 runnable";
@@ -31,7 +31,7 @@ class StackTraceFilterTest {
   }
 
   @Test
-  void testRegularStack() {
+  void regularStack() {
     String stack =
         "\"http-nio-8080-BlockPoller\" #31 daemon prio=5 os_prio=0 cpu=1475.30ms elapsed=11327.18s tid=0x00007f4411ca8000 nid=0xe8 runnable  [0x00007f43c9691000]\n"
             + "   java.lang.Thread.State: RUNNABLE\n"
@@ -43,7 +43,7 @@ class StackTraceFilterTest {
   }
 
   @Test
-  void testBatchedLogsExporter() {
+  void batchedLogsExporter() {
     String stack =
         "\"Batched Logs Exporter\" #15 daemon prio=5 os_prio=0 cpu=267.95ms elapsed=436.16s tid=0x00007f5194044800 nid=0xd9 waiting on condition  [0x00007f51d0467000]\n"
             + "   java.lang.Thread.State: TIMED_WAITING (parking)\n"
@@ -57,7 +57,7 @@ class StackTraceFilterTest {
   }
 
   @Test
-  void testBatchSpanProcessor() {
+  void batchSpanProcessor() {
     String stack =
         "\"BatchSpanProcessor_WorkerThread-1\" #12 daemon prio=5 os_prio=0 cpu=21.68ms elapsed=437.90s tid=0x00007f5200a8f000 nid=0xd4 waiting on condition  [0x00007f51d12ab000]\n"
             + "   java.lang.Thread.State: TIMED_WAITING (parking)\n"
@@ -69,7 +69,7 @@ class StackTraceFilterTest {
   }
 
   @Test
-  void testJFRThreads() {
+  void jfrThreads() {
     String stack =
         "\"JFR Recorder Thread\" #16 daemon prio=5 os_prio=0 cpu=75.99ms elapsed=436.13s tid=0x00007f5194e83800 nid=0xda waiting on condition  [0x0000000000000000]\n"
             + "   java.lang.Thread.State: RUNNABLE\n";
@@ -111,5 +111,11 @@ class StackTraceFilterTest {
                     "\"VM Periodic Task Thread\" os_prio=0 cpu=29.95ms elapsed=65.02s tid=0x00007f2b60c75800 nid=0x1a waiting on condition\n";
     StackTraceFilter filter = new StackTraceFilter(false);
     assertFalse(filter.test(stack, 0, stack.length()-1));
+  }
+
+  @Test
+  void badLastIndex() {
+    StackTraceFilter filter = new StackTraceFilter(false);
+    assertFalse(filter.test(null, 0, -1));
   }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
@@ -118,4 +118,11 @@ class StackTraceFilterTest {
     StackTraceFilter filter = new StackTraceFilter(false);
     assertFalse(filter.test(null, 0, -1));
   }
+
+  @Test
+  void lineDoesntStartWithDoubleQuote() {
+    String stack = "JNI global refs: 50, weak refs: 0\n";
+    StackTraceFilter filter = new StackTraceFilter(false);
+    assertFalse(filter.test(stack, 0, stack.length()-1));
+  }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
@@ -27,7 +27,7 @@ class StackTraceFilterTest {
     StackTraceFilter filter = new StackTraceFilter(false);
     String stack =
         "\"GC Thread#1\" os_prio=0 cpu=1285.69ms elapsed=11333.59s tid=0x00007f43e0001000 nid=0xd0 runnable";
-    assertFalse(filter.test(stack, 0, stack.length()-1));
+    assertFalse(filter.test(stack, 0, stack.length() - 1));
   }
 
   @Test
@@ -39,7 +39,7 @@ class StackTraceFilterTest {
             + "\tat sun.nio.ch.EPollSelectorImpl.doSelect(java.base@11.0.12/EPollSelectorImpl.java:120)\n"
             + "\t[...]";
     StackTraceFilter filter = new StackTraceFilter(false);
-    assertTrue(filter.test(stack, 0, stack.length()-1));
+    assertTrue(filter.test(stack, 0, stack.length() - 1));
   }
 
   @Test
@@ -53,7 +53,7 @@ class StackTraceFilterTest {
             + "        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(java.base@11.0.12/AbstractQueuedSynchronizer.java:2123)\n"
             + "        [...]";
     StackTraceFilter filter = new StackTraceFilter(false);
-    assertFalse(filter.test(stack, 0, stack.length()-1));
+    assertFalse(filter.test(stack, 0, stack.length() - 1));
   }
 
   @Test
@@ -65,7 +65,7 @@ class StackTraceFilterTest {
             + "        - parking to wait for  <0x00000000c3401f88> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)\n"
             + "        [...]";
     StackTraceFilter filter = new StackTraceFilter(false);
-    assertFalse(filter.test(stack, 0, stack.length()-1));
+    assertFalse(filter.test(stack, 0, stack.length() - 1));
   }
 
   @Test
@@ -74,43 +74,43 @@ class StackTraceFilterTest {
         "\"JFR Recorder Thread\" #16 daemon prio=5 os_prio=0 cpu=75.99ms elapsed=436.13s tid=0x00007f5194e83800 nid=0xda waiting on condition  [0x0000000000000000]\n"
             + "   java.lang.Thread.State: RUNNABLE\n";
     StackTraceFilter filter = new StackTraceFilter(false);
-    assertFalse(filter.test(stack, 0, stack.length()-1));
+    assertFalse(filter.test(stack, 0, stack.length() - 1));
     stack =
         "\"JFR Periodic Tasks\" #17 daemon prio=5 os_prio=0 cpu=171.78ms elapsed=435.78s tid=0x00007f5194ecd800 nid=0xdb in Object.wait()  [0x00007f5187dfe000]\n"
             + "   java.lang.Thread.State: TIMED_WAITING (on object monitor)\n"
             + "        at java.lang.Object.wait(java.base@11.0.12/Native Method)\n"
             + "        [...]";
-    assertFalse(filter.test(stack, 0, stack.length()-1));
+    assertFalse(filter.test(stack, 0, stack.length() - 1));
   }
 
   @Test
   void includeInternals() {
     String stack =
-            "\"JFR Recording Scheduler\" #28 daemon prio=5 os_prio=31 cpu=0.11ms elapsed=320.50s tid=0x00007fb9cefc2000 nid=0x7203 in Object.wait()  [0x00007000126c5000]\n" +
-                    "   java.lang.Thread.State: WAITING (on object monitor)\n" +
-                    "        at java.lang.Object.wait(java.base@11.0.9.1/Native Method)\n" +
-                    "        - waiting on <0x0000000600ca4e70> (a java.util.TaskQueue)\n" +
-                    "        at java.lang.Object.wait(java.base@11.0.9.1/Object.java:328)\n" +
-                    "        at java.util.TimerThread.mainLoop(java.base@11.0.9.1/Timer.java:527)\n" +
-                    "        - waiting to re-lock in wait() <0x0000000600ca4e70> (a java.util.TaskQueue)\n" +
-                    "        at java.util.TimerThread.run(java.base@11.0.9.1/Timer.java:506)";
+        "\"JFR Recording Scheduler\" #28 daemon prio=5 os_prio=31 cpu=0.11ms elapsed=320.50s tid=0x00007fb9cefc2000 nid=0x7203 in Object.wait()  [0x00007000126c5000]\n"
+            + "   java.lang.Thread.State: WAITING (on object monitor)\n"
+            + "        at java.lang.Object.wait(java.base@11.0.9.1/Native Method)\n"
+            + "        - waiting on <0x0000000600ca4e70> (a java.util.TaskQueue)\n"
+            + "        at java.lang.Object.wait(java.base@11.0.9.1/Object.java:328)\n"
+            + "        at java.util.TimerThread.mainLoop(java.base@11.0.9.1/Timer.java:527)\n"
+            + "        - waiting to re-lock in wait() <0x0000000600ca4e70> (a java.util.TaskQueue)\n"
+            + "        at java.util.TimerThread.run(java.base@11.0.9.1/Timer.java:506)";
     StackTraceFilter filter = new StackTraceFilter(true);
-    assertTrue(filter.test(stack, 0, stack.length()-1));
+    assertTrue(filter.test(stack, 0, stack.length() - 1));
     stack =
-            "\"JFR Periodic Tasks\" #17 daemon prio=5 os_prio=0 cpu=171.78ms elapsed=435.78s tid=0x00007f5194ecd800 nid=0xdb in Object.wait()  [0x00007f5187dfe000]\n"
-                    + "   java.lang.Thread.State: TIMED_WAITING (on object monitor)\n"
-                    + "        at java.lang.Object.wait(java.base@11.0.12/Native Method)\n"
-                    + "        [...]";
-    assertTrue(filter.test(stack, 0, stack.length()-1));
+        "\"JFR Periodic Tasks\" #17 daemon prio=5 os_prio=0 cpu=171.78ms elapsed=435.78s tid=0x00007f5194ecd800 nid=0xdb in Object.wait()  [0x00007f5187dfe000]\n"
+            + "   java.lang.Thread.State: TIMED_WAITING (on object monitor)\n"
+            + "        at java.lang.Object.wait(java.base@11.0.12/Native Method)\n"
+            + "        [...]";
+    assertTrue(filter.test(stack, 0, stack.length() - 1));
   }
 
   @Test
   void twoLines() {
     String stack =
-            "\"G1 Young RemSet Sampling\" os_prio=0 cpu=20.37ms elapsed=67.37s tid=0x00007f2b600eb800 nid=0xc runnable\n" +
-                    "\"VM Periodic Task Thread\" os_prio=0 cpu=29.95ms elapsed=65.02s tid=0x00007f2b60c75800 nid=0x1a waiting on condition\n";
+        "\"G1 Young RemSet Sampling\" os_prio=0 cpu=20.37ms elapsed=67.37s tid=0x00007f2b600eb800 nid=0xc runnable\n"
+            + "\"VM Periodic Task Thread\" os_prio=0 cpu=29.95ms elapsed=65.02s tid=0x00007f2b60c75800 nid=0x1a waiting on condition\n";
     StackTraceFilter filter = new StackTraceFilter(false);
-    assertFalse(filter.test(stack, 0, stack.length()-1));
+    assertFalse(filter.test(stack, 0, stack.length() - 1));
   }
 
   @Test
@@ -123,27 +123,26 @@ class StackTraceFilterTest {
   void lineDoesntStartWithDoubleQuote() {
     String stack = "JNI global refs: 50, weak refs: 0\n";
     StackTraceFilter filter = new StackTraceFilter(false);
-    assertFalse(filter.test(stack, 0, stack.length()-1));
+    assertFalse(filter.test(stack, 0, stack.length() - 1));
   }
 
   @Test
   void extractFromMiddle() {
-    String stack = "\"logback-7\" #75 daemon prio=5 os_prio=31 cpu=0.25ms elapsed=173.79s tid=0x00007fb98f0ad000 nid=0xd30b waiting on condiion  [0x0000700014a2e000]\n" +
-            "   java.lang.Thread.State: WAITING (parking)\n" +
-            "        at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)\n" +
-            "        - parking to wait for  <0x00000006127b80f8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)\n" +
-            "        at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)\n" +
-            "        at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)\n";
+    String stack =
+        "\"logback-7\" #75 daemon prio=5 os_prio=31 cpu=0.25ms elapsed=173.79s tid=0x00007fb98f0ad000 nid=0xd30b waiting on condiion  [0x0000700014a2e000]\n"
+            + "   java.lang.Thread.State: WAITING (parking)\n"
+            + "        at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)\n"
+            + "        - parking to wait for  <0x00000006127b80f8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)\n"
+            + "        at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)\n"
+            + "        at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)\n";
 
     String beforeStack = "something above\n";
     String afterStack = "something below\n";
-    String wallOfStacks = beforeStack +
-            "\n" +
-            stack +
-            "\n" +
-            afterStack;
+    String wallOfStacks = beforeStack + "\n" + stack + "\n" + afterStack;
     StackTraceFilter filter = new StackTraceFilter(false);
-    boolean result = filter.test(wallOfStacks, beforeStack.length()+1, beforeStack.length() + stack.length() + 2);
+    boolean result =
+        filter.test(
+            wallOfStacks, beforeStack.length() + 1, beforeStack.length() + stack.length() + 2);
     assertTrue(result);
   }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
@@ -27,7 +27,7 @@ class StackTraceFilterTest {
     StackTraceFilter filter = new StackTraceFilter(false);
     String stack =
         "\"GC Thread#1\" os_prio=0 cpu=1285.69ms elapsed=11333.59s tid=0x00007f43e0001000 nid=0xd0 runnable";
-    assertFalse(filter.test(stack, 0, stack.length()));
+    assertFalse(filter.test(stack, 0, stack.length()-1));
   }
 
   @Test
@@ -39,7 +39,7 @@ class StackTraceFilterTest {
             + "\tat sun.nio.ch.EPollSelectorImpl.doSelect(java.base@11.0.12/EPollSelectorImpl.java:120)\n"
             + "\t[...]";
     StackTraceFilter filter = new StackTraceFilter(false);
-    assertTrue(filter.test(stack, 0, stack.length()));
+    assertTrue(filter.test(stack, 0, stack.length()-1));
   }
 
   @Test
@@ -53,7 +53,7 @@ class StackTraceFilterTest {
             + "        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(java.base@11.0.12/AbstractQueuedSynchronizer.java:2123)\n"
             + "        [...]";
     StackTraceFilter filter = new StackTraceFilter(false);
-    assertFalse(filter.test(stack, 0, stack.length()));
+    assertFalse(filter.test(stack, 0, stack.length()-1));
   }
 
   @Test
@@ -65,7 +65,7 @@ class StackTraceFilterTest {
             + "        - parking to wait for  <0x00000000c3401f88> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)\n"
             + "        [...]";
     StackTraceFilter filter = new StackTraceFilter(false);
-    assertFalse(filter.test(stack, 0, stack.length()));
+    assertFalse(filter.test(stack, 0, stack.length()-1));
   }
 
   @Test
@@ -74,27 +74,42 @@ class StackTraceFilterTest {
         "\"JFR Recorder Thread\" #16 daemon prio=5 os_prio=0 cpu=75.99ms elapsed=436.13s tid=0x00007f5194e83800 nid=0xda waiting on condition  [0x0000000000000000]\n"
             + "   java.lang.Thread.State: RUNNABLE\n";
     StackTraceFilter filter = new StackTraceFilter(false);
-    assertFalse(filter.test(stack, 0, stack.length()));
+    assertFalse(filter.test(stack, 0, stack.length()-1));
     stack =
         "\"JFR Periodic Tasks\" #17 daemon prio=5 os_prio=0 cpu=171.78ms elapsed=435.78s tid=0x00007f5194ecd800 nid=0xdb in Object.wait()  [0x00007f5187dfe000]\n"
             + "   java.lang.Thread.State: TIMED_WAITING (on object monitor)\n"
             + "        at java.lang.Object.wait(java.base@11.0.12/Native Method)\n"
             + "        [...]";
-    assertFalse(filter.test(stack, 0, stack.length()));
+    assertFalse(filter.test(stack, 0, stack.length()-1));
   }
 
   @Test
   void includeInternals() {
     String stack =
-            "\"JFR Recorder Thread\" #16 daemon prio=5 os_prio=0 cpu=75.99ms elapsed=436.13s tid=0x00007f5194e83800 nid=0xda waiting on condition  [0x0000000000000000]\n"
-                    + "   java.lang.Thread.State: RUNNABLE\n";
+            "\"JFR Recording Scheduler\" #28 daemon prio=5 os_prio=31 cpu=0.11ms elapsed=320.50s tid=0x00007fb9cefc2000 nid=0x7203 in Object.wait()  [0x00007000126c5000]\n" +
+                    "   java.lang.Thread.State: WAITING (on object monitor)\n" +
+                    "        at java.lang.Object.wait(java.base@11.0.9.1/Native Method)\n" +
+                    "        - waiting on <0x0000000600ca4e70> (a java.util.TaskQueue)\n" +
+                    "        at java.lang.Object.wait(java.base@11.0.9.1/Object.java:328)\n" +
+                    "        at java.util.TimerThread.mainLoop(java.base@11.0.9.1/Timer.java:527)\n" +
+                    "        - waiting to re-lock in wait() <0x0000000600ca4e70> (a java.util.TaskQueue)\n" +
+                    "        at java.util.TimerThread.run(java.base@11.0.9.1/Timer.java:506)";
     StackTraceFilter filter = new StackTraceFilter(true);
-    assertTrue(filter.test(stack, 0, stack.length()));
+    assertTrue(filter.test(stack, 0, stack.length()-1));
     stack =
             "\"JFR Periodic Tasks\" #17 daemon prio=5 os_prio=0 cpu=171.78ms elapsed=435.78s tid=0x00007f5194ecd800 nid=0xdb in Object.wait()  [0x00007f5187dfe000]\n"
                     + "   java.lang.Thread.State: TIMED_WAITING (on object monitor)\n"
                     + "        at java.lang.Object.wait(java.base@11.0.12/Native Method)\n"
                     + "        [...]";
-    assertTrue(filter.test(stack, 0, stack.length()));
+    assertTrue(filter.test(stack, 0, stack.length()-1));
+  }
+
+  @Test
+  void twoLines() {
+    String stack =
+            "\"G1 Young RemSet Sampling\" os_prio=0 cpu=20.37ms elapsed=67.37s tid=0x00007f2b600eb800 nid=0xc runnable\n" +
+                    "\"VM Periodic Task Thread\" os_prio=0 cpu=29.95ms elapsed=65.02s tid=0x00007f2b60c75800 nid=0x1a waiting on condition\n";
+    StackTraceFilter filter = new StackTraceFilter(false);
+    assertFalse(filter.test(stack, 0, stack.length()-1));
   }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
@@ -20,11 +20,11 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 
-class AgentInternalsFilterTest {
+class StackTraceFilterTest {
 
   @Test
   void testOneLiners() {
-    AgentInternalsFilter filter = new AgentInternalsFilter(false);
+    StackTraceFilter filter = new StackTraceFilter(false);
     String stack =
         "\"GC Thread#1\" os_prio=0 cpu=1285.69ms elapsed=11333.59s tid=0x00007f43e0001000 nid=0xd0 runnable";
     assertFalse(filter.test(stack, 0, stack.length()));
@@ -38,7 +38,7 @@ class AgentInternalsFilterTest {
             + "\tat sun.nio.ch.EPoll.wait(java.base@11.0.12/Native Method)\n"
             + "\tat sun.nio.ch.EPollSelectorImpl.doSelect(java.base@11.0.12/EPollSelectorImpl.java:120)\n"
             + "\t[...]";
-    AgentInternalsFilter filter = new AgentInternalsFilter(false);
+    StackTraceFilter filter = new StackTraceFilter(false);
     assertTrue(filter.test(stack, 0, stack.length()));
   }
 
@@ -52,7 +52,7 @@ class AgentInternalsFilterTest {
             + "        at java.util.concurrent.locks.LockSupport.parkNanos(java.base@11.0.12/LockSupport.java:234)\n"
             + "        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(java.base@11.0.12/AbstractQueuedSynchronizer.java:2123)\n"
             + "        [...]";
-    AgentInternalsFilter filter = new AgentInternalsFilter(false);
+    StackTraceFilter filter = new StackTraceFilter(false);
     assertFalse(filter.test(stack, 0, stack.length()));
   }
 
@@ -64,7 +64,7 @@ class AgentInternalsFilterTest {
             + "        at jdk.internal.misc.Unsafe.park(java.base@11.0.12/Native Method)\n"
             + "        - parking to wait for  <0x00000000c3401f88> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)\n"
             + "        [...]";
-    AgentInternalsFilter filter = new AgentInternalsFilter(false);
+    StackTraceFilter filter = new StackTraceFilter(false);
     assertFalse(filter.test(stack, 0, stack.length()));
   }
 
@@ -73,7 +73,7 @@ class AgentInternalsFilterTest {
     String stack =
         "\"JFR Recorder Thread\" #16 daemon prio=5 os_prio=0 cpu=75.99ms elapsed=436.13s tid=0x00007f5194e83800 nid=0xda waiting on condition  [0x0000000000000000]\n"
             + "   java.lang.Thread.State: RUNNABLE\n";
-    AgentInternalsFilter filter = new AgentInternalsFilter(false);
+    StackTraceFilter filter = new StackTraceFilter(false);
     assertFalse(filter.test(stack, 0, stack.length()));
     stack =
         "\"JFR Periodic Tasks\" #17 daemon prio=5 os_prio=0 cpu=171.78ms elapsed=435.78s tid=0x00007f5194ecd800 nid=0xdb in Object.wait()  [0x00007f5187dfe000]\n"

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
@@ -125,4 +125,25 @@ class StackTraceFilterTest {
     StackTraceFilter filter = new StackTraceFilter(false);
     assertFalse(filter.test(stack, 0, stack.length()-1));
   }
+
+  @Test
+  void extractFromMiddle() {
+    String stack = "\"logback-7\" #75 daemon prio=5 os_prio=31 cpu=0.25ms elapsed=173.79s tid=0x00007fb98f0ad000 nid=0xd30b waiting on condiion  [0x0000700014a2e000]\n" +
+            "   java.lang.Thread.State: WAITING (parking)\n" +
+            "        at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)\n" +
+            "        - parking to wait for  <0x00000006127b80f8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)\n" +
+            "        at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)\n" +
+            "        at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)\n";
+
+    String beforeStack = "something above\n";
+    String afterStack = "something below\n";
+    String wallOfStacks = beforeStack +
+            "\n" +
+            stack +
+            "\n" +
+            afterStack;
+    StackTraceFilter filter = new StackTraceFilter(false);
+    boolean result = filter.test(wallOfStacks, beforeStack.length()+1, beforeStack.length() + stack.length() + 2);
+    assertTrue(result);
+  }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
@@ -82,4 +82,19 @@ class StackTraceFilterTest {
             + "        [...]";
     assertFalse(filter.test(stack, 0, stack.length()));
   }
+
+  @Test
+  void includeInternals() {
+    String stack =
+            "\"JFR Recorder Thread\" #16 daemon prio=5 os_prio=0 cpu=75.99ms elapsed=436.13s tid=0x00007f5194e83800 nid=0xda waiting on condition  [0x0000000000000000]\n"
+                    + "   java.lang.Thread.State: RUNNABLE\n";
+    StackTraceFilter filter = new StackTraceFilter(true);
+    assertTrue(filter.test(stack, 0, stack.length()));
+    stack =
+            "\"JFR Periodic Tasks\" #17 daemon prio=5 os_prio=0 cpu=171.78ms elapsed=435.78s tid=0x00007f5194ecd800 nid=0xdb in Object.wait()  [0x00007f5187dfe000]\n"
+                    + "   java.lang.Thread.State: TIMED_WAITING (on object monitor)\n"
+                    + "        at java.lang.Object.wait(java.base@11.0.12/Native Method)\n"
+                    + "        [...]";
+    assertTrue(filter.test(stack, 0, stack.length()));
+  }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ThreadDumpProcessorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ThreadDumpProcessorTest.java
@@ -62,8 +62,13 @@ class ThreadDumpProcessorTest {
 
     List<StackToSpanLinkage> results = new ArrayList<>();
     Consumer<StackToSpanLinkage> exportProcessor = results::add;
+    ThreadDumpToStacks threadDumpToStacks = new ThreadDumpToStacks(new AgentInternalsFilter(false));
     ThreadDumpProcessor processor =
-        new ThreadDumpProcessor(contextualizer, exportProcessor, agentInternalsFilter);
+        ThreadDumpProcessor.builder()
+            .spanContextualizer(contextualizer)
+            .processor(exportProcessor)
+            .threadDumpToStacks(threadDumpToStacks)
+            .build();
 
     processor.accept(event);
     assertEquals(3, results.size());
@@ -94,7 +99,7 @@ class ThreadDumpProcessorTest {
           + "0x00007fb4860b5000, 0x00007fb491817800, 0x00007fb4859f4800\n"
           + "}\n"
           + "\n"
-          + "\"Reference Handler\" #2 daemon prio=10 os_prio=31 cpu=4.92ms elapsed=50.48s tid=0x00007fb51702b000 nid=0x3403 waiting on condition  [0x000070000c6d6000]\n"
+          + "\"Definitely something\" #2 daemon prio=10 os_prio=31 cpu=4.92ms elapsed=50.48s tid=0x00007fb51702b000 nid=0x3403 waiting on condition  [0x000070000c6d6000]\n"
           + "   java.lang.Thread.State: RUNNABLE\n"
           + "        at java.lang.ref.Reference.waitForReferencePendingList(java.base@11.0.9.1/Native Method)\n"
           + "        at java.lang.ref.Reference.processPendingReferences(java.base@11.0.9.1/Reference.java:241)\n"
@@ -108,7 +113,7 @@ class ThreadDumpProcessorTest {
           + "        - waiting to re-lock in wait() <0x000000060066b908> (a java.lang.ref.ReferenceQueue$Lock)\n"
           + "        at com.something.something.AwesomeThinger.overHereDoingSpanThings(MyServer.java:123)\n"
           + "\n"
-          + "\"JFR Recording Scheduler\" #27 daemon prio=5 os_prio=31 cpu=0.13ms elapsed=48.39s tid=0x00007fb4b74b3000 nid=0x15103 in Object.wait()  [0x000070000ed4b000]\n"
+          + "\"Cool user thread\" #27 daemon prio=5 os_prio=31 cpu=0.13ms elapsed=48.39s tid=0x00007fb4b74b3000 nid=0x15103 in Object.wait()  [0x000070000ed4b000]\n"
           + "   java.lang.Thread.State: WAITING (on object monitor)\n"
           + "        at java.lang.Object.wait(java.base@11.0.9.1/Native Method)\n"
           + "        - waiting on <0x0000000625152778> (a java.util.TaskQueue)\n"

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ThreadDumpProcessorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ThreadDumpProcessorTest.java
@@ -62,7 +62,7 @@ class ThreadDumpProcessorTest {
 
     List<StackToSpanLinkage> results = new ArrayList<>();
     Consumer<StackToSpanLinkage> exportProcessor = results::add;
-    ThreadDumpToStacks threadDumpToStacks = new ThreadDumpToStacks(new AgentInternalsFilter(false));
+    ThreadDumpToStacks threadDumpToStacks = new ThreadDumpToStacks(new StackTraceFilter(false));
     ThreadDumpProcessor processor =
         ThreadDumpProcessor.builder()
             .spanContextualizer(contextualizer)

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ThreadDumpToStacksTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ThreadDumpToStacksTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.CharStreams;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ThreadDumpToStacksTest {
+
+  String threadDumpResult;
+
+  @BeforeEach
+  void setup() throws Exception {
+    InputStream in =
+        Thread.currentThread().getContextClassLoader().getResourceAsStream("thread-dump1.txt");
+    threadDumpResult = CharStreams.toString(new InputStreamReader(in, Charsets.UTF_8));
+  }
+
+  @Test
+  void testStream() {
+    ThreadDumpToStacks threadDumpToStacks = new ThreadDumpToStacks(new AgentInternalsFilter(false));
+    Stream<String> resultStream = threadDumpToStacks.toStream(threadDumpResult);
+    List<String> result = resultStream.collect(Collectors.toList());
+    assertEquals(40, result.size());
+    Stream.of(AgentInternalsFilter.UNWANTED_PREFIXES)
+        .forEach(
+            prefix -> {
+              assertThat(result).noneMatch(stack -> stack.contains(prefix));
+            });
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ThreadDumpToStacksTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ThreadDumpToStacksTest.java
@@ -42,11 +42,11 @@ class ThreadDumpToStacksTest {
 
   @Test
   void testStream() {
-    ThreadDumpToStacks threadDumpToStacks = new ThreadDumpToStacks(new AgentInternalsFilter(false));
+    ThreadDumpToStacks threadDumpToStacks = new ThreadDumpToStacks(new StackTraceFilter(false));
     Stream<String> resultStream = threadDumpToStacks.toStream(threadDumpResult);
     List<String> result = resultStream.collect(Collectors.toList());
     assertEquals(40, result.size());
-    Stream.of(AgentInternalsFilter.UNWANTED_PREFIXES)
+    Stream.of(StackTraceFilter.UNWANTED_PREFIXES)
         .forEach(
             prefix -> {
               assertThat(result).noneMatch(stack -> stack.contains(prefix));

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ThreadDumpToStacksTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ThreadDumpToStacksTest.java
@@ -18,6 +18,10 @@ package com.splunk.opentelemetry.profiler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.CharStreams;
@@ -51,5 +55,24 @@ class ThreadDumpToStacksTest {
             prefix -> {
               assertThat(result).noneMatch(stack -> stack.contains(prefix));
             });
+  }
+
+  @Test
+  void edgeCase1_simplyHitsEnd() {
+    StackTraceFilter filter = mock(StackTraceFilter.class);
+    when(filter.test(isA(String.class), anyInt(), anyInt())).thenReturn(true);
+
+    ThreadDumpToStacks threadDumpToStacks = new ThreadDumpToStacks(filter);
+    Stream<String> resultStream = threadDumpToStacks.toStream("something\n\n");
+    List<String> result = resultStream.collect(Collectors.toList());
+    assertThat(result).containsExactly("something");
+  }
+
+  @Test
+  void edgeCase2_emptyString() {
+    ThreadDumpToStacks threadDumpToStacks = new ThreadDumpToStacks(null);
+    Stream<String> resultStream = threadDumpToStacks.toStream("");
+    List<String> result = resultStream.collect(Collectors.toList());
+    assertTrue(result.isEmpty());
   }
 }

--- a/profiler/src/test/resources/thread-dump1.txt
+++ b/profiler/src/test/resources/thread-dump1.txt
@@ -1,0 +1,716 @@
+2021-09-22 16:55:28
+Full thread dump OpenJDK 64-Bit Server VM (11.0.9.1+1 mixed mode):
+
+Threads class SMR info:
+_java_thread_list=0x00007fdad832e940, length=55, elements={
+0x00007fdb5d010800, 0x00007fdb5d80d000, 0x00007fdb5c984800, 0x00007fdb5d011800,
+0x00007fdb5d012800, 0x00007fdb5d013800, 0x00007fdb5c997000, 0x00007fdb3c8e1000,
+0x00007fdb5cb28800, 0x00007fdb0d8c0000, 0x00007fdb5cdba800, 0x00007fdb5db2d800,
+0x00007fdb1cc8b800, 0x00007fdb5d3e5800, 0x00007fdb1ccb5000, 0x00007fdb5cde6000,
+0x00007fdb5dcba000, 0x00007fdb3cc22000, 0x00007fdb5e36e000, 0x00007fdb1cb33800,
+0x00007fdb1cd0a000, 0x00007fdb3cae5000, 0x00007fdb5e1c2800, 0x00007fdb3cabd000,
+0x00007fdb4ccdb800, 0x00007fdb5e448800, 0x00007fdad903d800, 0x00007fdb4ccf5800,
+0x00007fdb4cd0e800, 0x00007fdaae268800, 0x00007fdb4cd24000, 0x00007fdaae41e000,
+0x00007fdb5d1fd000, 0x00007fdb4cd33800, 0x00007fdb5e3fd000, 0x00007fdb5ceee000,
+0x00007fdb5dca0800, 0x00007fdad882f800, 0x00007fdb5d8b7800, 0x00007fdb5d422800,
+0x00007fdb5d6fa800, 0x00007fdb4c858800, 0x00007fdb5d413000, 0x00007fdaaeb44000,
+0x00007fdb5d419800, 0x00007fdb1c9cd800, 0x00007fdaaf03e000, 0x00007fdaaf81e000,
+0x00007fdaafc70000, 0x00007fdaaf03d000, 0x00007fdaaf041800, 0x00007fdaafaa6800,
+0x00007fdaaf98b000, 0x00007fdaafb59800, 0x00007fdaafaa5000
+}
+
+"Reference Handler" #2 daemon prio=10 os_prio=31 cpu=7.04ms elapsed=3966.90s tid=0x00007fdb5d010800 nid=0x3703 waiting on condition  [0x000070000d0a7000]
+   java.lang.Thread.State: RUNNABLE
+	at java.lang.ref.Reference.waitForReferencePendingList(java.base@11.0.9.1/Native Method)
+	at java.lang.ref.Reference.processPendingReferences(java.base@11.0.9.1/Reference.java:241)
+	at java.lang.ref.Reference$ReferenceHandler.run(java.base@11.0.9.1/Reference.java:213)
+
+"Finalizer" #3 daemon prio=8 os_prio=31 cpu=1.02ms elapsed=3966.90s tid=0x00007fdb5d80d000 nid=0x3903 in Object.wait()  [0x000070000d1aa000]
+   java.lang.Thread.State: WAITING (on object monitor)
+	at java.lang.Object.wait(java.base@11.0.9.1/Native Method)
+	- waiting on <no object reference available>
+	at java.lang.ref.ReferenceQueue.remove(java.base@11.0.9.1/ReferenceQueue.java:155)
+	- waiting to re-lock in wait() <0x0000000600401608> (a java.lang.ref.ReferenceQueue$Lock)
+	at java.lang.ref.ReferenceQueue.remove(java.base@11.0.9.1/ReferenceQueue.java:176)
+	at java.lang.ref.Finalizer$FinalizerThread.run(java.base@11.0.9.1/Finalizer.java:170)
+
+"Signal Dispatcher" #4 daemon prio=9 os_prio=31 cpu=0.27ms elapsed=3966.89s tid=0x00007fdb5c984800 nid=0x3f03 runnable  [0x0000000000000000]
+   java.lang.Thread.State: RUNNABLE
+
+"C2 CompilerThread0" #5 daemon prio=9 os_prio=31 cpu=20054.39ms elapsed=3966.89s tid=0x00007fdb5d011800 nid=0xa903 waiting on condition  [0x0000000000000000]
+   java.lang.Thread.State: RUNNABLE
+   No compile task
+
+"C1 CompilerThread0" #13 daemon prio=9 os_prio=31 cpu=2169.89ms elapsed=3966.89s tid=0x00007fdb5d012800 nid=0xa703 waiting on condition  [0x0000000000000000]
+   java.lang.Thread.State: RUNNABLE
+   No compile task
+
+"Sweeper thread" #17 daemon prio=9 os_prio=31 cpu=2920.17ms elapsed=3966.89s tid=0x00007fdb5d013800 nid=0xa403 runnable  [0x0000000000000000]
+   java.lang.Thread.State: RUNNABLE
+
+"Common-Cleaner" #18 daemon prio=8 os_prio=31 cpu=17.86ms elapsed=3966.86s tid=0x00007fdb5c997000 nid=0x5903 in Object.wait()  [0x000070000d7bf000]
+   java.lang.Thread.State: TIMED_WAITING (on object monitor)
+	at java.lang.Object.wait(java.base@11.0.9.1/Native Method)
+	- waiting on <no object reference available>
+	at java.lang.ref.ReferenceQueue.remove(java.base@11.0.9.1/ReferenceQueue.java:155)
+	- waiting to re-lock in wait() <0x00000006004027f8> (a java.lang.ref.ReferenceQueue$Lock)
+	at jdk.internal.ref.CleanerImpl.run(java.base@11.0.9.1/CleanerImpl.java:148)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+	at jdk.internal.misc.InnocuousThread.run(java.base@11.0.9.1/InnocuousThread.java:134)
+
+"BatchSpanProcessor_WorkerThread-1" #19 daemon prio=5 os_prio=31 cpu=78.78ms elapsed=3966.17s tid=0x00007fdb3c8e1000 nid=0x6b03 waiting on condition  [0x000070000e7ef000]
+   java.lang.Thread.State: TIMED_WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x00000006007f3b78> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.parkNanos(java.base@11.0.9.1/LockSupport.java:234)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(java.base@11.0.9.1/AbstractQueuedSynchronizer.java:2123)
+	at java.util.concurrent.ArrayBlockingQueue.poll(java.base@11.0.9.1/ArrayBlockingQueue.java:432)
+	at io.opentelemetry.sdk.trace.export.BatchSpanProcessor$Worker.run(BatchSpanProcessor.java:230)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"Service Thread" #22 daemon prio=9 os_prio=31 cpu=51.00ms elapsed=3964.59s tid=0x00007fdb5cb28800 nid=0x7103 runnable  [0x0000000000000000]
+   java.lang.Thread.State: RUNNABLE
+
+"Batched Logs Exporter" #23 daemon prio=5 os_prio=31 cpu=1041.73ms elapsed=3964.52s tid=0x00007fdb0d8c0000 nid=0x8903 waiting on condition  [0x000070000ee01000]
+   java.lang.Thread.State: TIMED_WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x0000000600db05b8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.parkNanos(java.base@11.0.9.1/LockSupport.java:234)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(java.base@11.0.9.1/AbstractQueuedSynchronizer.java:2123)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:1182)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:899)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1054)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"JFR Recorder Thread" #24 daemon prio=5 os_prio=31 cpu=650.21ms elapsed=3964.50s tid=0x00007fdb5cdba800 nid=0x8603 waiting on condition  [0x0000000000000000]
+   java.lang.Thread.State: RUNNABLE
+
+"JFR Periodic Tasks" #25 daemon prio=5 os_prio=31 cpu=879.27ms elapsed=3964.13s tid=0x00007fdb5db2d800 nid=0x8303 waiting on condition  [0x000070000f007000]
+   java.lang.Thread.State: RUNNABLE
+	at jdk.jfr.internal.JVM.emitEvent(jdk.jfr@11.0.9.1/Native Method)
+	at jdk.jfr.internal.RequestEngine$RequestHook.execute(jdk.jfr@11.0.9.1/RequestEngine.java:68)
+	at jdk.jfr.internal.RequestEngine.run_requests(jdk.jfr@11.0.9.1/RequestEngine.java:230)
+	at jdk.jfr.internal.RequestEngine.doPeriodic(jdk.jfr@11.0.9.1/RequestEngine.java:183)
+	at jdk.jfr.internal.PlatformRecorder.periodicTask(jdk.jfr@11.0.9.1/PlatformRecorder.java:439)
+	at jdk.jfr.internal.PlatformRecorder.lambda$startDiskMonitor$1(jdk.jfr@11.0.9.1/PlatformRecorder.java:386)
+	at jdk.jfr.internal.PlatformRecorder$$Lambda$220/0x00000008003de440.run(jdk.jfr@11.0.9.1/Unknown Source)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"JFR Recording Scheduler" #28 daemon prio=5 os_prio=31 cpu=0.11ms elapsed=3964.13s tid=0x00007fdb1cc8b800 nid=0x7f03 in Object.wait()  [0x000070000f20d000]
+   java.lang.Thread.State: WAITING (on object monitor)
+	at java.lang.Object.wait(java.base@11.0.9.1/Native Method)
+	- waiting on <0x0000000600dcc4e0> (a java.util.TaskQueue)
+	at java.lang.Object.wait(java.base@11.0.9.1/Object.java:328)
+	at java.util.TimerThread.mainLoop(java.base@11.0.9.1/Timer.java:527)
+	- waiting to re-lock in wait() <0x0000000600dcc4e0> (a java.util.TaskQueue)
+	at java.util.TimerThread.run(java.base@11.0.9.1/Timer.java:506)
+
+"JFR Recording Sequencer" #29 daemon prio=5 os_prio=31 cpu=6865.10ms elapsed=3964.12s tid=0x00007fdb5d3e5800 nid=0x8107 waiting on condition  [0x000070000f10a000]
+   java.lang.Thread.State: TIMED_WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x0000000600ddcec8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.parkNanos(java.base@11.0.9.1/LockSupport.java:234)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(java.base@11.0.9.1/AbstractQueuedSynchronizer.java:2123)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:1182)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:899)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1054)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"logback-2" #33 daemon prio=5 os_prio=31 cpu=11.49ms elapsed=3963.34s tid=0x00007fdb1ccb5000 nid=0x8d0b waiting on condition  [0x000070000eaf8000]
+   java.lang.Thread.State: TIMED_WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x0000000600de83f8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.parkNanos(java.base@11.0.9.1/LockSupport.java:234)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(java.base@11.0.9.1/AbstractQueuedSynchronizer.java:2123)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:1182)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:899)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1054)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"Catalina-utility-1" #37 prio=1 os_prio=31 cpu=259.74ms elapsed=3959.56s tid=0x00007fdb5cde6000 nid=0x7b07 waiting on condition  [0x000070000f310000]
+   java.lang.Thread.State: TIMED_WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x00000006066e1b88> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.parkNanos(java.base@11.0.9.1/LockSupport.java:234)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(java.base@11.0.9.1/AbstractQueuedSynchronizer.java:2123)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:1182)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:899)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1054)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"Catalina-utility-2" #38 prio=1 os_prio=31 cpu=255.62ms elapsed=3959.55s tid=0x00007fdb5dcba000 nid=0x7707 waiting on condition  [0x000070000f516000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x00000006066e1b88> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@11.0.9.1/LockSupport.java:194)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@11.0.9.1/AbstractQueuedSynchronizer.java:2081)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:1177)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:899)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1054)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"container-0" #39 prio=5 os_prio=31 cpu=14.73ms elapsed=3959.55s tid=0x00007fdb3cc22000 nid=0xaa03 waiting on condition  [0x000070000f619000]
+   java.lang.Thread.State: TIMED_WAITING (sleeping)
+	at java.lang.Thread.sleep(java.base@11.0.9.1/Native Method)
+	at org.apache.catalina.core.StandardServer.await(StandardServer.java:570)
+	at org.springframework.boot.web.embedded.tomcat.TomcatWebServer$1.run(TomcatWebServer.java:197)
+
+"mysql-cj-abandoned-connection-cleanup" #40 daemon prio=5 os_prio=31 cpu=116.73ms elapsed=3959.43s tid=0x00007fdb5e36e000 nid=0x15303 in Object.wait()  [0x000070000f71c000]
+   java.lang.Thread.State: TIMED_WAITING (on object monitor)
+	at java.lang.Object.wait(java.base@11.0.9.1/Native Method)
+	- waiting on <no object reference available>
+	at java.lang.ref.ReferenceQueue.remove(java.base@11.0.9.1/ReferenceQueue.java:155)
+	- waiting to re-lock in wait() <0x0000000606704d98> (a java.lang.ref.ReferenceQueue$Lock)
+	at com.mysql.cj.jdbc.AbandonedConnectionCleanupThread.run(AbandonedConnectionCleanupThread.java:91)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1128)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"HikariPool-1 housekeeper" #41 daemon prio=5 os_prio=31 cpu=20.52ms elapsed=3958.99s tid=0x00007fdb1cb33800 nid=0xad03 waiting on condition  [0x000070000f81f000]
+   java.lang.Thread.State: TIMED_WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x0000000606727fb8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.parkNanos(java.base@11.0.9.1/LockSupport.java:234)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(java.base@11.0.9.1/AbstractQueuedSynchronizer.java:2123)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:1182)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:899)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1054)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"supportability_metrics_reporter" #42 daemon prio=5 os_prio=31 cpu=52.65ms elapsed=3958.90s tid=0x00007fdb1cd0a000 nid=0x15103 waiting on condition  [0x000070000f922000]
+   java.lang.Thread.State: TIMED_WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x00000006067398c8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.parkNanos(java.base@11.0.9.1/LockSupport.java:234)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(java.base@11.0.9.1/AbstractQueuedSynchronizer.java:2123)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:1182)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:899)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1054)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"grpc-nio-worker-ELG-1-1" #44 daemon prio=5 os_prio=31 cpu=3.59ms elapsed=3956.14s tid=0x00007fdb3cae5000 nid=0x5c07 runnable  [0x000070000dac8000]
+   java.lang.Thread.State: RUNNABLE
+	at sun.nio.ch.KQueue.poll(java.base@11.0.9.1/Native Method)
+	at sun.nio.ch.KQueueSelectorImpl.doSelect(java.base@11.0.9.1/KQueueSelectorImpl.java:122)
+	at sun.nio.ch.SelectorImpl.lockAndDoSelect(java.base@11.0.9.1/SelectorImpl.java:124)
+	- locked <0x00000006007f5408> (a io.grpc.netty.shaded.io.netty.channel.nio.SelectedSelectionKeySet)
+	- locked <0x00000006007f53a8> (a sun.nio.ch.KQueueSelectorImpl)
+	at sun.nio.ch.SelectorImpl.select(java.base@11.0.9.1/SelectorImpl.java:141)
+	at io.grpc.netty.shaded.io.netty.channel.nio.SelectedSelectionKeySetSelector.select(SelectedSelectionKeySetSelector.java:68)
+	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoop.select(NioEventLoop.java:805)
+	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:457)
+	at io.grpc.netty.shaded.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
+	at io.grpc.netty.shaded.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.grpc.netty.shaded.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"grpc-nio-worker-ELG-1-2" #46 daemon prio=5 os_prio=31 cpu=0.36ms elapsed=3956.13s tid=0x00007fdb5e1c2800 nid=0x14c03 runnable  [0x000070000fc2b000]
+   java.lang.Thread.State: RUNNABLE
+	at sun.nio.ch.KQueue.poll(java.base@11.0.9.1/Native Method)
+	at sun.nio.ch.KQueueSelectorImpl.doSelect(java.base@11.0.9.1/KQueueSelectorImpl.java:122)
+	at sun.nio.ch.SelectorImpl.lockAndDoSelect(java.base@11.0.9.1/SelectorImpl.java:124)
+	- locked <0x00000006007f4c70> (a io.grpc.netty.shaded.io.netty.channel.nio.SelectedSelectionKeySet)
+	- locked <0x00000006007f4c10> (a sun.nio.ch.KQueueSelectorImpl)
+	at sun.nio.ch.SelectorImpl.select(java.base@11.0.9.1/SelectorImpl.java:141)
+	at io.grpc.netty.shaded.io.netty.channel.nio.SelectedSelectionKeySetSelector.select(SelectedSelectionKeySetSelector.java:68)
+	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoop.select(NioEventLoop.java:805)
+	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:457)
+	at io.grpc.netty.shaded.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
+	at io.grpc.netty.shaded.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.grpc.netty.shaded.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"grpc-nio-worker-ELG-1-3" #48 daemon prio=5 os_prio=31 cpu=0.30ms elapsed=3956.11s tid=0x00007fdb3cabd000 nid=0x14b03 runnable  [0x000070000fe31000]
+   java.lang.Thread.State: RUNNABLE
+	at sun.nio.ch.KQueue.poll(java.base@11.0.9.1/Native Method)
+	at sun.nio.ch.KQueueSelectorImpl.doSelect(java.base@11.0.9.1/KQueueSelectorImpl.java:122)
+	at sun.nio.ch.SelectorImpl.lockAndDoSelect(java.base@11.0.9.1/SelectorImpl.java:124)
+	- locked <0x00000006007f4488> (a io.grpc.netty.shaded.io.netty.channel.nio.SelectedSelectionKeySet)
+	- locked <0x00000006007f4428> (a sun.nio.ch.KQueueSelectorImpl)
+	at sun.nio.ch.SelectorImpl.select(java.base@11.0.9.1/SelectorImpl.java:141)
+	at io.grpc.netty.shaded.io.netty.channel.nio.SelectedSelectionKeySetSelector.select(SelectedSelectionKeySetSelector.java:68)
+	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoop.select(NioEventLoop.java:805)
+	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:457)
+	at io.grpc.netty.shaded.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
+	at io.grpc.netty.shaded.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.grpc.netty.shaded.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"grpc-nio-worker-ELG-1-4" #50 daemon prio=5 os_prio=31 cpu=75.58ms elapsed=3955.89s tid=0x00007fdb4ccdb800 nid=0x14803 runnable  [0x0000700010037000]
+   java.lang.Thread.State: RUNNABLE
+	at sun.nio.ch.KQueue.poll(java.base@11.0.9.1/Native Method)
+	at sun.nio.ch.KQueueSelectorImpl.doSelect(java.base@11.0.9.1/KQueueSelectorImpl.java:122)
+	at sun.nio.ch.SelectorImpl.lockAndDoSelect(java.base@11.0.9.1/SelectorImpl.java:124)
+	- locked <0x00000006007f5c18> (a io.grpc.netty.shaded.io.netty.channel.nio.SelectedSelectionKeySet)
+	- locked <0x00000006007f5bb8> (a sun.nio.ch.KQueueSelectorImpl)
+	at sun.nio.ch.SelectorImpl.select(java.base@11.0.9.1/SelectorImpl.java:141)
+	at io.grpc.netty.shaded.io.netty.channel.nio.SelectedSelectionKeySetSelector.select(SelectedSelectionKeySetSelector.java:68)
+	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoop.select(NioEventLoop.java:805)
+	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:457)
+	at io.grpc.netty.shaded.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
+	at io.grpc.netty.shaded.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.grpc.netty.shaded.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"http-nio-9966-BlockPoller" #51 daemon prio=5 os_prio=31 cpu=119.93ms elapsed=3953.70s tid=0x00007fdb5e448800 nid=0x15007 runnable  [0x000070000fa25000]
+   java.lang.Thread.State: RUNNABLE
+	at sun.nio.ch.KQueue.poll(java.base@11.0.9.1/Native Method)
+	at sun.nio.ch.KQueueSelectorImpl.doSelect(java.base@11.0.9.1/KQueueSelectorImpl.java:122)
+	at sun.nio.ch.SelectorImpl.lockAndDoSelect(java.base@11.0.9.1/SelectorImpl.java:124)
+	- locked <0x000000061261b0b0> (a sun.nio.ch.Util$2)
+	- locked <0x000000061261b0c0> (a sun.nio.ch.KQueueSelectorImpl)
+	at sun.nio.ch.SelectorImpl.select(java.base@11.0.9.1/SelectorImpl.java:136)
+	at org.apache.tomcat.util.net.NioBlockingSelector$BlockPoller.run(NioBlockingSelector.java:313)
+
+"http-nio-9966-exec-1" #52 daemon prio=5 os_prio=31 cpu=0.15ms elapsed=3953.68s tid=0x00007fdad903d800 nid=0x14603 waiting on condition  [0x000070001013a000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x00000006126a1ae8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@11.0.9.1/LockSupport.java:194)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@11.0.9.1/AbstractQueuedSynchronizer.java:2081)
+	at java.util.concurrent.LinkedBlockingQueue.take(java.base@11.0.9.1/LinkedBlockingQueue.java:433)
+	at org.apache.tomcat.util.threads.TaskQueue.take(TaskQueue.java:108)
+	at org.apache.tomcat.util.threads.TaskQueue.take(TaskQueue.java:33)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1054)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"http-nio-9966-exec-2" #53 daemon prio=5 os_prio=31 cpu=0.12ms elapsed=3953.69s tid=0x00007fdb4ccf5800 nid=0xbe03 waiting on condition  [0x000070001023d000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x00000006126a1ae8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@11.0.9.1/LockSupport.java:194)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@11.0.9.1/AbstractQueuedSynchronizer.java:2081)
+	at java.util.concurrent.LinkedBlockingQueue.take(java.base@11.0.9.1/LinkedBlockingQueue.java:433)
+	at org.apache.tomcat.util.threads.TaskQueue.take(TaskQueue.java:108)
+	at org.apache.tomcat.util.threads.TaskQueue.take(TaskQueue.java:33)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1054)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"http-nio-9966-exec-3" #54 daemon prio=5 os_prio=31 cpu=0.17ms elapsed=3953.69s tid=0x00007fdb4cd0e800 nid=0xc103 waiting on condition  [0x0000700010340000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x00000006126a1ae8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@11.0.9.1/LockSupport.java:194)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@11.0.9.1/AbstractQueuedSynchronizer.java:2081)
+	at java.util.concurrent.LinkedBlockingQueue.take(java.base@11.0.9.1/LinkedBlockingQueue.java:433)
+	at org.apache.tomcat.util.threads.TaskQueue.take(TaskQueue.java:108)
+	at org.apache.tomcat.util.threads.TaskQueue.take(TaskQueue.java:33)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1054)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"http-nio-9966-exec-4" #55 daemon prio=5 os_prio=31 cpu=0.10ms elapsed=3953.68s tid=0x00007fdaae268800 nid=0x14203 waiting on condition  [0x0000700010443000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x00000006126a1ae8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@11.0.9.1/LockSupport.java:194)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@11.0.9.1/AbstractQueuedSynchronizer.java:2081)
+	at java.util.concurrent.LinkedBlockingQueue.take(java.base@11.0.9.1/LinkedBlockingQueue.java:433)
+	at org.apache.tomcat.util.threads.TaskQueue.take(TaskQueue.java:108)
+	at org.apache.tomcat.util.threads.TaskQueue.take(TaskQueue.java:33)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1054)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"http-nio-9966-exec-5" #56 daemon prio=5 os_prio=31 cpu=0.11ms elapsed=3953.68s tid=0x00007fdb4cd24000 nid=0xc303 waiting on condition  [0x0000700010546000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x00000006126a1ae8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@11.0.9.1/LockSupport.java:194)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@11.0.9.1/AbstractQueuedSynchronizer.java:2081)
+	at java.util.concurrent.LinkedBlockingQueue.take(java.base@11.0.9.1/LinkedBlockingQueue.java:433)
+	at org.apache.tomcat.util.threads.TaskQueue.take(TaskQueue.java:108)
+	at org.apache.tomcat.util.threads.TaskQueue.take(TaskQueue.java:33)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1054)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"http-nio-9966-exec-6" #57 daemon prio=5 os_prio=31 cpu=0.10ms elapsed=3953.68s tid=0x00007fdaae41e000 nid=0xc603 waiting on condition  [0x0000700010649000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x00000006126a1ae8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@11.0.9.1/LockSupport.java:194)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@11.0.9.1/AbstractQueuedSynchronizer.java:2081)
+	at java.util.concurrent.LinkedBlockingQueue.take(java.base@11.0.9.1/LinkedBlockingQueue.java:433)
+	at org.apache.tomcat.util.threads.TaskQueue.take(TaskQueue.java:108)
+	at org.apache.tomcat.util.threads.TaskQueue.take(TaskQueue.java:33)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1054)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"http-nio-9966-exec-7" #58 daemon prio=5 os_prio=31 cpu=0.10ms elapsed=3953.68s tid=0x00007fdb5d1fd000 nid=0x13f03 waiting on condition  [0x000070001074c000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x00000006126a1ae8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@11.0.9.1/LockSupport.java:194)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@11.0.9.1/AbstractQueuedSynchronizer.java:2081)
+	at java.util.concurrent.LinkedBlockingQueue.take(java.base@11.0.9.1/LinkedBlockingQueue.java:433)
+	at org.apache.tomcat.util.threads.TaskQueue.take(TaskQueue.java:108)
+	at org.apache.tomcat.util.threads.TaskQueue.take(TaskQueue.java:33)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1054)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"http-nio-9966-exec-8" #59 daemon prio=5 os_prio=31 cpu=0.09ms elapsed=3953.68s tid=0x00007fdb4cd33800 nid=0x13e03 waiting on condition  [0x000070001084f000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x00000006126a1ae8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@11.0.9.1/LockSupport.java:194)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@11.0.9.1/AbstractQueuedSynchronizer.java:2081)
+	at java.util.concurrent.LinkedBlockingQueue.take(java.base@11.0.9.1/LinkedBlockingQueue.java:433)
+	at org.apache.tomcat.util.threads.TaskQueue.take(TaskQueue.java:108)
+	at org.apache.tomcat.util.threads.TaskQueue.take(TaskQueue.java:33)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1054)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"http-nio-9966-exec-9" #60 daemon prio=5 os_prio=31 cpu=0.08ms elapsed=3953.68s tid=0x00007fdb5e3fd000 nid=0x13d03 waiting on condition  [0x0000700010952000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x00000006126a1ae8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@11.0.9.1/LockSupport.java:194)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@11.0.9.1/AbstractQueuedSynchronizer.java:2081)
+	at java.util.concurrent.LinkedBlockingQueue.take(java.base@11.0.9.1/LinkedBlockingQueue.java:433)
+	at org.apache.tomcat.util.threads.TaskQueue.take(TaskQueue.java:108)
+	at org.apache.tomcat.util.threads.TaskQueue.take(TaskQueue.java:33)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1054)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"http-nio-9966-exec-10" #61 daemon prio=5 os_prio=31 cpu=0.11ms elapsed=3953.68s tid=0x00007fdb5ceee000 nid=0xcd03 waiting on condition  [0x0000700010a55000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x00000006126a1ae8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@11.0.9.1/LockSupport.java:194)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@11.0.9.1/AbstractQueuedSynchronizer.java:2081)
+	at java.util.concurrent.LinkedBlockingQueue.take(java.base@11.0.9.1/LinkedBlockingQueue.java:433)
+	at org.apache.tomcat.util.threads.TaskQueue.take(TaskQueue.java:108)
+	at org.apache.tomcat.util.threads.TaskQueue.take(TaskQueue.java:33)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1054)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"http-nio-9966-ClientPoller" #62 daemon prio=5 os_prio=31 cpu=126.42ms elapsed=3953.68s tid=0x00007fdb5dca0800 nid=0xd003 runnable  [0x0000700010b58000]
+   java.lang.Thread.State: RUNNABLE
+	at sun.nio.ch.KQueue.poll(java.base@11.0.9.1/Native Method)
+	at sun.nio.ch.KQueueSelectorImpl.doSelect(java.base@11.0.9.1/KQueueSelectorImpl.java:122)
+	at sun.nio.ch.SelectorImpl.lockAndDoSelect(java.base@11.0.9.1/SelectorImpl.java:124)
+	- locked <0x00000006126a1d80> (a sun.nio.ch.Util$2)
+	- locked <0x00000006126a1d90> (a sun.nio.ch.KQueueSelectorImpl)
+	at sun.nio.ch.SelectorImpl.select(java.base@11.0.9.1/SelectorImpl.java:136)
+	at org.apache.tomcat.util.net.NioEndpoint$Poller.run(NioEndpoint.java:711)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"http-nio-9966-Acceptor" #63 daemon prio=5 os_prio=31 cpu=1.20ms elapsed=3953.67s tid=0x00007fdad882f800 nid=0xd203 runnable  [0x0000700010c5b000]
+   java.lang.Thread.State: RUNNABLE
+	at sun.nio.ch.ServerSocketChannelImpl.accept0(java.base@11.0.9.1/Native Method)
+	at sun.nio.ch.ServerSocketChannelImpl.accept(java.base@11.0.9.1/ServerSocketChannelImpl.java:533)
+	at sun.nio.ch.ServerSocketChannelImpl.accept(java.base@11.0.9.1/ServerSocketChannelImpl.java:285)
+	at org.apache.tomcat.util.net.NioEndpoint.serverSocketAccept(NioEndpoint.java:469)
+	at org.apache.tomcat.util.net.NioEndpoint.serverSocketAccept(NioEndpoint.java:71)
+	at org.apache.tomcat.util.net.Acceptor.run(Acceptor.java:106)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"DestroyJavaVM" #64 prio=5 os_prio=31 cpu=11863.89ms elapsed=3953.20s tid=0x00007fdb5d8b7800 nid=0x1d03 waiting on condition  [0x0000000000000000]
+   java.lang.Thread.State: RUNNABLE
+
+"grpc-nio-worker-ELG-1-5" #65 daemon prio=5 os_prio=31 cpu=0.25ms elapsed=3950.81s tid=0x00007fdb5d422800 nid=0xa007 runnable  [0x000070000d8c2000]
+   java.lang.Thread.State: RUNNABLE
+	at sun.nio.ch.KQueue.poll(java.base@11.0.9.1/Native Method)
+	at sun.nio.ch.KQueueSelectorImpl.doSelect(java.base@11.0.9.1/KQueueSelectorImpl.java:122)
+	at sun.nio.ch.SelectorImpl.lockAndDoSelect(java.base@11.0.9.1/SelectorImpl.java:124)
+	- locked <0x00000006007f6c38> (a io.grpc.netty.shaded.io.netty.channel.nio.SelectedSelectionKeySet)
+	- locked <0x00000006007f6bd8> (a sun.nio.ch.KQueueSelectorImpl)
+	at sun.nio.ch.SelectorImpl.select(java.base@11.0.9.1/SelectorImpl.java:141)
+	at io.grpc.netty.shaded.io.netty.channel.nio.SelectedSelectionKeySetSelector.select(SelectedSelectionKeySetSelector.java:68)
+	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoop.select(NioEventLoop.java:805)
+	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:457)
+	at io.grpc.netty.shaded.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
+	at io.grpc.netty.shaded.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.grpc.netty.shaded.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"grpc-nio-worker-ELG-1-6" #66 daemon prio=5 os_prio=31 cpu=0.57ms elapsed=3948.01s tid=0x00007fdb5d6fa800 nid=0x5b07 runnable  [0x000070000d9c5000]
+   java.lang.Thread.State: RUNNABLE
+	at sun.nio.ch.KQueue.poll(java.base@11.0.9.1/Native Method)
+	at sun.nio.ch.KQueueSelectorImpl.doSelect(java.base@11.0.9.1/KQueueSelectorImpl.java:122)
+	at sun.nio.ch.SelectorImpl.lockAndDoSelect(java.base@11.0.9.1/SelectorImpl.java:124)
+	- locked <0x00000006007f64a0> (a io.grpc.netty.shaded.io.netty.channel.nio.SelectedSelectionKeySet)
+	- locked <0x00000006007f6440> (a sun.nio.ch.KQueueSelectorImpl)
+	at sun.nio.ch.SelectorImpl.select(java.base@11.0.9.1/SelectorImpl.java:141)
+	at io.grpc.netty.shaded.io.netty.channel.nio.SelectedSelectionKeySetSelector.select(SelectedSelectionKeySetSelector.java:68)
+	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoop.select(NioEventLoop.java:805)
+	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:457)
+	at io.grpc.netty.shaded.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
+	at io.grpc.netty.shaded.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.grpc.netty.shaded.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"grpc-nio-worker-ELG-1-7" #67 daemon prio=5 os_prio=31 cpu=1300.76ms elapsed=3948.01s tid=0x00007fdb4c858800 nid=0x5d07 runnable  [0x000070000dbcb000]
+   java.lang.Thread.State: RUNNABLE
+	at sun.nio.ch.KQueue.poll(java.base@11.0.9.1/Native Method)
+	at sun.nio.ch.KQueueSelectorImpl.doSelect(java.base@11.0.9.1/KQueueSelectorImpl.java:122)
+	at sun.nio.ch.SelectorImpl.lockAndDoSelect(java.base@11.0.9.1/SelectorImpl.java:124)
+	- locked <0x00000006007f4d98> (a io.grpc.netty.shaded.io.netty.channel.nio.SelectedSelectionKeySet)
+	- locked <0x00000006007f4d38> (a sun.nio.ch.KQueueSelectorImpl)
+	at sun.nio.ch.SelectorImpl.select(java.base@11.0.9.1/SelectorImpl.java:141)
+	at io.grpc.netty.shaded.io.netty.channel.nio.SelectedSelectionKeySetSelector.select(SelectedSelectionKeySetSelector.java:68)
+	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoop.select(NioEventLoop.java:805)
+	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:457)
+	at io.grpc.netty.shaded.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
+	at io.grpc.netty.shaded.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.grpc.netty.shaded.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"logback-3" #68 daemon prio=5 os_prio=31 cpu=1.08ms elapsed=3933.33s tid=0x00007fdb5d413000 nid=0xd503 waiting on condition  [0x0000700010d5e000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x0000000600de83f8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@11.0.9.1/LockSupport.java:194)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@11.0.9.1/AbstractQueuedSynchronizer.java:2081)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:1177)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:899)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1054)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"logback-4" #69 daemon prio=5 os_prio=31 cpu=0.93ms elapsed=3903.34s tid=0x00007fdaaeb44000 nid=0xe10f waiting on condition  [0x0000700010e61000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x0000000600de83f8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@11.0.9.1/LockSupport.java:194)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@11.0.9.1/AbstractQueuedSynchronizer.java:2081)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:1177)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:899)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1054)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"logback-5" #70 daemon prio=5 os_prio=31 cpu=0.71ms elapsed=3873.33s tid=0x00007fdb5d419800 nid=0xb90b waiting on condition  [0x000070000fd2e000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x0000000600de83f8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@11.0.9.1/LockSupport.java:194)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@11.0.9.1/AbstractQueuedSynchronizer.java:2081)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:1177)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:899)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1054)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"logback-6" #71 daemon prio=5 os_prio=31 cpu=0.59ms elapsed=3843.33s tid=0x00007fdb1c9cd800 nid=0x13817 waiting on condition  [0x000070000ff34000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x0000000600de83f8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@11.0.9.1/LockSupport.java:194)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@11.0.9.1/AbstractQueuedSynchronizer.java:2081)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:1177)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:899)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1054)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"Attach Listener" #72 daemon prio=9 os_prio=31 cpu=45.15ms elapsed=3823.48s tid=0x00007fdaaf03e000 nid=0xb713 runnable  [0x0000000000000000]
+   java.lang.Thread.State: RUNNABLE
+
+"logback-7" #73 daemon prio=5 os_prio=31 cpu=0.64ms elapsed=3813.33s tid=0x00007fdaaf81e000 nid=0xd70f waiting on condition  [0x0000700011067000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x0000000600de83f8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@11.0.9.1/LockSupport.java:194)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@11.0.9.1/AbstractQueuedSynchronizer.java:2081)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:1177)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:899)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1054)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"logback-8" #74 daemon prio=5 os_prio=31 cpu=0.54ms elapsed=3783.33s tid=0x00007fdaafc70000 nid=0xdd0f waiting on condition  [0x000070001116a000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x0000000600de83f8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@11.0.9.1/LockSupport.java:194)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@11.0.9.1/AbstractQueuedSynchronizer.java:2081)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:1177)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:899)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1054)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"logback-9" #75 daemon prio=5 os_prio=31 cpu=0.48ms elapsed=3753.33s tid=0x00007fdaaf03d000 nid=0x13403 waiting on condition  [0x0000700011473000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x0000000600de83f8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@11.0.9.1/LockSupport.java:194)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@11.0.9.1/AbstractQueuedSynchronizer.java:2081)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:1177)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.9.1/ScheduledThreadPoolExecutor.java:899)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1054)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"grpc-nio-worker-ELG-1-8" #87 daemon prio=5 os_prio=31 cpu=2.95ms elapsed=2156.08s tid=0x00007fdaaf041800 nid=0x1321b runnable  [0x000070000fb28000]
+   java.lang.Thread.State: RUNNABLE
+	at sun.nio.ch.KQueue.poll(java.base@11.0.9.1/Native Method)
+	at sun.nio.ch.KQueueSelectorImpl.doSelect(java.base@11.0.9.1/KQueueSelectorImpl.java:122)
+	at sun.nio.ch.SelectorImpl.lockAndDoSelect(java.base@11.0.9.1/SelectorImpl.java:124)
+	- locked <0x00000006008a9c20> (a io.grpc.netty.shaded.io.netty.channel.nio.SelectedSelectionKeySet)
+	- locked <0x00000006008a9c38> (a sun.nio.ch.KQueueSelectorImpl)
+	at sun.nio.ch.SelectorImpl.select(java.base@11.0.9.1/SelectorImpl.java:141)
+	at io.grpc.netty.shaded.io.netty.channel.nio.SelectedSelectionKeySetSelector.select(SelectedSelectionKeySetSelector.java:68)
+	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoop.select(NioEventLoop.java:805)
+	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:457)
+	at io.grpc.netty.shaded.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
+	at io.grpc.netty.shaded.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.grpc.netty.shaded.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"grpc-nio-worker-ELG-1-9" #88 daemon prio=5 os_prio=31 cpu=1.45ms elapsed=2150.74s tid=0x00007fdaafaa6800 nid=0x12e23 runnable  [0x0000700011576000]
+   java.lang.Thread.State: RUNNABLE
+	at sun.nio.ch.KQueue.poll(java.base@11.0.9.1/Native Method)
+	at sun.nio.ch.KQueueSelectorImpl.doSelect(java.base@11.0.9.1/KQueueSelectorImpl.java:122)
+	at sun.nio.ch.SelectorImpl.lockAndDoSelect(java.base@11.0.9.1/SelectorImpl.java:124)
+	- locked <0x000000060088c090> (a io.grpc.netty.shaded.io.netty.channel.nio.SelectedSelectionKeySet)
+	- locked <0x000000060088c0a8> (a sun.nio.ch.KQueueSelectorImpl)
+	at sun.nio.ch.SelectorImpl.select(java.base@11.0.9.1/SelectorImpl.java:141)
+	at io.grpc.netty.shaded.io.netty.channel.nio.SelectedSelectionKeySetSelector.select(SelectedSelectionKeySetSelector.java:68)
+	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoop.select(NioEventLoop.java:805)
+	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:457)
+	at io.grpc.netty.shaded.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
+	at io.grpc.netty.shaded.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.grpc.netty.shaded.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"grpc-nio-worker-ELG-1-10" #89 daemon prio=5 os_prio=31 cpu=0.35ms elapsed=2147.95s tid=0x00007fdaaf98b000 nid=0x14d13 runnable  [0x0000700011679000]
+   java.lang.Thread.State: RUNNABLE
+	at sun.nio.ch.KQueue.poll(java.base@11.0.9.1/Native Method)
+	at sun.nio.ch.KQueueSelectorImpl.doSelect(java.base@11.0.9.1/KQueueSelectorImpl.java:122)
+	at sun.nio.ch.SelectorImpl.lockAndDoSelect(java.base@11.0.9.1/SelectorImpl.java:124)
+	- locked <0x0000000600876600> (a io.grpc.netty.shaded.io.netty.channel.nio.SelectedSelectionKeySet)
+	- locked <0x0000000600876618> (a sun.nio.ch.KQueueSelectorImpl)
+	at sun.nio.ch.SelectorImpl.select(java.base@11.0.9.1/SelectorImpl.java:136)
+	at io.grpc.netty.shaded.io.netty.channel.nio.SelectedSelectionKeySetSelector.select(SelectedSelectionKeySetSelector.java:62)
+	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoop.select(NioEventLoop.java:809)
+	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:457)
+	at io.grpc.netty.shaded.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
+	at io.grpc.netty.shaded.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
+	at io.grpc.netty.shaded.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"grpc-default-executor-12" #94 daemon prio=5 os_prio=31 cpu=2.59ms elapsed=119.46s tid=0x00007fdaafb59800 nid=0xd92f waiting on condition  [0x000070001126d000]
+   java.lang.Thread.State: TIMED_WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x00000006007f63c8> (a java.util.concurrent.SynchronousQueue$TransferStack)
+	at java.util.concurrent.locks.LockSupport.parkNanos(java.base@11.0.9.1/LockSupport.java:234)
+	at java.util.concurrent.SynchronousQueue$TransferStack.awaitFulfill(java.base@11.0.9.1/SynchronousQueue.java:462)
+	at java.util.concurrent.SynchronousQueue$TransferStack.transfer(java.base@11.0.9.1/SynchronousQueue.java:361)
+	at java.util.concurrent.SynchronousQueue.poll(java.base@11.0.9.1/SynchronousQueue.java:937)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1053)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"grpc-default-executor-13" #95 daemon prio=5 os_prio=31 cpu=0.15ms elapsed=7.45s tid=0x00007fdaafaa5000 nid=0x12b13 waiting on condition  [0x0000700011982000]
+   java.lang.Thread.State: TIMED_WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)
+	- parking to wait for  <0x00000006007f63c8> (a java.util.concurrent.SynchronousQueue$TransferStack)
+	at java.util.concurrent.locks.LockSupport.parkNanos(java.base@11.0.9.1/LockSupport.java:234)
+	at java.util.concurrent.SynchronousQueue$TransferStack.awaitFulfill(java.base@11.0.9.1/SynchronousQueue.java:462)
+	at java.util.concurrent.SynchronousQueue$TransferStack.transfer(java.base@11.0.9.1/SynchronousQueue.java:361)
+	at java.util.concurrent.SynchronousQueue.poll(java.base@11.0.9.1/SynchronousQueue.java:937)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/ThreadPoolExecutor.java:1053)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1114)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
+	at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)
+
+"VM Thread" os_prio=31 cpu=7052.30ms elapsed=3966.91s tid=0x00007fdb1c80b000 nid=0x4903 runnable
+
+"GC Thread#0" os_prio=31 cpu=415.03ms elapsed=3966.92s tid=0x00007fdb5e009000 nid=0x2e03 runnable
+
+"GC Thread#1" os_prio=31 cpu=421.80ms elapsed=3966.38s tid=0x00007fdb4c81d800 nid=0x5f03 runnable
+
+"GC Thread#2" os_prio=31 cpu=422.05ms elapsed=3966.38s tid=0x00007fdb5e13f000 nid=0x9903 runnable
+
+"GC Thread#3" os_prio=31 cpu=407.66ms elapsed=3966.38s tid=0x00007fdb5e145800 nid=0x6003 runnable
+
+"GC Thread#4" os_prio=31 cpu=411.57ms elapsed=3966.38s tid=0x00007fdb0d010800 nid=0x6103 runnable
+
+"GC Thread#5" os_prio=31 cpu=413.62ms elapsed=3966.38s tid=0x00007fdb5d073800 nid=0x6203 runnable
+
+"GC Thread#6" os_prio=31 cpu=412.80ms elapsed=3966.38s tid=0x00007fdb5e0b7800 nid=0x9403 runnable
+
+"GC Thread#7" os_prio=31 cpu=417.40ms elapsed=3966.38s tid=0x00007fdb0d011000 nid=0x9203 runnable
+
+"GC Thread#8" os_prio=31 cpu=412.28ms elapsed=3966.38s tid=0x00007fdb4c8c7800 nid=0x6403 runnable
+
+"GC Thread#9" os_prio=31 cpu=412.74ms elapsed=3966.38s tid=0x00007fdb5d8bd000 nid=0x6603 runnable
+
+"GC Thread#10" os_prio=31 cpu=406.52ms elapsed=3966.38s tid=0x00007fdb4c8c8800 nid=0x6703 runnable
+
+"GC Thread#11" os_prio=31 cpu=428.74ms elapsed=3966.38s tid=0x00007fdb5c978800 nid=0x6903 runnable
+
+"GC Thread#12" os_prio=31 cpu=389.47ms elapsed=3962.75s tid=0x00007fdb5d69f800 nid=0x7d03 runnable
+
+"G1 Main Marker" os_prio=31 cpu=1.00ms elapsed=3966.92s tid=0x00007fdb5c809000 nid=0x5103 runnable
+
+"G1 Conc#0" os_prio=31 cpu=34.13ms elapsed=3966.92s tid=0x00007fdb5e010800 nid=0x4d03 runnable
+
+"G1 Conc#1" os_prio=31 cpu=33.95ms elapsed=3965.98s tid=0x00007fdb5e16a800 nid=0x6c03 runnable
+
+"G1 Conc#2" os_prio=31 cpu=37.12ms elapsed=3965.98s tid=0x00007fdb0d82b800 nid=0x6e03 runnable
+
+"G1 Refine#0" os_prio=31 cpu=9.43ms elapsed=3966.92s tid=0x00007fdb5c970000 nid=0x4c03 runnable
+
+"G1 Refine#1" os_prio=31 cpu=3.20ms elapsed=3611.89s tid=0x00007fdb5dbdd800 nid=0xe607 runnable
+
+"G1 Refine#2" os_prio=31 cpu=1.34ms elapsed=3611.89s tid=0x00007fdb1cc88800 nid=0x13107 runnable
+
+"G1 Young RemSet Sampling" os_prio=31 cpu=1071.21ms elapsed=3966.92s tid=0x00007fdb5c971000 nid=0x4b03 runnable
+"VM Periodic Task Thread" os_prio=31 cpu=2039.53ms elapsed=3964.59s tid=0x00007fdb4c9f9800 nid=0x7203 waiting on condition
+
+JNI global refs: 45, weak refs: 0

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -52,5 +52,6 @@ include(
     "smoke-tests",
     "testing:agent-for-testing",
     "testing:agent-test-extension",
+    "testing:jmh-benchmarks",
     "testing:profiler-tests",
     "testing:common")

--- a/testing/jmh-benchmarks/build.gradle.kts
+++ b/testing/jmh-benchmarks/build.gradle.kts
@@ -1,27 +1,27 @@
 plugins {
-    `java-library`
-    id("me.champeau.jmh") version "0.6.6"
+  `java-library`
+  id("me.champeau.jmh") version "0.6.6"
 }
 
 repositories {
-    mavenCentral()
+  mavenCentral()
 }
 
 dependencies {
-    implementation(project(":profiler"))
-    implementation("org.slf4j:slf4j-api")
-    testImplementation("org.slf4j:slf4j-api")
-    testImplementation("org.junit.jupiter:junit-jupiter-api")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+  implementation(project(":profiler"))
+  implementation("org.slf4j:slf4j-api")
+  testImplementation("org.slf4j:slf4j-api")
+  testImplementation("org.junit.jupiter:junit-jupiter-api")
+  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }
 
 tasks.named<Test>("test") {
-    useJUnitPlatform()
+  useJUnitPlatform()
 }
 
 jmh {
-    profilers.add("gc")
-    warmupIterations.set(2)
-    iterations.set(10)
-    fork.set(2)
+  profilers.add("gc")
+  warmupIterations.set(2)
+  iterations.set(10)
+  fork.set(2)
 }

--- a/testing/jmh-benchmarks/build.gradle.kts
+++ b/testing/jmh-benchmarks/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    `java-library`
+    id("me.champeau.jmh") version "0.6.6"
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(project(":profiler"))
+    implementation("org.slf4j:slf4j-api")
+    testImplementation("org.slf4j:slf4j-api")
+    testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+}
+
+tasks.named<Test>("test") {
+    useJUnitPlatform()
+}
+
+jmh {
+    profilers.add("gc")
+    warmupIterations.set(2)
+    iterations.set(10)
+    fork.set(2)
+}

--- a/testing/jmh-benchmarks/src/jmh/java/com/splunk/opentelemetry/profiler/ThreadDumpProcessorBenchmark.java
+++ b/testing/jmh-benchmarks/src/jmh/java/com/splunk/opentelemetry/profiler/ThreadDumpProcessorBenchmark.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import com.splunk.opentelemetry.profiler.context.SpanContextualizer;
+import com.splunk.opentelemetry.profiler.context.StackToSpanLinkage;
+import com.splunk.opentelemetry.profiler.old.AgentInternalsFilter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+public class ThreadDumpProcessorBenchmark {
+
+  public static final Path JFR_FILE = Path.of("benchmark.jfr");
+
+  public ThreadDumpProcessorBenchmark() {
+    try {
+      ensureJfrFileExists();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void ensureJfrFileExists() throws Exception {
+    if (Files.exists(JFR_FILE)) {
+      return;
+    }
+    System.out.println("Waiting for subprocess to create JFR file");
+    String path = JfrFileMaker.class.getProtectionDomain().getCodeSource().getLocation().getPath();
+    String cmd = "java -cp " + path + " " + JfrFileMaker.class.getName() + " " + JFR_FILE + " 60";
+    Process exec = Runtime.getRuntime().exec(cmd);
+    int rc = exec.waitFor();
+    if (rc != 0) {
+      System.out.println("rc = " + rc);
+      throw new IllegalStateException("NO JFR FILE");
+    }
+  }
+
+  private static ThreadDumpProcessor buildNewThreadDumpProcessor() {
+    SpanContextualizer contextualizer = new SpanContextualizer();
+    StackTraceFilter filter = new StackTraceFilter(false);
+    Consumer<StackToSpanLinkage> processor = x -> {};
+    ThreadDumpToStacks threadDumpToStacks = new ThreadDumpToStacks(filter);
+    return ThreadDumpProcessor.builder()
+        .processor(processor)
+        .spanContextualizer(contextualizer)
+        .threadDumpToStacks(threadDumpToStacks)
+        .build();
+  }
+
+  private static com.splunk.opentelemetry.profiler.old.ThreadDumpProcessor
+      buildOldThreadDumpProcessor() {
+    SpanContextualizer contextualizer = new SpanContextualizer();
+    Consumer<StackToSpanLinkage> processor = x -> {};
+    Predicate<String> filter = new AgentInternalsFilter();
+    return new com.splunk.opentelemetry.profiler.old.ThreadDumpProcessor(
+        contextualizer, processor, filter);
+  }
+
+  @Benchmark
+  public void newThreadDumpProcessor(RecordingFileState state) {
+    state.newThreadDumpProcessor.accept(state.nextEvent());
+  }
+
+  @Benchmark
+  public void oldThreadDumpProcessor(RecordingFileState state) {
+    state.oldThreadDumpProcessor.accept(state.nextEvent());
+  }
+
+  @State(Scope.Benchmark)
+  public static class RecordingFileState {
+    public final ThreadDumpProcessor newThreadDumpProcessor = buildNewThreadDumpProcessor();
+    public final com.splunk.opentelemetry.profiler.old.ThreadDumpProcessor oldThreadDumpProcessor =
+        buildOldThreadDumpProcessor();
+
+    public static final Path JFR_FILE = Path.of("benchmark.jfr");
+
+    List<RecordedEvent> events = new ArrayList<>();
+    int index = 0;
+
+    @Setup(Level.Trial)
+    public void setup() throws Exception {
+      RecordingFile recordingFile = new RecordingFile(JFR_FILE);
+      while (recordingFile.hasMoreEvents()) {
+        RecordedEvent event = recordingFile.readEvent();
+        if (event.getEventType().getName().equals("jdk.ThreadDump")) {
+          events.add(event);
+        }
+      }
+      recordingFile.close();
+    }
+
+    public RecordedEvent nextEvent() {
+      try {
+        return events.get(index++);
+      } finally {
+        if (index >= events.size()) {
+          index = 0;
+        }
+      }
+    }
+  }
+}

--- a/testing/jmh-benchmarks/src/main/java/com/splunk/opentelemetry/profiler/JfrFileMaker.java
+++ b/testing/jmh-benchmarks/src/main/java/com/splunk/opentelemetry/profiler/JfrFileMaker.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler;
+
+import static java.lang.Integer.parseInt;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import jdk.jfr.Recording;
+
+/**
+ * Just runs for a while to allow some jfr file data to be created. args[0] == filename, args[1] =
+ * length of time to run (in seconds)
+ */
+public class JfrFileMaker {
+
+  private static final int NUM_THREADS = 40;
+  private static final ExecutorService pool = Executors.newFixedThreadPool(NUM_THREADS);
+
+  public static void main(String[] args) throws Exception {
+    String jfrFilename = args[0];
+    int runSeconds = parseInt(args[1]);
+    startThreads(runSeconds);
+    Recording recording = new Recording();
+    Map<String, String> settings = new HashMap<>();
+    settings.put("jdk.ThreadDump#enabled", "true");
+    settings.put("jdk.ThreadDump#period", "100 ms");
+    recording.setSettings(settings);
+    recording.setToDisk(true);
+    recording.setDuration(null);
+    System.out.println("Starting JFR recording for " + runSeconds);
+    recording.start();
+    TimeUnit.SECONDS.sleep(runSeconds);
+    System.out.println("Dumping JFR contents to " + jfrFilename);
+    recording.dump(Path.of(jfrFilename));
+    recording.stop();
+    pool.shutdownNow();
+  }
+
+  private static void startThreads(int runSeconds) {
+    for (int i = 0; i < NUM_THREADS; i++) {
+      pool.submit(
+          () -> {
+            try {
+              TimeUnit.SECONDS.sleep(runSeconds);
+            } catch (InterruptedException e) {
+              e.printStackTrace();
+            }
+          });
+    }
+  }
+}

--- a/testing/jmh-benchmarks/src/main/java/com/splunk/opentelemetry/profiler/old/AgentInternalsFilter.java
+++ b/testing/jmh-benchmarks/src/main/java/com/splunk/opentelemetry/profiler/old/AgentInternalsFilter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler.old;
+
+import java.util.Arrays;
+import java.util.function.Predicate;
+
+public class AgentInternalsFilter implements Predicate<String> {
+
+  private static final String[] UNWANTED_PREFIXES =
+      new String[] {
+        "\"Batched Logs Exporter\"",
+        "\"BatchSpanProcessor_WorkerThread-",
+        "\"JFR Recorder Thread\"",
+        "\"JFR Periodic Tasks\"",
+        "\"JFR Recording Scheduler\"",
+        "\"JFR Recording Sequencer\""
+      };
+
+  @Override
+  public boolean test(String stack) {
+    if (Arrays.stream(UNWANTED_PREFIXES).anyMatch(stack::startsWith)) {
+      return false;
+    }
+    if (stack.indexOf('\n') == -1) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/testing/jmh-benchmarks/src/main/java/com/splunk/opentelemetry/profiler/old/ThreadDumpProcessor.java
+++ b/testing/jmh-benchmarks/src/main/java/com/splunk/opentelemetry/profiler/old/ThreadDumpProcessor.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler.old;
+
+import com.splunk.opentelemetry.profiler.context.SpanContextualizer;
+import com.splunk.opentelemetry.profiler.context.StackToSpanLinkage;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import jdk.jfr.consumer.RecordedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ThreadDumpProcessor {
+  public static final String EVENT_NAME = "jdk.ThreadDump";
+  private static final Logger logger = LoggerFactory.getLogger(ThreadDumpProcessor.class);
+  private final Pattern stackSeparator = Pattern.compile("\n\n");
+  private final SpanContextualizer contextualizer;
+  private final Consumer<StackToSpanLinkage> processor;
+  private final Predicate<String> agentInternalsFilter;
+
+  public ThreadDumpProcessor(
+      SpanContextualizer contextualizer,
+      Consumer<StackToSpanLinkage> processor,
+      Predicate<String> agentInternalsFilter) {
+    this.contextualizer = contextualizer;
+    this.processor = processor;
+    this.agentInternalsFilter = agentInternalsFilter;
+  }
+
+  public void accept(RecordedEvent event) {
+    String eventName = event.getEventType().getName();
+    logger.debug("Processing JFR event {}", eventName);
+    String wallOfStacks = event.getString("result");
+    String[] stacks = stackSeparator.split(wallOfStacks);
+    // TODO: Filter out all the VM and GC entries without real stack traces?
+    Stream.of(stacks)
+        .filter(stack -> stack.charAt(0) == '"') // omit non-stack entries
+        .filter(agentInternalsFilter)
+        .map(stack -> contextualizer.link(event.getStartTime(), stack, event))
+        .forEach(processor);
+  }
+}


### PR DESCRIPTION
The single large string instance obtained from the `jdk.ThreadDump` event has to be parsed so that we can send separate stack traces to ingest. Previously, we just simply called `.split("\n\n")` on this. The regex might be computationally expensive, whatever, but we definitely know that the split is allocating a lot of strings that get thrown away immediately when agent internal threads are omitted (default).

So, this creates a stateful parser to help handle this. We only create those smaller substrings in the event that we can parse a stack and pass the filters. This also adds a few more thread names to the filter list.