### PR TITLE
Switch back to collector latest

### DIFF
--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/LinuxTestContainerManager.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/LinuxTestContainerManager.java
@@ -51,7 +51,7 @@ public class LinuxTestContainerManager extends AbstractTestContainerManager {
     backend.start();
 
     collector =
-        new GenericContainer<>(DockerImageName.parse("otel/opentelemetry-collector-contrib:0.38.0"))
+        new GenericContainer<>(DockerImageName.parse("otel/opentelemetry-collector-contrib:latest"))
             .dependsOn(backend)
             .withNetwork(network)
             .withNetworkAliases(COLLECTOR_ALIAS)

--- a/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/profiler/ProfilerSmokeTest.java
+++ b/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/profiler/ProfilerSmokeTest.java
@@ -92,7 +92,7 @@ public class ProfilerSmokeTest {
     backend.start();
 
     collector =
-        new GenericContainer<>(DockerImageName.parse("otel/opentelemetry-collector-contrib:0.38.0"))
+        new GenericContainer<>(DockerImageName.parse("otel/opentelemetry-collector-contrib:latest"))
             .dependsOn(backend)
             .withNetwork(NETWORK)
             .withNetworkAliases("collector")


### PR DESCRIPTION
The problem with otel/opentelemetry-collector-contrib:latest has been resolved so we can switch back to using it.