### PR TITLE
Begin using upstream logs sdk

### DIFF
--- a/profiler/build.gradle.kts
+++ b/profiler/build.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
   compileOnly("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api")
   compileOnly("io.opentelemetry:opentelemetry-semconv")
   implementation("io.opentelemetry.proto:opentelemetry-proto")
-  implementation("io.opentelemetry:opentelemetry-sdk-logs:1.9.0-alpha")
+  implementation("io.opentelemetry:opentelemetry-sdk-logs")
 
   compileOnly("org.slf4j:slf4j-api")
   compileOnly("io.grpc:grpc-netty")

--- a/profiler/build.gradle.kts
+++ b/profiler/build.gradle.kts
@@ -7,6 +7,8 @@ dependencies {
   compileOnly("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api")
   compileOnly("io.opentelemetry:opentelemetry-semconv")
   implementation("io.opentelemetry.proto:opentelemetry-proto")
+  implementation("io.opentelemetry:opentelemetry-sdk-logs:1.9.0-alpha")
+
   compileOnly("org.slf4j:slf4j-api")
   compileOnly("io.grpc:grpc-netty")
   implementation("io.grpc:grpc-netty-shaded")

--- a/profiler/src/main/java/com/splunk/opentelemetry/logs/LogEntry.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/logs/LogEntry.java
@@ -80,14 +80,17 @@ public class LogEntry implements LogData {
     return null;
   }
 
+  @Override
   public String getName() {
     return name;
   }
 
+  @Override
   public Attributes getAttributes() {
     return attributes;
   }
 
+  @Override
   public Body getBody() {
     return body;
   }

--- a/profiler/src/main/java/com/splunk/opentelemetry/logs/LogEntryAdapter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/logs/LogEntryAdapter.java
@@ -35,7 +35,7 @@ public class LogEntryAdapter implements Function<LogEntry, LogRecord> {
 
   @Override
   public LogRecord apply(LogEntry logEntry) {
-    AnyValue body = AnyValue.newBuilder().setStringValue(logEntry.getBody()).build();
+    AnyValue body = AnyValue.newBuilder().setStringValue(logEntry.getBodyAsString()).build();
     Attributes sourceAttrs = logEntry.getAttributes();
     List<KeyValue> attributes =
         sourceAttrs.asMap().entrySet().stream()
@@ -60,6 +60,7 @@ public class LogEntryAdapter implements Function<LogEntry, LogRecord> {
       byte[] spanIdBytes =
           OtelEncodingUtils.bytesFromBase16(logEntry.getSpanId(), SpanId.getLength());
       builder.setSpanId(unsafeWrap(spanIdBytes));
+      builder.setFlags(logEntry.getSpanContext().getTraceFlags().asByte());
     }
     return builder.build();
   }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrContextStorage.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrContextStorage.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.splunk.opentelemetry.profiler.events.ContextAttached;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextStorage;
 import io.opentelemetry.context.Scope;
@@ -44,9 +45,10 @@ class JfrContextStorage implements ContextStorage {
 
   static ContextAttached newEvent(SpanContext spanContext) {
     if (spanContext.isValid()) {
-      return new ContextAttached(spanContext.getTraceId(), spanContext.getSpanId());
+      return new ContextAttached(
+          spanContext.getTraceId(), spanContext.getSpanId(), spanContext.getTraceFlags().asByte());
     }
-    return new ContextAttached(null, null);
+    return new ContextAttached(null, null, TraceFlags.getDefault().asByte());
   }
 
   @Override

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/LogEntryCreator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/LogEntryCreator.java
@@ -39,10 +39,10 @@ public class LogEntryCreator implements Function<StackToSpanLinkage, LogEntry> {
         LogEntry.builder()
             .name(PROFILING_SOURCE)
             .time(linkedStack.getTime())
-            .body(linkedStack.getRawStack())
+            .bodyString(linkedStack.getRawStack())
             .attributes(attributes);
     if (linkedStack.hasSpanInfo()) {
-      builder.traceId(linkedStack.getTraceId()).spanId(linkedStack.getSpanId());
+      builder.spanContext(linkedStack.getSpanContext());
     }
     return builder.build();
   }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/TLABProcessor.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/TLABProcessor.java
@@ -87,7 +87,7 @@ public class TLABProcessor implements Consumer<RecordedEvent> {
         LogEntry.builder()
             .name(PROFILING_SOURCE)
             .time(time)
-            .body(stack)
+            .bodyString(stack)
             .attributes(attributes)
             .build();
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/SpanLinkage.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/SpanLinkage.java
@@ -16,30 +16,22 @@
 
 package com.splunk.opentelemetry.profiler.context;
 
-import javax.annotation.Nullable;
+import io.opentelemetry.api.trace.SpanContext;
 
 public class SpanLinkage {
 
-  public static final SpanLinkage NONE = new SpanLinkage(null, null, -1);
+  public static final SpanLinkage NONE = new SpanLinkage(SpanContext.getInvalid(), -1);
 
-  @Nullable private final String spanId;
-  @Nullable private final String traceId;
+  private final SpanContext spanContext;
   private final long threadId;
 
-  public SpanLinkage(@Nullable String traceId, @Nullable String spanId, long threadId) {
-    this.spanId = spanId;
-    this.traceId = traceId;
+  public SpanLinkage(SpanContext spanContext, long threadId) {
+    this.spanContext = spanContext;
     this.threadId = threadId;
   }
 
-  @Nullable
-  String getSpanId() {
-    return spanId;
-  }
-
-  @Nullable
-  String getTraceId() {
-    return traceId;
+  SpanContext getSpanContext() {
+    return spanContext;
   }
 
   long getThreadId() {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/StackToSpanLinkage.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/context/StackToSpanLinkage.java
@@ -16,6 +16,7 @@
 
 package com.splunk.opentelemetry.profiler.context;
 
+import io.opentelemetry.api.trace.SpanContext;
 import java.time.Instant;
 
 /** A wrapper for a RecordedEvent that may or may not have accompanying span information. */
@@ -34,7 +35,7 @@ public class StackToSpanLinkage {
   }
 
   public boolean hasSpanInfo() {
-    return getSpanId() != null;
+    return getSpanContext().isValid();
   }
 
   public Instant getTime() {
@@ -45,12 +46,8 @@ public class StackToSpanLinkage {
     return rawStack;
   }
 
-  public String getTraceId() {
-    return spanLinkage.getTraceId();
-  }
-
-  public String getSpanId() {
-    return spanLinkage.getSpanId();
+  public SpanContext getSpanContext() {
+    return spanLinkage.getSpanContext();
   }
 
   public Long getSpanStartThread() {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/events/ContextAttached.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/events/ContextAttached.java
@@ -34,10 +34,12 @@ public class ContextAttached extends Event {
 
   public final String traceId;
   public final String spanId;
+  public final byte traceFlags;
 
-  public ContextAttached(String traceId, String spanId) {
+  public ContextAttached(String traceId, String spanId, byte traceFlags) {
     this.traceId = traceId;
     this.spanId = spanId;
+    this.traceFlags = traceFlags;
   }
 
   public String getTraceId() {
@@ -46,5 +48,9 @@ public class ContextAttached extends Event {
 
   public String getSpanId() {
     return spanId;
+  }
+
+  public byte getTraceFlags() {
+    return traceFlags;
   }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/logs/BatchingLogsProcessorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/logs/BatchingLogsProcessorTest.java
@@ -41,17 +41,17 @@ class BatchingLogsProcessorTest {
     log1 =
         LogEntry.builder()
             .attributes(Attributes.of(AttributeKey.stringKey("one"), "one"))
-            .body("foo")
+            .bodyString("foo")
             .build();
     log2 =
         LogEntry.builder()
             .attributes(Attributes.of(AttributeKey.stringKey("two"), "two"))
-            .body("bar")
+            .bodyString("bar")
             .build();
     log3 =
         LogEntry.builder()
             .attributes(Attributes.of(AttributeKey.stringKey("three"), "three"))
-            .body("baz")
+            .bodyString("baz")
             .build();
   }
 

--- a/profiler/src/test/java/com/splunk/opentelemetry/logs/InstrumentationLibraryLogAdapterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/logs/InstrumentationLibraryLogAdapterTest.java
@@ -38,19 +38,19 @@ class InstrumentationLibraryLogAdapterTest {
         LogEntry.builder()
             .time(now.plus(0, MINUTES))
             .attributes(Attributes.of(HTTP_METHOD, "get"))
-            .body("log1")
+            .bodyString("log1")
             .build();
     LogEntry log2 =
         LogEntry.builder()
             .time(now.plus(1, MINUTES))
             .attributes(Attributes.of(HTTP_METHOD, "put"))
-            .body("log2")
+            .bodyString("log2")
             .build();
     LogEntry log3 =
         LogEntry.builder()
             .time(now.plus(2, MINUTES))
             .attributes(Attributes.of(HTTP_METHOD, "patch"))
-            .body("log3")
+            .bodyString("log3")
             .build();
     List<LogEntry> logsEntries = Arrays.asList(log1, log2, log3);
     LogEntryAdapter logEntryAdapter = new LogEntryAdapter();

--- a/profiler/src/test/java/com/splunk/opentelemetry/logs/LogEntryAdapterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/logs/LogEntryAdapterTest.java
@@ -20,6 +20,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.proto.common.v1.KeyValue;
 import io.opentelemetry.proto.logs.v1.LogRecord;
 import java.time.Instant;
@@ -51,7 +54,8 @@ class LogEntryAdapterTest {
 
     assertEquals(entry.getTraceId(), toHexString(result.getTraceId().toByteArray()));
     assertEquals(entry.getSpanId(), toHexString(result.getSpanId().toByteArray()));
-    assertEquals(entry.getBody(), result.getBody().getStringValue());
+    assertEquals(entry.getSpanContext().getTraceFlags().asByte(), result.getFlags());
+    assertEquals(entry.getBody().asString(), result.getBody().getStringValue());
     assertEquals("MyClass.myMethod(line:123)", origination.get().getValue().getStringValue());
   }
 
@@ -71,9 +75,13 @@ class LogEntryAdapterTest {
     return LogEntry.builder()
         .name("__LOG__")
         .time(time)
-        .body(body)
-        .traceId("c78bda329abae6a6c7111111112ae666")
-        .spanId("c78bda329abae6a6")
+        .bodyString(body)
+        .spanContext(
+            SpanContext.create(
+                "c78bda329abae6a6c7111111112ae666",
+                "c78bda329abae6a6",
+                TraceFlags.getSampled(),
+                TraceState.getDefault()))
         .attributes(attributes);
   }
 

--- a/profiler/src/test/java/com/splunk/opentelemetry/logs/ResourceLogsAdapterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/logs/ResourceLogsAdapterTest.java
@@ -41,19 +41,19 @@ class ResourceLogsAdapterTest {
         LogEntry.builder()
             .time(now.plus(0, SECONDS))
             .attributes(Attributes.of(ENDUSER_ID, "jimmy"))
-            .body("test log 1")
+            .bodyString("test log 1")
             .build();
     LogEntry log2 =
         LogEntry.builder()
             .time(now.plus(1, SECONDS))
             .attributes(Attributes.of(ENDUSER_ID, "sally"))
-            .body("test log 2")
+            .bodyString("test log 2")
             .build();
     LogEntry log3 =
         LogEntry.builder()
             .time(now.plus(2, SECONDS))
             .attributes(Attributes.of(ENDUSER_ID, "ward"))
-            .body("test log 3")
+            .bodyString("test log 3")
             .build();
     List<LogEntry> sourceLogs = Arrays.asList(log1, log2, log3);
     LogEntryAdapter logEntryAdapter = new LogEntryAdapter();

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackToSpanLinkageProcessorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackToSpanLinkageProcessorTest.java
@@ -37,7 +37,7 @@ class StackToSpanLinkageProcessorTest {
     LogEntryCreator logCreator = mock(LogEntryCreator.class);
     BatchingLogsProcessor exportProcessor = mock(BatchingLogsProcessor.class);
 
-    LogEntry log = LogEntry.builder().body("the.body").build();
+    LogEntry log = LogEntry.builder().bodyString("the.body").build();
     when(logCreator.apply(linkedSpan)).thenReturn(log);
 
     StackToSpanLinkageProcessor processor =

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/TLABProcessorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/TLABProcessorTest.java
@@ -120,7 +120,7 @@ class TLABProcessorTest {
     TLABProcessor processor = new TLABProcessor(config, serializer, consumer, commonAttrs);
     processor.accept(event);
 
-    assertEquals(stackAsString, seenLogEntry.get().getBody());
+    assertEquals(stackAsString, seenLogEntry.get().getBody().asString());
     assertEquals(now, seenLogEntry.get().getTime());
     assertEquals("otel.profiling", seenLogEntry.get().getAttributes().get(SOURCE_TYPE));
     assertEquals("tee-lab", seenLogEntry.get().getAttributes().get(SOURCE_EVENT_NAME));
@@ -130,7 +130,6 @@ class TLABProcessorTest {
     } else {
       assertEquals(tlabSize, seenLogEntry.get().getAttributes().get(TLAB_SIZE_KEY));
     }
-    assertNull(seenLogEntry.get().getSpanId());
-    assertNull(seenLogEntry.get().getTraceId());
+    assertFalse(seenLogEntry.get().getSpanContext().isValid());
   }
 }


### PR DESCRIPTION
This will be the first in a series of incremental enhancements that move us in the direction of using logs from upstream (rather than our own implementation).

Two main things in this PR:
* Our core log model object is called `LogEntry` and it is a concrete class with no interfaces. This PR lets that class implement the upstream `LogData` class. In doing this, it made sense to change the individual `spanId` and `traceId` fields to `spanContext`, which also made sense to make the other change....
* Add a new byte field for `traceFlags` into the `ContextAttached` events in order to more accurately reinflate the span context.

Following PRs can migrate usages of `LogEntry` to the interface, and once the direct references are gone we can migrate to the upstream data object.