### PR TITLE
Add filter for jvm internal stack traces

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/StackTraceFilter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/StackTraceFilter.java
@@ -60,8 +60,8 @@ public class StackTraceFilter {
     if (includeAgentInternals) {
       return true;
     }
-    if(Stream.of(StackTraceFilter.UNWANTED_PREFIXES)
-            .anyMatch(prefix -> wallOfStacks.regionMatches(startIndex, prefix, 0, prefix.length()))){
+    if (Stream.of(StackTraceFilter.UNWANTED_PREFIXES)
+        .anyMatch(prefix -> wallOfStacks.regionMatches(startIndex, prefix, 0, prefix.length()))) {
       return false;
     }
 
@@ -77,15 +77,15 @@ public class StackTraceFilter {
   }
 
   private boolean checkFramesInternal(String wallOfStacks, int startOfFrame, int lastIndex) {
-    if(startOfFrame == -1 || (startOfFrame >= lastIndex)){
+    if (startOfFrame == -1 || (startOfFrame >= lastIndex)) {
       // reached the bottom, every item is jvm internal
       return true;
     }
     int nextLine = wallOfStacks.indexOf('\n', startOfFrame) + 1;
-    if(wallOfStacks.regionMatches(startOfFrame, "\t-", 0, 2) ||
-       wallOfStacks.regionMatches(startOfFrame, "\tat java.", 0, 9) ||
-       wallOfStacks.regionMatches(startOfFrame, "\tat jdk.", 0, 8) ||
-       wallOfStacks.regionMatches(startOfFrame, "\tat sun.", 0, 8)) {
+    if (wallOfStacks.regionMatches(startOfFrame, "\t-", 0, 2)
+        || wallOfStacks.regionMatches(startOfFrame, "\tat java.", 0, 9)
+        || wallOfStacks.regionMatches(startOfFrame, "\tat jdk.", 0, 8)
+        || wallOfStacks.regionMatches(startOfFrame, "\tat sun.", 0, 8)) {
       return checkFramesInternal(wallOfStacks, nextLine, lastIndex);
     }
     return false;

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/StackTraceFilter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/StackTraceFilter.java
@@ -60,7 +60,34 @@ public class StackTraceFilter {
     if (includeAgentInternals) {
       return true;
     }
-    return Stream.of(StackTraceFilter.UNWANTED_PREFIXES)
-        .noneMatch(prefix -> wallOfStacks.regionMatches(startIndex, prefix, 0, prefix.length()));
+    if(Stream.of(StackTraceFilter.UNWANTED_PREFIXES)
+            .anyMatch(prefix -> wallOfStacks.regionMatches(startIndex, prefix, 0, prefix.length()))){
+      return false;
+    }
+
+    return !everyFrameIsJvmInternal(wallOfStacks, startIndex, lastIndex);
+  }
+
+  private boolean everyFrameIsJvmInternal(String wallOfStacks, int startIndex, int lastIndex) {
+    int offsetToThreadState = wallOfStacks.indexOf('\n', startIndex) + 1;
+    if (offsetToThreadState <= 0 || offsetToThreadState >= lastIndex) return false;
+    int offsetToFirstFrame = wallOfStacks.indexOf('\n', offsetToThreadState) + 1;
+    if (offsetToFirstFrame <= 0 || offsetToFirstFrame >= lastIndex) return false;
+    return checkFramesInternal(wallOfStacks, offsetToFirstFrame, lastIndex);
+  }
+
+  private boolean checkFramesInternal(String wallOfStacks, int startOfFrame, int lastIndex) {
+    if(startOfFrame == -1 || (startOfFrame >= lastIndex)){
+      // reached the bottom, every item is jvm internal
+      return true;
+    }
+    int nextLine = wallOfStacks.indexOf('\n', startOfFrame) + 1;
+    if(wallOfStacks.regionMatches(startOfFrame, "\t-", 0, 2) ||
+       wallOfStacks.regionMatches(startOfFrame, "\tat java.", 0, 9) ||
+       wallOfStacks.regionMatches(startOfFrame, "\tat jdk.", 0, 8) ||
+       wallOfStacks.regionMatches(startOfFrame, "\tat sun.", 0, 8)) {
+      return checkFramesInternal(wallOfStacks, nextLine, lastIndex);
+    }
+    return false;
   }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
@@ -171,23 +171,4 @@ class StackTraceFilterTest {
     boolean result = filter.test(stack, 0, stack.length() - 1);
     assertFalse(result);
   }
-
-  @Test
-  void testDelme() throws Exception {
-    RecordingFile file = new RecordingFile(Paths.get("/Users/jplumb/code/spring-petclinic-rest", "test-recording.jfr"));
-    StackTraceFilter filter = new StackTraceFilter(false);
-    ThreadDumpToStacks toStacks = new ThreadDumpToStacks(filter);
-    while(file.hasMoreEvents()){
-      RecordedEvent event = file.readEvent();
-      String name = event.getEventType().getName();
-      if(name.equals("jdk.ThreadDump")){
-        String wallOfStacks = event.getString("result");
-        toStacks.toStream(wallOfStacks).forEach(stack -> {
-          boolean xxx = filter.test(stack, 0, stack.length() - 1);
-          System.out.println(xxx);
-          System.out.println(stack);
-        });
-      }
-    }
-  }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
@@ -18,14 +18,7 @@ package com.splunk.opentelemetry.profiler;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import jdk.jfr.consumer.RecordedEvent;
-import jdk.jfr.consumer.RecordingFile;
 import org.junit.jupiter.api.Test;
-
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.stream.Stream;
 
 class StackTraceFilterTest {
 
@@ -155,18 +148,19 @@ class StackTraceFilterTest {
 
   @Test
   void testOmitStacksEntirelyJvmInternal() {
-    String stack = "\"logback-2\" #22 daemon prio=5 os_prio=31 cpu=2.42ms elapsed=563.96s tid=0x00007fd540\n" +
-            "   java.lang.Thread.State: TIMED_WAITING (parking)\n" +
-            "\tat jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)\n" +
-            "\t- parking to wait for  <0x0000000600001920> (a java.util.concurrent.locks.Ab\n" +
-            "\tat java.util.concurrent.locks.LockSupport.parkNanos(java.base@11.0.9.1/LockS\n" +
-            "\tat java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awa\n" +
-            "\tat java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ja\n" +
-            "\tat java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ja\n" +
-            "\tat java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/Thread\n" +
-            "\tat java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/Thre\n" +
-            "\tat java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/Thr\n" +
-            "\tat java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)\n";
+    String stack =
+        "\"logback-2\" #22 daemon prio=5 os_prio=31 cpu=2.42ms elapsed=563.96s tid=0x00007fd540\n"
+            + "   java.lang.Thread.State: TIMED_WAITING (parking)\n"
+            + "\tat jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)\n"
+            + "\t- parking to wait for  <0x0000000600001920> (a java.util.concurrent.locks.Ab\n"
+            + "\tat java.util.concurrent.locks.LockSupport.parkNanos(java.base@11.0.9.1/LockS\n"
+            + "\tat java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awa\n"
+            + "\tat java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ja\n"
+            + "\tat java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ja\n"
+            + "\tat java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/Thread\n"
+            + "\tat java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/Thre\n"
+            + "\tat java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/Thr\n"
+            + "\tat java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)\n";
     StackTraceFilter filter = new StackTraceFilter(false);
     boolean result = filter.test(stack, 0, stack.length() - 1);
     assertFalse(result);

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
@@ -18,7 +18,14 @@ package com.splunk.opentelemetry.profiler;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
 import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Stream;
 
 class StackTraceFilterTest {
 
@@ -144,5 +151,43 @@ class StackTraceFilterTest {
         filter.test(
             wallOfStacks, beforeStack.length() + 1, beforeStack.length() + stack.length() + 2);
     assertTrue(result);
+  }
+
+  @Test
+  void testOmitStacksEntirelyJvmInternal() {
+    String stack = "\"logback-2\" #22 daemon prio=5 os_prio=31 cpu=2.42ms elapsed=563.96s tid=0x00007fd540\n" +
+            "   java.lang.Thread.State: TIMED_WAITING (parking)\n" +
+            "\tat jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)\n" +
+            "\t- parking to wait for  <0x0000000600001920> (a java.util.concurrent.locks.Ab\n" +
+            "\tat java.util.concurrent.locks.LockSupport.parkNanos(java.base@11.0.9.1/LockS\n" +
+            "\tat java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awa\n" +
+            "\tat java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ja\n" +
+            "\tat java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ja\n" +
+            "\tat java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/Thread\n" +
+            "\tat java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/Thre\n" +
+            "\tat java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/Thr\n" +
+            "\tat java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)\n";
+    StackTraceFilter filter = new StackTraceFilter(false);
+    boolean result = filter.test(stack, 0, stack.length() - 1);
+    assertFalse(result);
+  }
+
+  @Test
+  void testDelme() throws Exception {
+    RecordingFile file = new RecordingFile(Paths.get("/Users/jplumb/code/spring-petclinic-rest", "test-recording.jfr"));
+    StackTraceFilter filter = new StackTraceFilter(false);
+    ThreadDumpToStacks toStacks = new ThreadDumpToStacks(filter);
+    while(file.hasMoreEvents()){
+      RecordedEvent event = file.readEvent();
+      String name = event.getEventType().getName();
+      if(name.equals("jdk.ThreadDump")){
+        String wallOfStacks = event.getString("result");
+        toStacks.toStream(wallOfStacks).forEach(stack -> {
+          boolean xxx = filter.test(stack, 0, stack.length() - 1);
+          System.out.println(xxx);
+          System.out.println(stack);
+        });
+      }
+    }
   }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ThreadDumpToStacksTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ThreadDumpToStacksTest.java
@@ -49,7 +49,7 @@ class ThreadDumpToStacksTest {
     ThreadDumpToStacks threadDumpToStacks = new ThreadDumpToStacks(new StackTraceFilter(false));
     Stream<String> resultStream = threadDumpToStacks.toStream(threadDumpResult);
     List<String> result = resultStream.collect(Collectors.toList());
-    assertEquals(40, result.size());
+    assertEquals(28, result.size());
     Stream.of(StackTraceFilter.UNWANTED_PREFIXES)
         .forEach(
             prefix -> {


### PR DESCRIPTION
When profiling with JFR, a good number of call stacks consist entirely of JVM internal frames. The stacks are expensive to ingest and do not offer much value to the profiling user.

There will be follow-up efforts to allow this to be quantified and to allow the user to override this behavior.