### PR TITLE
Leverage SCHEMA_URL from upstream

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/logs/InstrumentationLibraryLogsAdapter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/logs/InstrumentationLibraryLogsAdapter.java
@@ -16,10 +16,10 @@
 
 package com.splunk.opentelemetry.logs;
 
-import com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes;
 import io.opentelemetry.proto.common.v1.InstrumentationLibrary;
 import io.opentelemetry.proto.logs.v1.InstrumentationLibraryLogs;
 import io.opentelemetry.proto.logs.v1.LogRecord;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -53,7 +53,7 @@ public class InstrumentationLibraryLogsAdapter
     List<LogRecord> logs = logEntries.stream().map(logEntryAdapter).collect(Collectors.toList());
 
     return InstrumentationLibraryLogs.newBuilder()
-        .setSchemaUrl(ProfilingSemanticAttributes.SCHEMA_URL)
+        .setSchemaUrl(ResourceAttributes.SCHEMA_URL)
         .setInstrumentationLibrary(library)
         .addAllLogs(logs)
         .build();

--- a/profiler/src/main/java/com/splunk/opentelemetry/logs/ResourceLogsAdapter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/logs/ResourceLogsAdapter.java
@@ -16,11 +16,11 @@
 
 package com.splunk.opentelemetry.logs;
 
-import com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes;
 import io.opentelemetry.proto.common.v1.KeyValue;
 import io.opentelemetry.proto.logs.v1.InstrumentationLibraryLogs;
 import io.opentelemetry.proto.logs.v1.ResourceLogs;
 import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -56,7 +56,7 @@ public class ResourceLogsAdapter implements Function<List<LogEntry>, ResourceLog
             .build();
     return ResourceLogs.newBuilder()
         .setResource(protoResource)
-        .setSchemaUrl(ProfilingSemanticAttributes.SCHEMA_URL)
+        .setSchemaUrl(ResourceAttributes.SCHEMA_URL)
         .addInstrumentationLibraryLogs(instrumentationLibraryLogs)
         .build();
   }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/ProfilingSemanticAttributes.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/ProfilingSemanticAttributes.java
@@ -23,10 +23,6 @@ import io.opentelemetry.api.common.AttributeKey;
 
 public class ProfilingSemanticAttributes {
 
-  // NOTE: When we update to upstream 1.4.0+ this can be found on ResourceAttributes and this can be
-  // removed
-  public static final String SCHEMA_URL = "https://opentelemetry.io/schemas/1.4.0";
-
   /** This is a HEC field that shows up in the Logging UI. */
   public static final AttributeKey<String> SOURCE_TYPE = stringKey("com.splunk.sourcetype");
 

--- a/profiler/src/test/java/com/splunk/opentelemetry/logs/InstrumentationLibraryLogAdapterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/logs/InstrumentationLibraryLogAdapterTest.java
@@ -16,7 +16,7 @@
 
 package com.splunk.opentelemetry.logs;
 
-import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SCHEMA_URL;
+import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.SCHEMA_URL;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_METHOD;
 import static java.time.temporal.ChronoUnit.MINUTES;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/profiler/src/test/java/com/splunk/opentelemetry/logs/ResourceLogAdapterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/logs/ResourceLogAdapterTest.java
@@ -16,7 +16,7 @@
 
 package com.splunk.opentelemetry.logs;
 
-import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SCHEMA_URL;
+import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.SCHEMA_URL;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.ENDUSER_ID;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
There was a note from a while back. Let's remove our own hardcoded version and use upstream.