### PR TITLE
Rename ResourceLogsAdapterTest to match class under test

### DIFF
--- a/profiler/src/test/java/com/splunk/opentelemetry/logs/ResourceLogsAdapterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/logs/ResourceLogsAdapterTest.java
@@ -32,7 +32,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-class ResourceLogAdapterTest {
+class ResourceLogsAdapterTest {
 
   @Test
   void testApply() {


### PR DESCRIPTION
Just a class rename (it didn't match the class under test).
`ResourceLogAdapterTest` -> `ResourceLogsAdapterTest`