### PR TITLE
Add config to include jvm internal stacks

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
@@ -35,8 +35,10 @@ public class Configuration implements ConfigPropertySource {
   public static final String CONFIG_KEY_OTEL_OTLP_URL = "otel.exporter.otlp.endpoint";
   public static final String CONFIG_KEY_PERIOD_PREFIX = "splunk.profiler.period";
   public static final String CONFIG_KEY_TLAB_ENABLED = "splunk.profiler.tlab.enabled";
-  public static final String CONFIG_KEY_INCLUDE_INTERNALS =
+  public static final String CONFIG_KEY_INCLUDE_AGENT_INTERNALS =
       "splunk.profiler.include.agent.internals";
+  public static final String CONFIG_KEY_INCLUDE_JVM_INTERNALS =
+      "splunk.profiler.include.jvm.internals";
 
   @Override
   public Map<String, String> getProperties() {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
@@ -37,6 +37,7 @@ public class Configuration implements ConfigPropertySource {
   public static final String CONFIG_KEY_TLAB_ENABLED = "splunk.profiler.tlab.enabled";
   public static final String CONFIG_KEY_INCLUDE_AGENT_INTERNALS =
       "splunk.profiler.include.agent.internals";
+  // Include stacks where every frame starts with jvm/sun/jdk
   public static final String CONFIG_KEY_INCLUDE_JVM_INTERNALS =
       "splunk.profiler.include.jvm.internals";
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
@@ -17,7 +17,8 @@
 package com.splunk.opentelemetry.profiler;
 
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_ENABLE_PROFILER;
-import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_INCLUDE_INTERNALS;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_INCLUDE_AGENT_INTERNALS;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_INCLUDE_JVM_INTERNALS;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_KEEP_FILES;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PROFILER_DIRECTORY;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_RECORDING_DURATION;
@@ -161,7 +162,9 @@ public class JfrActivator implements AgentListener {
 
   /** May filter out agent internal call stacks based on the config. */
   private StackTraceFilter buildStackTraceFilter(Config config) {
-    return new StackTraceFilter(config.getBoolean(CONFIG_KEY_INCLUDE_INTERNALS, false));
+    boolean includeAgentInternals = config.getBoolean(CONFIG_KEY_INCLUDE_AGENT_INTERNALS, false);
+    boolean includeJVMInternals = config.getBoolean(CONFIG_KEY_INCLUDE_JVM_INTERNALS, false);
+    return new StackTraceFilter(includeAgentInternals, includeJVMInternals);
   }
 
   private Map<String, String> buildJfrSettings(Config config) {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/StackTraceFilter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/StackTraceFilter.java
@@ -34,9 +34,15 @@ public class StackTraceFilter {
         "\"Common-Cleaner\""
       };
   private final boolean includeAgentInternals;
+  private final boolean includeJVMInternals;
 
   public StackTraceFilter(boolean includeAgentInternals) {
+    this(includeAgentInternals, false);
+  }
+
+  public StackTraceFilter(boolean includeAgentInternals, boolean includeJVMInternals) {
     this.includeAgentInternals = includeAgentInternals;
+    this.includeJVMInternals = includeJVMInternals;
   }
 
   public boolean test(String wallOfStacks, int startIndex, int lastIndex) {
@@ -65,6 +71,9 @@ public class StackTraceFilter {
       return false;
     }
 
+    if (includeJVMInternals) {
+      return true;
+    }
     return !everyFrameIsJvmInternal(wallOfStacks, startIndex, lastIndex);
   }
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/StackTraceFilter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/StackTraceFilter.java
@@ -34,15 +34,15 @@ public class StackTraceFilter {
         "\"Common-Cleaner\""
       };
   private final boolean includeAgentInternals;
-  private final boolean includeJVMInternals;
+  private final boolean includeJvmInternals;
 
   public StackTraceFilter(boolean includeAgentInternals) {
     this(includeAgentInternals, false);
   }
 
-  public StackTraceFilter(boolean includeAgentInternals, boolean includeJVMInternals) {
+  public StackTraceFilter(boolean includeAgentInternals, boolean includeJvmInternals) {
     this.includeAgentInternals = includeAgentInternals;
-    this.includeJVMInternals = includeJVMInternals;
+    this.includeJvmInternals = includeJvmInternals;
   }
 
   public boolean test(String wallOfStacks, int startIndex, int lastIndex) {
@@ -71,7 +71,7 @@ public class StackTraceFilter {
       return false;
     }
 
-    if (includeJVMInternals) {
+    if (includeJvmInternals) {
       return true;
     }
     return !everyFrameIsJvmInternal(wallOfStacks, startIndex, lastIndex);

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/StackTraceFilter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/StackTraceFilter.java
@@ -77,6 +77,10 @@ public class StackTraceFilter {
     return !everyFrameIsJvmInternal(wallOfStacks, startIndex, lastIndex);
   }
 
+  /**
+   * Frames are considered JVM internal if every frame in the stack stars with one of "jdk.", "sun."
+   * or "java.".
+   */
   private boolean everyFrameIsJvmInternal(String wallOfStacks, int startIndex, int lastIndex) {
     int offsetToThreadState = wallOfStacks.indexOf('\n', startIndex) + 1;
     if (offsetToThreadState <= 0 || offsetToThreadState >= lastIndex) return false;

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 class StackTraceFilterTest {
 
   public static final String JVM_INTERNAL_STACK =
-      "\"logback-2\" #22 daemon prio=5 os_prio=31 cpu=2.42ms elapsed=563.96s tid=0x00007fd540\n"
+      "\"jvm-internal-magic\" #22 daemon prio=5 os_prio=31 cpu=2.42ms elapsed=563.96s tid=0x00007fd540\n"
           + "   java.lang.Thread.State: TIMED_WAITING (parking)\n"
           + "\tat jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)\n"
           + "\t- parking to wait for  <0x0000000600001920> (a java.util.concurrent.locks.Ab\n"

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
@@ -22,6 +22,20 @@ import org.junit.jupiter.api.Test;
 
 class StackTraceFilterTest {
 
+  public static final String JVM_INTERNAL_STACK =
+      "\"logback-2\" #22 daemon prio=5 os_prio=31 cpu=2.42ms elapsed=563.96s tid=0x00007fd540\n"
+          + "   java.lang.Thread.State: TIMED_WAITING (parking)\n"
+          + "\tat jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)\n"
+          + "\t- parking to wait for  <0x0000000600001920> (a java.util.concurrent.locks.Ab\n"
+          + "\tat java.util.concurrent.locks.LockSupport.parkNanos(java.base@11.0.9.1/LockS\n"
+          + "\tat java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awa\n"
+          + "\tat java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ja\n"
+          + "\tat java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ja\n"
+          + "\tat java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/Thread\n"
+          + "\tat java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/Thre\n"
+          + "\tat java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/Thr\n"
+          + "\tat java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)\n";
+
   @Test
   void oneLiners() {
     StackTraceFilter filter = new StackTraceFilter(false);
@@ -147,22 +161,18 @@ class StackTraceFilterTest {
   }
 
   @Test
-  void testOmitStacksEntirelyJvmInternal() {
-    String stack =
-        "\"logback-2\" #22 daemon prio=5 os_prio=31 cpu=2.42ms elapsed=563.96s tid=0x00007fd540\n"
-            + "   java.lang.Thread.State: TIMED_WAITING (parking)\n"
-            + "\tat jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)\n"
-            + "\t- parking to wait for  <0x0000000600001920> (a java.util.concurrent.locks.Ab\n"
-            + "\tat java.util.concurrent.locks.LockSupport.parkNanos(java.base@11.0.9.1/LockS\n"
-            + "\tat java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awa\n"
-            + "\tat java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ja\n"
-            + "\tat java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ja\n"
-            + "\tat java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.9.1/Thread\n"
-            + "\tat java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/Thre\n"
-            + "\tat java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/Thr\n"
-            + "\tat java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)\n";
+  void omitStacksEntirelyJvmInternal() {
+    String stack = JVM_INTERNAL_STACK;
     StackTraceFilter filter = new StackTraceFilter(false);
     boolean result = filter.test(stack, 0, stack.length() - 1);
     assertFalse(result);
+  }
+
+  @Test
+  void canIncludeJvmInternalStacks() {
+    String stack = JVM_INTERNAL_STACK;
+    StackTraceFilter filter = new StackTraceFilter(false, true);
+    boolean result = filter.test(stack, 0, stack.length() - 1);
+    assertTrue(result);
   }
 }


### PR DESCRIPTION
We need a config item here so that we can compare data volume and overhead with/without jvm internal stacks.