### PR TITLE
Include the trace flags as part of the attached context

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/logs/LogEntry.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/logs/LogEntry.java
@@ -28,6 +28,7 @@ public class LogEntry {
   private final Attributes attributes;
   private final Instant time;
   private final String body;
+  private final int traceFlags;
   @Nullable private final String traceId;
   @Nullable private final String spanId;
 
@@ -36,6 +37,7 @@ public class LogEntry {
     this.attributes = builder.attributes;
     this.time = builder.time;
     this.body = builder.body;
+    this.traceFlags = builder.traceFlags;
     this.traceId = builder.traceId;
     this.spanId = builder.spanId;
   }
@@ -60,6 +62,10 @@ public class LogEntry {
     return traceId;
   }
 
+  public int getTraceFlags() {
+    return traceFlags;
+  }
+
   public String getSpanId() {
     return spanId;
   }
@@ -73,6 +79,7 @@ public class LogEntry {
     private Attributes attributes = Attributes.empty();
     private Instant time;
     private String body;
+    public int traceFlags = 0;
     private String traceId;
     private String spanId;
 
@@ -93,6 +100,11 @@ public class LogEntry {
 
     public Builder body(String body) {
       this.body = body;
+      return this;
+    }
+
+    public Builder traceFlags(int traceFlags) {
+      this.traceFlags = traceFlags;
       return this;
     }
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/logs/LogEntryAdapter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/logs/LogEntryAdapter.java
@@ -55,6 +55,7 @@ public class LogEntryAdapter implements Function<LogEntry, LogRecord> {
       byte[] traceIdBytes =
           OtelEncodingUtils.bytesFromBase16(logEntry.getTraceId(), TraceId.getLength());
       builder.setTraceId(unsafeWrap(traceIdBytes));
+      builder.setFlags(logEntry.getTraceFlags());
     }
     if (logEntry.getSpanId() != null) {
       byte[] spanIdBytes =

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrContextStorage.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrContextStorage.java
@@ -44,7 +44,8 @@ class JfrContextStorage implements ContextStorage {
 
   static ContextAttached newEvent(SpanContext spanContext) {
     if (spanContext.isValid()) {
-      return new ContextAttached(spanContext.getTraceId(), spanContext.getSpanId());
+      return new ContextAttached(
+          spanContext.getTraceFlags().asByte(), spanContext.getTraceId(), spanContext.getSpanId());
     }
     return new ContextAttached(null, null);
   }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/SpanContextualizer.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/SpanContextualizer.java
@@ -44,6 +44,7 @@ public class SpanContextualizer {
   public void updateContext(RecordedEvent event) {
     String spanId = event.getString("spanId");
     String traceId = event.getString("traceId");
+    int traceFlags = event.getInt("traceFlags");
     long javaThreadId = event.getThread().getJavaThreadId();
 
     logger.debug(
@@ -56,7 +57,7 @@ public class SpanContextualizer {
     if (traceId == null || spanId == null) {
       threadSpans.remove(javaThreadId);
     } else {
-      SpanLinkage linkage = new SpanLinkage(traceId, spanId, javaThreadId);
+      SpanLinkage linkage = new SpanLinkage(traceFlags, traceId, spanId, javaThreadId);
       threadSpans.put(javaThreadId, linkage);
     }
   }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/SpanLinkage.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/SpanLinkage.java
@@ -20,16 +20,23 @@ import javax.annotation.Nullable;
 
 public class SpanLinkage {
 
-  public static final SpanLinkage NONE = new SpanLinkage(null, null, -1);
+  public static final SpanLinkage NONE = new SpanLinkage(0, null, null, -1);
 
+  private final int traceFlags;
   @Nullable private final String spanId;
   @Nullable private final String traceId;
   private final long threadId;
 
-  public SpanLinkage(@Nullable String traceId, @Nullable String spanId, long threadId) {
+  public SpanLinkage(
+      int traceFlags, @Nullable String traceId, @Nullable String spanId, long threadId) {
+    this.traceFlags = traceFlags;
     this.spanId = spanId;
     this.traceId = traceId;
     this.threadId = threadId;
+  }
+
+  int getTraceFlags() {
+    return traceFlags;
   }
 
   @Nullable

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/StackToSpanLinkage.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/StackToSpanLinkage.java
@@ -46,6 +46,10 @@ public class StackToSpanLinkage {
     return rawStack;
   }
 
+  public int getTraceFlags() {
+    return spanLinkage.getTraceFlags();
+  }
+
   public String getTraceId() {
     return spanLinkage.getTraceId();
   }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/events/ContextAttached.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/events/ContextAttached.java
@@ -32,12 +32,22 @@ public class ContextAttached extends Event {
 
   public static final String EVENT_NAME = "otel.ContextAttached";
 
+  public final int traceFlags;
   public final String traceId;
   public final String spanId;
 
   public ContextAttached(String traceId, String spanId) {
+    this(0, traceId, spanId);
+  }
+
+  public ContextAttached(int traceFlags, String traceId, String spanId) {
     this.traceId = traceId;
     this.spanId = spanId;
+    this.traceFlags = traceFlags;
+  }
+
+  public int getTraceFlags() {
+    return traceFlags;
   }
 
   public String getTraceId() {

--- a/profiler/src/test/java/com/splunk/opentelemetry/logs/LogEntryAdapterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/logs/LogEntryAdapterTest.java
@@ -49,6 +49,7 @@ class LogEntryAdapterTest {
     assertEquals(entry.getName(), result.getName());
     assertEquals(entry.getTime().toEpochMilli() * 1_000_000L, result.getTimeUnixNano());
 
+    assertEquals(entry.getTraceFlags(), result.getFlags());
     assertEquals(entry.getTraceId(), toHexString(result.getTraceId().toByteArray()));
     assertEquals(entry.getSpanId(), toHexString(result.getSpanId().toByteArray()));
     assertEquals(entry.getBody(), result.getBody().getStringValue());
@@ -72,6 +73,7 @@ class LogEntryAdapterTest {
         .name("__LOG__")
         .time(time)
         .body(body)
+        .traceFlags(0x42)
         .traceId("c78bda329abae6a6c7111111112ae666")
         .spanId("c78bda329abae6a6")
         .attributes(attributes);

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrContextStorageTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrContextStorageTest.java
@@ -43,6 +43,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class JfrContextStorageTest {
 
+  int traceFlags = 0x42;
   String traceId;
   String spanId;
   Span span;
@@ -56,7 +57,11 @@ class JfrContextStorageTest {
     traceId = TraceId.fromLongs(123, 455);
     spanId = SpanId.fromLong(23498);
     spanContext =
-        SpanContext.create(traceId, spanId, TraceFlags.getDefault(), TraceState.getDefault());
+        SpanContext.create(
+            traceId,
+            spanId,
+            TraceFlags.fromByte((byte) (traceFlags & 0xFF)),
+            TraceState.getDefault());
     span = Span.wrap(spanContext);
     newContext = Context.root().with(span);
   }
@@ -64,6 +69,7 @@ class JfrContextStorageTest {
   @Test
   void testNewEvent() {
     ContextAttached result = JfrContextStorage.newEvent(spanContext);
+    assertEquals(traceFlags, result.getTraceFlags());
     assertEquals(traceId, result.getTraceId());
     assertEquals(spanId, result.getSpanId());
   }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/LogEntryCreatorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/LogEntryCreatorTest.java
@@ -46,6 +46,7 @@ class LogEntryCreatorTest {
     String traceId = "abc123";
 
     long threadId = 987L;
+    int traceFlags = 0x42;
     EventType eventType = mock(EventType.class);
     RecordedEvent sourceEvent = mock(RecordedEvent.class);
     EventPeriods periods = mock(EventPeriods.class);
@@ -54,7 +55,7 @@ class LogEntryCreatorTest {
     when(eventType.getName()).thenReturn("GoodEventHere");
     when(periods.getDuration("GoodEventHere")).thenReturn(Duration.ofMillis(606));
 
-    SpanLinkage linkage = new SpanLinkage(traceId, spanId, threadId);
+    SpanLinkage linkage = new SpanLinkage(traceFlags, traceId, spanId, threadId);
     Attributes attributes =
         Attributes.of(
             SOURCE_EVENT_NAME,
@@ -65,6 +66,7 @@ class LogEntryCreatorTest {
             "otel.profiling");
     LogEntry expected =
         LogEntry.builder()
+            .traceFlags(traceFlags)
             .traceId(traceId)
             .spanId(spanId)
             .name(PROFILING_SOURCE)

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/context/SpanContextualizerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/context/SpanContextualizerTest.java
@@ -35,8 +35,9 @@ import org.junit.jupiter.api.Test;
 
 class SpanContextualizerTest {
 
-  private final String spanId = "abc123";
+  private final int traceFlags = 0x42;
   private final String traceId = "23489uasdpfoiajsdfph23oij";
+  private final String spanId = "abc123";
   private final String rawStack = "raw is raw";
   private final Instant time = Instant.now();
 
@@ -277,6 +278,7 @@ class SpanContextualizerTest {
     StackToSpanLinkage result = testClass.link(time, stack, events.threadId, events.sourceEvent);
     assertEquals(events.spanId, result.getSpanId());
     assertEquals(traceId, result.getTraceId());
+    assertEquals(traceFlags, result.getTraceFlags());
     assertEquals(stack, result.getRawStack());
     assertEquals(result.getSourceEventName(), "GreatSourceEventHere");
   }
@@ -315,24 +317,26 @@ class SpanContextualizerTest {
   }
 
   private RecordedEvent contextEventIn(String spanId, long threadId) {
-    return contextEvent(traceId, spanId, threadId);
+    return contextEvent(traceFlags, traceId, spanId, threadId);
   }
 
   private RecordedEvent contextEventOut(Events parent, long threadId) {
     if (parent == null) {
-      return contextEvent(null, null, threadId);
+      return contextEvent(0, null, null, threadId);
     } else {
-      return contextEvent(traceId, parent.spanId, threadId);
+      return contextEvent(traceFlags, traceId, parent.spanId, threadId);
     }
   }
 
-  private static RecordedEvent contextEvent(String traceId, String spanId, long threadId) {
+  private static RecordedEvent contextEvent(
+      int traceFlags, String traceId, String spanId, long threadId) {
     RecordedEvent event = mock(RecordedEvent.class);
     EventType type = mock(EventType.class);
     when(type.getName()).thenReturn(ContextAttached.EVENT_NAME);
     when(event.getEventType()).thenReturn(type);
     when(event.getString("traceId")).thenReturn(traceId);
     when(event.getString("spanId")).thenReturn(spanId);
+    when(event.getInt("traceFlags")).thenReturn(traceFlags);
     RecordedThread thread = mock(RecordedThread.class);
     when(thread.getJavaThreadId()).thenReturn(threadId);
     when(event.getThread()).thenReturn(thread);


### PR DESCRIPTION
Upstream includes this in the data model, and @flands pointed out that it's important to pass along in case we want to make decisions down the line when sampled.