### PR TITLE
Update project to GDI spec version 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
   <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.7.0">
     <img alt="OpenTelemetry Instrumentation for Java Version" src="https://img.shields.io/badge/otel-1.7.0-blueviolet?style=for-the-badge">
   </a>
-  <a href="https://github.com/signalfx/gdi-specification/releases/tag/v1.0.0">
-    <img alt="Splunk GDI specification" src="https://img.shields.io/badge/GDI-1.0.0-blueviolet?style=for-the-badge">
+  <a href="https://github.com/signalfx/gdi-specification/releases/tag/v1.1.0">
+    <img alt="Splunk GDI specification" src="https://img.shields.io/badge/GDI-1.1.0-blueviolet?style=for-the-badge">
   </a>
   <a href="https://github.com/signalfx/splunk-otel-java/releases">
     <img alt="GitHub release (latest SemVer)" src="https://img.shields.io/github/v/release/signalfx/splunk-otel-java?include_prereleases&style=for-the-badge">

--- a/custom/src/main/java/com/splunk/opentelemetry/SplunkTracerProviderConfigurer.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/SplunkTracerProviderConfigurer.java
@@ -25,7 +25,7 @@ import io.opentelemetry.sdk.trace.SpanLimits;
 @AutoService(SdkTracerProviderConfigurer.class)
 public class SplunkTracerProviderConfigurer implements SdkTracerProviderConfigurer {
 
-  static final int SPLUNK_DEFAULT_ATTRIBUTE_VALUE_LENGTH = 12_000;
+  static final int SPLUNK_MAX_ATTRIBUTE_VALUE_LENGTH = 12_000;
 
   @Override
   public void configure(SdkTracerProviderBuilder tracerProviderBuilder, ConfigProperties config) {
@@ -36,7 +36,7 @@ public class SplunkTracerProviderConfigurer implements SdkTracerProviderConfigur
             .setMaxNumberOfLinks(1000)
             .setMaxNumberOfAttributesPerEvent(Integer.MAX_VALUE)
             .setMaxNumberOfAttributesPerLink(Integer.MAX_VALUE)
-            .setMaxAttributeValueLength(SPLUNK_DEFAULT_ATTRIBUTE_VALUE_LENGTH)
+            .setMaxAttributeValueLength(SPLUNK_MAX_ATTRIBUTE_VALUE_LENGTH)
             .build());
   }
 }

--- a/custom/src/main/java/com/splunk/opentelemetry/SplunkTracerProviderConfigurer.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/SplunkTracerProviderConfigurer.java
@@ -25,6 +25,8 @@ import io.opentelemetry.sdk.trace.SpanLimits;
 @AutoService(SdkTracerProviderConfigurer.class)
 public class SplunkTracerProviderConfigurer implements SdkTracerProviderConfigurer {
 
+  static final int SPLUNK_DEFAULT_ATTRIBUTE_VALUE_LENGTH = 12_000;
+
   @Override
   public void configure(SdkTracerProviderBuilder tracerProviderBuilder, ConfigProperties config) {
     tracerProviderBuilder.setSpanLimits(
@@ -34,6 +36,7 @@ public class SplunkTracerProviderConfigurer implements SdkTracerProviderConfigur
             .setMaxNumberOfLinks(1000)
             .setMaxNumberOfAttributesPerEvent(Integer.MAX_VALUE)
             .setMaxNumberOfAttributesPerLink(Integer.MAX_VALUE)
+            .setMaxAttributeValueLength(SPLUNK_DEFAULT_ATTRIBUTE_VALUE_LENGTH)
             .build());
   }
 }

--- a/custom/src/test/java/com/splunk/opentelemetry/SplunkTracerProviderConfigurerTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/SplunkTracerProviderConfigurerTest.java
@@ -16,7 +16,7 @@
 
 package com.splunk.opentelemetry;
 
-import static com.splunk.opentelemetry.SplunkTracerProviderConfigurer.SPLUNK_DEFAULT_ATTRIBUTE_VALUE_LENGTH;
+import static com.splunk.opentelemetry.SplunkTracerProviderConfigurer.SPLUNK_MAX_ATTRIBUTE_VALUE_LENGTH;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -46,7 +46,7 @@ class SplunkTracerProviderConfigurerTest {
                 .setMaxNumberOfLinks(1000)
                 .setMaxNumberOfAttributesPerEvent(Integer.MAX_VALUE)
                 .setMaxNumberOfAttributesPerLink(Integer.MAX_VALUE)
-                .setMaxAttributeValueLength(SPLUNK_DEFAULT_ATTRIBUTE_VALUE_LENGTH)
+                .setMaxAttributeValueLength(SPLUNK_MAX_ATTRIBUTE_VALUE_LENGTH)
                 .build());
   }
 }

--- a/custom/src/test/java/com/splunk/opentelemetry/SplunkTracerProviderConfigurerTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/SplunkTracerProviderConfigurerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry;
+
+import static com.splunk.opentelemetry.SplunkTracerProviderConfigurer.SPLUNK_DEFAULT_ATTRIBUTE_VALUE_LENGTH;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
+import io.opentelemetry.sdk.trace.SpanLimits;
+import org.junit.jupiter.api.Test;
+
+class SplunkTracerProviderConfigurerTest {
+
+  @Test
+  void shouldConfigureSpanLimits() {
+    // given
+    var tracerProviderBuilder = mock(SdkTracerProviderBuilder.class);
+    var config = mock(ConfigProperties.class);
+    var underTest = new SplunkTracerProviderConfigurer();
+
+    // when
+    underTest.configure(tracerProviderBuilder, config);
+
+    // then
+    verify(tracerProviderBuilder)
+        .setSpanLimits(
+            SpanLimits.builder()
+                .setMaxNumberOfAttributes(Integer.MAX_VALUE)
+                .setMaxNumberOfEvents(Integer.MAX_VALUE)
+                .setMaxNumberOfLinks(1000)
+                .setMaxNumberOfAttributesPerEvent(Integer.MAX_VALUE)
+                .setMaxNumberOfAttributesPerLink(Integer.MAX_VALUE)
+                .setMaxAttributeValueLength(SPLUNK_DEFAULT_ATTRIBUTE_VALUE_LENGTH)
+                .build());
+  }
+}


### PR DESCRIPTION
Turns out it was just the max attribute value length, we already had implemented everything else that was introduced in 1.1.0.