### PR TITLE
Remove info level log

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/SdkCustomizer.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/SdkCustomizer.java
@@ -24,18 +24,13 @@ import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.SdkTracerProviderConfigurer;
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @AutoService(SdkTracerProviderConfigurer.class)
 public class SdkCustomizer implements SdkTracerProviderConfigurer {
 
-  private static final Logger logger = LoggerFactory.getLogger(SdkCustomizer.class);
-
   @Override
   public void configure(SdkTracerProviderBuilder tracerProviderBuilder, ConfigProperties config) {
     if (jfrIsAvailable() && jfrIsEnabledInConfig()) {
-      logger.info("Enabling JfrContextStorage");
       ContextStorage.addWrapper(JfrContextStorage::new);
     }
   }


### PR DESCRIPTION
`INFO` level log is written to stdout. We should make sure that everything we log at info level is relevant to end users.