### PR TITLE
Add profiler memory.enabled option

### DIFF
--- a/profiler/README.md
+++ b/profiler/README.md
@@ -49,7 +49,8 @@ property or as environment variables (by making them uppercase and replacing dot
 |`splunk.profiler.keep-files`              | false                  | leave JFR files on disk id `true`         |
 |`splunk.profiler.logs-endpoint`           | `otel.exporter.otlp.endpoint` or http://localhost:4317  | where to send OTLP logs                   |
 |`splunk.profiler.period.{eventName}`      | n/a                    | customize period (in ms) for a specific jfr event. For example, to set the ThreadDump frequency to 1s (1000ms): `-Dsplunk.profiler.period.threaddump=1000` |
-|`splunk.profiler.tlab.enabled`            | false                  | set to `false` to disable TLAB memory events |
+|`splunk.profiler.memory.enabled`          | false                  | set to `true` to enable all other memory profiling options unless explicitly disabled |
+|`splunk.profiler.tlab.enabled`            | `splunk.profiler.memory.enabled` | set to `true` to enable TLAB events even if `splunk.profiler.memory.enabled` is `false` |
 |`splunk.profiler.include.agent.internals` | false                  | set to `true` to include agent internal call stacks |
 
 # Escape hatch

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
@@ -50,7 +50,6 @@ public class Configuration implements ConfigPropertySource {
     config.put(CONFIG_KEY_RECORDING_DURATION, DEFAULT_RECORDING_DURATION);
     config.put(CONFIG_KEY_KEEP_FILES, "false");
     config.put(CONFIG_KEY_MEMORY_ENABLED, "false");
-    config.put(CONFIG_KEY_TLAB_ENABLED, "false");
     return config;
   }
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
@@ -34,6 +34,7 @@ public class Configuration implements ConfigPropertySource {
   public static final String CONFIG_KEY_INGEST_URL = "splunk.profiler.logs-endpoint";
   public static final String CONFIG_KEY_OTEL_OTLP_URL = "otel.exporter.otlp.endpoint";
   public static final String CONFIG_KEY_PERIOD_PREFIX = "splunk.profiler.period";
+  public static final String CONFIG_KEY_MEMORY_ENABLED = "splunk.profiler.memory.enabled";
   public static final String CONFIG_KEY_TLAB_ENABLED = "splunk.profiler.tlab.enabled";
   public static final String CONFIG_KEY_INCLUDE_AGENT_INTERNALS =
       "splunk.profiler.include.agent.internals";
@@ -48,6 +49,7 @@ public class Configuration implements ConfigPropertySource {
     config.put(CONFIG_KEY_PROFILER_DIRECTORY, ".");
     config.put(CONFIG_KEY_RECORDING_DURATION, DEFAULT_RECORDING_DURATION);
     config.put(CONFIG_KEY_KEEP_FILES, "false");
+    config.put(CONFIG_KEY_MEMORY_ENABLED, "false");
     config.put(CONFIG_KEY_TLAB_ENABLED, "false");
     return config;
   }
@@ -58,5 +60,13 @@ public class Configuration implements ConfigPropertySource {
       return config.getString(CONFIG_KEY_OTEL_OTLP_URL);
     }
     return ingestUrl;
+  }
+
+  public static boolean getTLABEnabled(Config config) {
+    Boolean enabled = config.getBoolean(CONFIG_KEY_TLAB_ENABLED);
+    if (enabled == null) {
+      return config.getBoolean(CONFIG_KEY_MEMORY_ENABLED, false);
+    }
+    return enabled;
   }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
@@ -26,6 +26,7 @@ import java.util.Map;
 public class Configuration implements ConfigPropertySource {
 
   private static final String DEFAULT_RECORDING_DURATION = "20s";
+  public static final boolean DEFAULT_MEMORY_ENABLED = false;
 
   public static final String CONFIG_KEY_ENABLE_PROFILER = "splunk.profiler.enabled";
   public static final String CONFIG_KEY_PROFILER_DIRECTORY = "splunk.profiler.directory";
@@ -49,23 +50,17 @@ public class Configuration implements ConfigPropertySource {
     config.put(CONFIG_KEY_PROFILER_DIRECTORY, ".");
     config.put(CONFIG_KEY_RECORDING_DURATION, DEFAULT_RECORDING_DURATION);
     config.put(CONFIG_KEY_KEEP_FILES, "false");
-    config.put(CONFIG_KEY_MEMORY_ENABLED, "false");
+    config.put(CONFIG_KEY_MEMORY_ENABLED, String.valueOf(DEFAULT_MEMORY_ENABLED));
     return config;
   }
 
   public static String getConfigUrl(Config config) {
-    String ingestUrl = config.getString(CONFIG_KEY_INGEST_URL);
-    if (ingestUrl == null) {
-      return config.getString(CONFIG_KEY_OTEL_OTLP_URL);
-    }
-    return ingestUrl;
+    String ingestUrl = config.getString(CONFIG_KEY_OTEL_OTLP_URL, null);
+    return config.getString(CONFIG_KEY_INGEST_URL, ingestUrl);
   }
 
   public static boolean getTLABEnabled(Config config) {
-    Boolean enabled = config.getBoolean(CONFIG_KEY_TLAB_ENABLED);
-    if (enabled == null) {
-      return config.getBoolean(CONFIG_KEY_MEMORY_ENABLED, false);
-    }
-    return enabled;
+    boolean memoryEnabled = config.getBoolean(CONFIG_KEY_MEMORY_ENABLED, DEFAULT_MEMORY_ENABLED);
+    return config.getBoolean(CONFIG_KEY_TLAB_ENABLED, memoryEnabled);
   }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/ConfigurationLogger.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/ConfigurationLogger.java
@@ -25,6 +25,7 @@ import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PERIOD_
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PROFILER_DIRECTORY;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_RECORDING_DURATION;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_TLAB_ENABLED;
+import static com.splunk.opentelemetry.profiler.Configuration.DEFAULT_MEMORY_ENABLED;
 
 import io.opentelemetry.instrumentation.api.config.Config;
 import java.util.function.Function;
@@ -44,8 +45,8 @@ public class ConfigurationLogger {
     log(CONFIG_KEY_RECORDING_DURATION, config::getString);
     log(CONFIG_KEY_KEEP_FILES, config::getBoolean);
     log(CONFIG_KEY_INGEST_URL, (it) -> Configuration.getConfigUrl(config));
-    log(CONFIG_KEY_OTEL_OTLP_URL, config::getString);
-    log(CONFIG_KEY_MEMORY_ENABLED, config::getBoolean);
+    log(CONFIG_KEY_OTEL_OTLP_URL, (it) -> config.getString(it, null));
+    log(CONFIG_KEY_MEMORY_ENABLED, (it) -> config.getBoolean(it, DEFAULT_MEMORY_ENABLED));
     log(CONFIG_KEY_TLAB_ENABLED, (it) -> Configuration.getTLABEnabled(config));
     log(CONFIG_KEY_PERIOD_PREFIX + "." + "threaddump", config::getDuration);
     logger.info("-----------------------");

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/ConfigurationLogger.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/ConfigurationLogger.java
@@ -19,6 +19,7 @@ package com.splunk.opentelemetry.profiler;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_ENABLE_PROFILER;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_INGEST_URL;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_KEEP_FILES;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_MEMORY_ENABLED;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_OTEL_OTLP_URL;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PERIOD_PREFIX;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PROFILER_DIRECTORY;
@@ -42,9 +43,10 @@ public class ConfigurationLogger {
     log(CONFIG_KEY_PROFILER_DIRECTORY, config::getString);
     log(CONFIG_KEY_RECORDING_DURATION, config::getString);
     log(CONFIG_KEY_KEEP_FILES, config::getBoolean);
-    log(CONFIG_KEY_INGEST_URL, config::getString);
+    log(CONFIG_KEY_INGEST_URL, (it) -> Configuration.getConfigUrl(config));
     log(CONFIG_KEY_OTEL_OTLP_URL, config::getString);
-    log(CONFIG_KEY_TLAB_ENABLED, config::getBoolean);
+    log(CONFIG_KEY_MEMORY_ENABLED, config::getBoolean);
+    log(CONFIG_KEY_TLAB_ENABLED, (it) -> Configuration.getTLABEnabled(config));
     log(CONFIG_KEY_PERIOD_PREFIX + "." + "threaddump", config::getDuration);
     logger.info("-----------------------");
   }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrSettingsOverrides.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrSettingsOverrides.java
@@ -17,7 +17,6 @@
 package com.splunk.opentelemetry.profiler;
 
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PERIOD_PREFIX;
-import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_TLAB_ENABLED;
 
 import io.opentelemetry.instrumentation.api.config.Config;
 import java.util.HashMap;
@@ -61,7 +60,7 @@ class JfrSettingsOverrides {
   }
 
   private Map<String, String> maybeEnableTLABs(Map<String, String> settings) {
-    if (config.getBoolean(CONFIG_KEY_TLAB_ENABLED, false)) {
+    if (Configuration.getTLABEnabled(config)) {
       settings.put("jdk.ObjectAllocationInNewTLAB#enabled", "true");
       settings.put("jdk.ObjectAllocationOutsideTLAB#enabled", "true");
     }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/TLABProcessor.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/TLABProcessor.java
@@ -16,7 +16,6 @@
 
 package com.splunk.opentelemetry.profiler;
 
-import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_TLAB_ENABLED;
 import static com.splunk.opentelemetry.profiler.LogDataCreator.PROFILING_SOURCE;
 import static com.splunk.opentelemetry.profiler.LogsExporterBuilder.INSTRUMENTATION_LIBRARY_INFO;
 
@@ -89,7 +88,7 @@ public class TLABProcessor implements Consumer<RecordedEvent> {
   }
 
   static Builder builder(Config config) {
-    boolean enabled = config.getBoolean(CONFIG_KEY_TLAB_ENABLED, false);
+    boolean enabled = Configuration.getTLABEnabled(config);
     return new Builder(enabled);
   }
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/events/RelevantEvents.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/events/RelevantEvents.java
@@ -36,7 +36,7 @@ public class RelevantEvents {
   public static RelevantEvents create(Config config) {
     Set<String> eventNames =
         new HashSet<>(Arrays.asList(ThreadDumpProcessor.EVENT_NAME, ContextAttached.EVENT_NAME));
-    if (config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED, false)) {
+    if (Configuration.getTLABEnabled(config)) {
       eventNames.add(TLABProcessor.NEW_TLAB_EVENT_NAME);
       eventNames.add(TLABProcessor.OUTSIDE_TLAB_EVENT_NAME);
     }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationLoggerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationLoggerTest.java
@@ -19,6 +19,7 @@ package com.splunk.opentelemetry.profiler;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_ENABLE_PROFILER;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_INGEST_URL;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_KEEP_FILES;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_MEMORY_ENABLED;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_OTEL_OTLP_URL;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PERIOD_PREFIX;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PROFILER_DIRECTORY;
@@ -48,6 +49,7 @@ class ConfigurationLoggerTest {
     when(config.getBoolean(CONFIG_KEY_KEEP_FILES)).thenReturn(true);
     when(config.getString(CONFIG_KEY_INGEST_URL)).thenReturn("http://example.com");
     when(config.getString(CONFIG_KEY_OTEL_OTLP_URL)).thenReturn("http://otel.example.com");
+    when(config.getBoolean(CONFIG_KEY_MEMORY_ENABLED)).thenReturn(false);
     when(config.getBoolean(CONFIG_KEY_TLAB_ENABLED)).thenReturn(false);
     when(config.getDuration(CONFIG_KEY_PERIOD_PREFIX + ".threaddump"))
         .thenReturn(Duration.ofMillis(500));
@@ -64,7 +66,41 @@ class ConfigurationLoggerTest {
     log.assertContains("             splunk.profiler.keep-files : true");
     log.assertContains("          splunk.profiler.logs-endpoint : http://example.com");
     log.assertContains("            otel.exporter.otlp.endpoint : http://otel.example.com");
+    log.assertContains("         splunk.profiler.memory.enabled : false");
     log.assertContains("           splunk.profiler.tlab.enabled : false");
+    log.assertContains("      splunk.profiler.period.threaddump : PT0.5S");
+  }
+
+  @Test
+  void testLogInheritDefaultValues() {
+    Config config = mock(Config.class);
+
+    when(config.getBoolean(CONFIG_KEY_ENABLE_PROFILER)).thenReturn(true);
+    when(config.getString(CONFIG_KEY_PROFILER_DIRECTORY)).thenReturn("somedir");
+    when(config.getString(CONFIG_KEY_RECORDING_DURATION)).thenReturn("33m");
+    when(config.getBoolean(CONFIG_KEY_KEEP_FILES)).thenReturn(true);
+    when(config.getString(CONFIG_KEY_INGEST_URL)).thenReturn(null);
+    when(config.getString(CONFIG_KEY_OTEL_OTLP_URL)).thenReturn("http://otel.example.com");
+    when(config.getBoolean(CONFIG_KEY_MEMORY_ENABLED)).thenReturn(true);
+    when(config.getBoolean(CONFIG_KEY_MEMORY_ENABLED, false)).thenReturn(true);
+    when(config.getBoolean(CONFIG_KEY_TLAB_ENABLED)).thenReturn(null);
+    when(config.getDuration(CONFIG_KEY_PERIOD_PREFIX + ".threaddump"))
+        .thenReturn(Duration.ofMillis(500));
+
+    ConfigurationLogger configurationLogger = new ConfigurationLogger();
+
+    configurationLogger.log(config);
+
+    log.assertContains("-----------------------");
+    log.assertContains("Profiler configuration:");
+    log.assertContains("                splunk.profiler.enabled : true");
+    log.assertContains("              splunk.profiler.directory : somedir");
+    log.assertContains("     splunk.profiler.recording.duration : 33m");
+    log.assertContains("             splunk.profiler.keep-files : true");
+    log.assertContains("          splunk.profiler.logs-endpoint : http://otel.example.com");
+    log.assertContains("            otel.exporter.otlp.endpoint : http://otel.example.com");
+    log.assertContains("         splunk.profiler.memory.enabled : true");
+    log.assertContains("           splunk.profiler.tlab.enabled : true");
     log.assertContains("      splunk.profiler.period.threaddump : PT0.5S");
   }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationLoggerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationLoggerTest.java
@@ -49,7 +49,8 @@ class ConfigurationLoggerTest {
     when(config.getString(CONFIG_KEY_RECORDING_DURATION)).thenReturn("33m");
     when(config.getBoolean(CONFIG_KEY_KEEP_FILES)).thenReturn(true);
     when(config.getString(CONFIG_KEY_OTEL_OTLP_URL, null)).thenReturn("http://otel.example.com");
-    when(config.getString(CONFIG_KEY_INGEST_URL, "http://otel.example.com")).thenReturn("http://example.com");
+    when(config.getString(CONFIG_KEY_INGEST_URL, "http://otel.example.com"))
+        .thenReturn("http://example.com");
     when(config.getBoolean(CONFIG_KEY_MEMORY_ENABLED, DEFAULT_MEMORY_ENABLED)).thenReturn(false);
     when(config.getBoolean(CONFIG_KEY_TLAB_ENABLED, false)).thenReturn(true);
     when(config.getDuration(CONFIG_KEY_PERIOD_PREFIX + ".threaddump"))

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationLoggerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationLoggerTest.java
@@ -75,32 +75,19 @@ class ConfigurationLoggerTest {
   void testLogInheritDefaultValues() {
     Config config = mock(Config.class);
 
-    when(config.getBoolean(CONFIG_KEY_ENABLE_PROFILER)).thenReturn(true);
-    when(config.getString(CONFIG_KEY_PROFILER_DIRECTORY)).thenReturn("somedir");
-    when(config.getString(CONFIG_KEY_RECORDING_DURATION)).thenReturn("33m");
-    when(config.getBoolean(CONFIG_KEY_KEEP_FILES)).thenReturn(true);
     when(config.getString(CONFIG_KEY_INGEST_URL)).thenReturn(null);
     when(config.getString(CONFIG_KEY_OTEL_OTLP_URL)).thenReturn("http://otel.example.com");
     when(config.getBoolean(CONFIG_KEY_MEMORY_ENABLED)).thenReturn(true);
     when(config.getBoolean(CONFIG_KEY_MEMORY_ENABLED, false)).thenReturn(true);
     when(config.getBoolean(CONFIG_KEY_TLAB_ENABLED)).thenReturn(null);
-    when(config.getDuration(CONFIG_KEY_PERIOD_PREFIX + ".threaddump"))
-        .thenReturn(Duration.ofMillis(500));
 
     ConfigurationLogger configurationLogger = new ConfigurationLogger();
 
     configurationLogger.log(config);
 
-    log.assertContains("-----------------------");
-    log.assertContains("Profiler configuration:");
-    log.assertContains("                splunk.profiler.enabled : true");
-    log.assertContains("              splunk.profiler.directory : somedir");
-    log.assertContains("     splunk.profiler.recording.duration : 33m");
-    log.assertContains("             splunk.profiler.keep-files : true");
     log.assertContains("          splunk.profiler.logs-endpoint : http://otel.example.com");
     log.assertContains("            otel.exporter.otlp.endpoint : http://otel.example.com");
     log.assertContains("         splunk.profiler.memory.enabled : true");
     log.assertContains("           splunk.profiler.tlab.enabled : true");
-    log.assertContains("      splunk.profiler.period.threaddump : PT0.5S");
   }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationLoggerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationLoggerTest.java
@@ -25,6 +25,7 @@ import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PERIOD_
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PROFILER_DIRECTORY;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_RECORDING_DURATION;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_TLAB_ENABLED;
+import static com.splunk.opentelemetry.profiler.Configuration.DEFAULT_MEMORY_ENABLED;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -47,10 +48,10 @@ class ConfigurationLoggerTest {
     when(config.getString(CONFIG_KEY_PROFILER_DIRECTORY)).thenReturn("somedir");
     when(config.getString(CONFIG_KEY_RECORDING_DURATION)).thenReturn("33m");
     when(config.getBoolean(CONFIG_KEY_KEEP_FILES)).thenReturn(true);
-    when(config.getString(CONFIG_KEY_INGEST_URL)).thenReturn("http://example.com");
-    when(config.getString(CONFIG_KEY_OTEL_OTLP_URL)).thenReturn("http://otel.example.com");
-    when(config.getBoolean(CONFIG_KEY_MEMORY_ENABLED)).thenReturn(false);
-    when(config.getBoolean(CONFIG_KEY_TLAB_ENABLED)).thenReturn(false);
+    when(config.getString(CONFIG_KEY_OTEL_OTLP_URL, null)).thenReturn("http://otel.example.com");
+    when(config.getString(CONFIG_KEY_INGEST_URL, "http://otel.example.com")).thenReturn("http://example.com");
+    when(config.getBoolean(CONFIG_KEY_MEMORY_ENABLED, DEFAULT_MEMORY_ENABLED)).thenReturn(false);
+    when(config.getBoolean(CONFIG_KEY_TLAB_ENABLED, false)).thenReturn(true);
     when(config.getDuration(CONFIG_KEY_PERIOD_PREFIX + ".threaddump"))
         .thenReturn(Duration.ofMillis(500));
 
@@ -67,7 +68,7 @@ class ConfigurationLoggerTest {
     log.assertContains("          splunk.profiler.logs-endpoint : http://example.com");
     log.assertContains("            otel.exporter.otlp.endpoint : http://otel.example.com");
     log.assertContains("         splunk.profiler.memory.enabled : false");
-    log.assertContains("           splunk.profiler.tlab.enabled : false");
+    log.assertContains("           splunk.profiler.tlab.enabled : true");
     log.assertContains("      splunk.profiler.period.threaddump : PT0.5S");
   }
 
@@ -75,11 +76,11 @@ class ConfigurationLoggerTest {
   void testLogInheritDefaultValues() {
     Config config = mock(Config.class);
 
-    when(config.getString(CONFIG_KEY_INGEST_URL)).thenReturn(null);
-    when(config.getString(CONFIG_KEY_OTEL_OTLP_URL)).thenReturn("http://otel.example.com");
-    when(config.getBoolean(CONFIG_KEY_MEMORY_ENABLED)).thenReturn(true);
-    when(config.getBoolean(CONFIG_KEY_MEMORY_ENABLED, false)).thenReturn(true);
-    when(config.getBoolean(CONFIG_KEY_TLAB_ENABLED)).thenReturn(null);
+    String inheritedUrl = "http://otel.example.com";
+    when(config.getString(CONFIG_KEY_OTEL_OTLP_URL, null)).thenReturn(inheritedUrl);
+    when(config.getString(CONFIG_KEY_INGEST_URL, inheritedUrl)).thenReturn(inheritedUrl);
+    when(config.getBoolean(CONFIG_KEY_MEMORY_ENABLED, DEFAULT_MEMORY_ENABLED)).thenReturn(true);
+    when(config.getBoolean(CONFIG_KEY_TLAB_ENABLED, true)).thenReturn(false);
 
     ConfigurationLogger configurationLogger = new ConfigurationLogger();
 
@@ -88,6 +89,6 @@ class ConfigurationLoggerTest {
     log.assertContains("          splunk.profiler.logs-endpoint : http://otel.example.com");
     log.assertContains("            otel.exporter.otlp.endpoint : http://otel.example.com");
     log.assertContains("         splunk.profiler.memory.enabled : true");
-    log.assertContains("           splunk.profiler.tlab.enabled : true");
+    log.assertContains("           splunk.profiler.tlab.enabled : false");
   }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationTest.java
@@ -54,4 +54,31 @@ class ConfigurationTest {
     String result = Configuration.getConfigUrl(config);
     assertNull(result);
   }
+
+  @Test
+  void getTLABEnabled_override() {
+    Config config = mock(Config.class);
+    when(config.getBoolean(Configuration.CONFIG_KEY_MEMORY_ENABLED, false)).thenReturn(false);
+    when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED)).thenReturn(true);
+    boolean result = Configuration.getTLABEnabled(config);
+    assertTrue(result);
+  }
+
+  @Test
+  void getTLABEnabled_inheritedTrue() {
+    Config config = mock(Config.class);
+    when(config.getBoolean(Configuration.CONFIG_KEY_MEMORY_ENABLED, false)).thenReturn(true);
+    when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED)).thenReturn(null);
+    boolean result = Configuration.getTLABEnabled(config);
+    assertTrue(result);
+  }
+
+  @Test
+  void getTLABEnabled_inheritedFalse() {
+    Config config = mock(Config.class);
+    when(config.getBoolean(Configuration.CONFIG_KEY_MEMORY_ENABLED, false)).thenReturn(false);
+    when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED)).thenReturn(null);
+    boolean result = Configuration.getTLABEnabled(config);
+    assertFalse(result);
+  }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationTest.java
@@ -16,12 +16,15 @@
 
 package com.splunk.opentelemetry.profiler;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import io.opentelemetry.instrumentation.api.config.Config;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class ConfigurationTest {
 
@@ -31,8 +34,8 @@ class ConfigurationTest {
   @Test
   void getConfigUrl_endpointDefined() {
     Config config = mock(Config.class);
-    when(config.getString(Configuration.CONFIG_KEY_INGEST_URL)).thenReturn(logsEndpoint);
-    when(config.getString(Configuration.CONFIG_KEY_OTEL_OTLP_URL)).thenReturn(otelEndpoint);
+    when(config.getString(Configuration.CONFIG_KEY_OTEL_OTLP_URL, null)).thenReturn(otelEndpoint);
+    when(config.getString(Configuration.CONFIG_KEY_INGEST_URL, otelEndpoint)).thenReturn(logsEndpoint);
     String result = Configuration.getConfigUrl(config);
     assertEquals(result, logsEndpoint);
   }
@@ -40,8 +43,8 @@ class ConfigurationTest {
   @Test
   void getConfigUrl_endpointNotDefined() {
     Config config = mock(Config.class);
-    when(config.getString(Configuration.CONFIG_KEY_INGEST_URL)).thenReturn(null);
-    when(config.getString(Configuration.CONFIG_KEY_OTEL_OTLP_URL)).thenReturn(otelEndpoint);
+    when(config.getString(Configuration.CONFIG_KEY_OTEL_OTLP_URL, null)).thenReturn(otelEndpoint);
+    when(config.getString(Configuration.CONFIG_KEY_INGEST_URL, otelEndpoint)).thenReturn(otelEndpoint);
     String result = Configuration.getConfigUrl(config);
     assertEquals(result, otelEndpoint);
   }
@@ -49,8 +52,8 @@ class ConfigurationTest {
   @Test
   void getConfigUrlNull() {
     Config config = mock(Config.class);
-    when(config.getString(Configuration.CONFIG_KEY_INGEST_URL)).thenReturn(null);
-    when(config.getString(Configuration.CONFIG_KEY_OTEL_OTLP_URL)).thenReturn(null);
+    when(config.getString(Configuration.CONFIG_KEY_OTEL_OTLP_URL, null)).thenReturn(null);
+    when(config.getString(Configuration.CONFIG_KEY_INGEST_URL, null)).thenReturn(null);
     String result = Configuration.getConfigUrl(config);
     assertNull(result);
   }
@@ -58,8 +61,9 @@ class ConfigurationTest {
   @Test
   void getTLABEnabled_override() {
     Config config = mock(Config.class);
-    when(config.getBoolean(Configuration.CONFIG_KEY_MEMORY_ENABLED, false)).thenReturn(false);
-    when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED)).thenReturn(true);
+    when(config.getBoolean(Configuration.CONFIG_KEY_MEMORY_ENABLED, Configuration.DEFAULT_MEMORY_ENABLED))
+        .thenReturn(false);
+    when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED, false)).thenReturn(true);
     boolean result = Configuration.getTLABEnabled(config);
     assertTrue(result);
   }
@@ -67,8 +71,9 @@ class ConfigurationTest {
   @Test
   void getTLABEnabled_inheritedTrue() {
     Config config = mock(Config.class);
-    when(config.getBoolean(Configuration.CONFIG_KEY_MEMORY_ENABLED, false)).thenReturn(true);
-    when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED)).thenReturn(null);
+    when(config.getBoolean(Configuration.CONFIG_KEY_MEMORY_ENABLED, Configuration.DEFAULT_MEMORY_ENABLED))
+        .thenReturn(true);
+    when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED, true)).thenReturn(true);
     boolean result = Configuration.getTLABEnabled(config);
     assertTrue(result);
   }
@@ -76,8 +81,9 @@ class ConfigurationTest {
   @Test
   void getTLABEnabled_inheritedFalse() {
     Config config = mock(Config.class);
-    when(config.getBoolean(Configuration.CONFIG_KEY_MEMORY_ENABLED, false)).thenReturn(false);
-    when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED)).thenReturn(null);
+    when(config.getBoolean(Configuration.CONFIG_KEY_MEMORY_ENABLED, Configuration.DEFAULT_MEMORY_ENABLED))
+        .thenReturn(false);
+    when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED, false)).thenReturn(false);
     boolean result = Configuration.getTLABEnabled(config);
     assertFalse(result);
   }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationTest.java
@@ -16,15 +16,15 @@
 
 package com.splunk.opentelemetry.profiler;
 
-import io.opentelemetry.instrumentation.api.config.Config;
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import io.opentelemetry.instrumentation.api.config.Config;
+import org.junit.jupiter.api.Test;
 
 class ConfigurationTest {
 
@@ -35,7 +35,8 @@ class ConfigurationTest {
   void getConfigUrl_endpointDefined() {
     Config config = mock(Config.class);
     when(config.getString(Configuration.CONFIG_KEY_OTEL_OTLP_URL, null)).thenReturn(otelEndpoint);
-    when(config.getString(Configuration.CONFIG_KEY_INGEST_URL, otelEndpoint)).thenReturn(logsEndpoint);
+    when(config.getString(Configuration.CONFIG_KEY_INGEST_URL, otelEndpoint))
+        .thenReturn(logsEndpoint);
     String result = Configuration.getConfigUrl(config);
     assertEquals(result, logsEndpoint);
   }
@@ -44,7 +45,8 @@ class ConfigurationTest {
   void getConfigUrl_endpointNotDefined() {
     Config config = mock(Config.class);
     when(config.getString(Configuration.CONFIG_KEY_OTEL_OTLP_URL, null)).thenReturn(otelEndpoint);
-    when(config.getString(Configuration.CONFIG_KEY_INGEST_URL, otelEndpoint)).thenReturn(otelEndpoint);
+    when(config.getString(Configuration.CONFIG_KEY_INGEST_URL, otelEndpoint))
+        .thenReturn(otelEndpoint);
     String result = Configuration.getConfigUrl(config);
     assertEquals(result, otelEndpoint);
   }
@@ -61,7 +63,8 @@ class ConfigurationTest {
   @Test
   void getTLABEnabled_override() {
     Config config = mock(Config.class);
-    when(config.getBoolean(Configuration.CONFIG_KEY_MEMORY_ENABLED, Configuration.DEFAULT_MEMORY_ENABLED))
+    when(config.getBoolean(
+            Configuration.CONFIG_KEY_MEMORY_ENABLED, Configuration.DEFAULT_MEMORY_ENABLED))
         .thenReturn(false);
     when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED, false)).thenReturn(true);
     boolean result = Configuration.getTLABEnabled(config);
@@ -71,7 +74,8 @@ class ConfigurationTest {
   @Test
   void getTLABEnabled_inheritedTrue() {
     Config config = mock(Config.class);
-    when(config.getBoolean(Configuration.CONFIG_KEY_MEMORY_ENABLED, Configuration.DEFAULT_MEMORY_ENABLED))
+    when(config.getBoolean(
+            Configuration.CONFIG_KEY_MEMORY_ENABLED, Configuration.DEFAULT_MEMORY_ENABLED))
         .thenReturn(true);
     when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED, true)).thenReturn(true);
     boolean result = Configuration.getTLABEnabled(config);
@@ -81,7 +85,8 @@ class ConfigurationTest {
   @Test
   void getTLABEnabled_inheritedFalse() {
     Config config = mock(Config.class);
-    when(config.getBoolean(Configuration.CONFIG_KEY_MEMORY_ENABLED, Configuration.DEFAULT_MEMORY_ENABLED))
+    when(config.getBoolean(
+            Configuration.CONFIG_KEY_MEMORY_ENABLED, Configuration.DEFAULT_MEMORY_ENABLED))
         .thenReturn(false);
     when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED, false)).thenReturn(false);
     boolean result = Configuration.getTLABEnabled(config);

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/LogsExporterBuilderTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/LogsExporterBuilderTest.java
@@ -41,24 +41,14 @@ class LogsExporterBuilderTest {
   @Test
   void testCustomEndpoint() {
     Config config = mock(Config.class);
-    when(config.getString(Configuration.CONFIG_KEY_INGEST_URL))
+    when(config.getString(Configuration.CONFIG_KEY_OTEL_OTLP_URL, null))
+        .thenReturn("http://shadowed.example.com:9122/");
+    when(config.getString(Configuration.CONFIG_KEY_INGEST_URL, "http://shadowed.example.com:9122/"))
         .thenReturn("http://example.com:9122/");
     OtlpLogsExporter exporter =
         (OtlpLogsExporter) LogsExporterBuilder.fromConfig(config, Resource.empty());
     String endpoint = exporter.getEndpoint();
     assertEquals("example.com:9122", endpoint);
-    assertNotNull(exporter.getAdapter());
-  }
-
-  @Test
-  void defaultEndpoint() {
-    Config config = mock(Config.class);
-    when(config.getString(Configuration.CONFIG_KEY_OTEL_OTLP_URL))
-        .thenReturn("http://mycollector.com:4312/");
-    OtlpLogsExporter exporter =
-        (OtlpLogsExporter) LogsExporterBuilder.fromConfig(config, Resource.empty());
-    String endpoint = exporter.getEndpoint();
-    assertEquals("mycollector.com:4312", endpoint);
     assertNotNull(exporter.getAdapter());
   }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/TLABProcessorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/TLABProcessorTest.java
@@ -17,6 +17,7 @@
 package com.splunk.opentelemetry.profiler;
 
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_TLAB_ENABLED;
+import static com.splunk.opentelemetry.profiler.Configuration.DEFAULT_MEMORY_ENABLED;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SOURCE_EVENT_NAME;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SOURCE_TYPE;
 import static com.splunk.opentelemetry.profiler.TLABProcessor.ALLOCATION_SIZE_KEY;
@@ -59,7 +60,7 @@ class TLABProcessorTest {
     when(event.getStackTrace()).thenReturn(null); // just to be explicit
 
     Config config = mock(Config.class);
-    when(config.getBoolean(CONFIG_KEY_TLAB_ENABLED)).thenReturn(true);
+    when(config.getBoolean(CONFIG_KEY_TLAB_ENABLED, DEFAULT_MEMORY_ENABLED)).thenReturn(true);
 
     TLABProcessor processor = TLABProcessor.builder(config).build();
     processor.accept(event);
@@ -80,7 +81,7 @@ class TLABProcessorTest {
             });
 
     Config config = mock(Config.class);
-    when(config.getBoolean(CONFIG_KEY_TLAB_ENABLED)).thenReturn(false);
+    when(config.getBoolean(CONFIG_KEY_TLAB_ENABLED, DEFAULT_MEMORY_ENABLED)).thenReturn(false);
 
     TLABProcessor processor = TLABProcessor.builder(config).build();
     processor.accept(event);
@@ -119,7 +120,7 @@ class TLABProcessorTest {
     when(serializer.serialize(stack)).thenReturn(stackAsString);
 
     Config config = mock(Config.class);
-    when(config.getBoolean(CONFIG_KEY_TLAB_ENABLED)).thenReturn(true);
+    when(config.getBoolean(CONFIG_KEY_TLAB_ENABLED, DEFAULT_MEMORY_ENABLED)).thenReturn(true);
 
     TLABProcessor processor =
         TLABProcessor.builder(config)

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/TLABProcessorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/TLABProcessorTest.java
@@ -59,7 +59,7 @@ class TLABProcessorTest {
     when(event.getStackTrace()).thenReturn(null); // just to be explicit
 
     Config config = mock(Config.class);
-    when(config.getBoolean(CONFIG_KEY_TLAB_ENABLED, false)).thenReturn(true);
+    when(config.getBoolean(CONFIG_KEY_TLAB_ENABLED)).thenReturn(true);
 
     TLABProcessor processor = TLABProcessor.builder(config).build();
     processor.accept(event);
@@ -80,7 +80,7 @@ class TLABProcessorTest {
             });
 
     Config config = mock(Config.class);
-    when(config.getBoolean(CONFIG_KEY_TLAB_ENABLED, false)).thenReturn(false);
+    when(config.getBoolean(CONFIG_KEY_TLAB_ENABLED)).thenReturn(false);
 
     TLABProcessor processor = TLABProcessor.builder(config).build();
     processor.accept(event);
@@ -119,7 +119,7 @@ class TLABProcessorTest {
     when(serializer.serialize(stack)).thenReturn(stackAsString);
 
     Config config = mock(Config.class);
-    when(config.getBoolean(CONFIG_KEY_TLAB_ENABLED, false)).thenReturn(true);
+    when(config.getBoolean(CONFIG_KEY_TLAB_ENABLED)).thenReturn(true);
 
     TLABProcessor processor =
         TLABProcessor.builder(config)

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/events/RelevantEventsTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/events/RelevantEventsTest.java
@@ -54,7 +54,8 @@ class RelevantEventsTest {
   @Test
   void testTlabEnabled() {
     Config config = mock(Config.class);
-    when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED, Configuration.DEFAULT_MEMORY_ENABLED))
+    when(config.getBoolean(
+            Configuration.CONFIG_KEY_TLAB_ENABLED, Configuration.DEFAULT_MEMORY_ENABLED))
         .thenReturn(true);
     RelevantEvents relevantEvents = RelevantEvents.create(config);
     assertTrue(relevantEvents.isRelevant(threadDump));
@@ -64,7 +65,8 @@ class RelevantEventsTest {
   @Test
   void testTlabNotEnabled() {
     Config config = mock(Config.class);
-    when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED, Configuration.DEFAULT_MEMORY_ENABLED))
+    when(config.getBoolean(
+            Configuration.CONFIG_KEY_TLAB_ENABLED, Configuration.DEFAULT_MEMORY_ENABLED))
         .thenReturn(false);
     RelevantEvents relevantEvents = RelevantEvents.create(config);
     assertTrue(relevantEvents.isRelevant(threadDump));

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/events/RelevantEventsTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/events/RelevantEventsTest.java
@@ -54,7 +54,7 @@ class RelevantEventsTest {
   @Test
   void testTlabEnabled() {
     Config config = mock(Config.class);
-    when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED, false)).thenReturn(true);
+    when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED)).thenReturn(true);
     RelevantEvents relevantEvents = RelevantEvents.create(config);
     assertTrue(relevantEvents.isRelevant(threadDump));
     assertTrue(relevantEvents.isRelevant(tlab));
@@ -63,7 +63,7 @@ class RelevantEventsTest {
   @Test
   void testTlabNotEnabled() {
     Config config = mock(Config.class);
-    when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED, false)).thenReturn(false);
+    when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED)).thenReturn(false);
     RelevantEvents relevantEvents = RelevantEvents.create(config);
     assertTrue(relevantEvents.isRelevant(threadDump));
     assertFalse(relevantEvents.isRelevant(tlab));

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/events/RelevantEventsTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/events/RelevantEventsTest.java
@@ -54,7 +54,8 @@ class RelevantEventsTest {
   @Test
   void testTlabEnabled() {
     Config config = mock(Config.class);
-    when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED)).thenReturn(true);
+    when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED, Configuration.DEFAULT_MEMORY_ENABLED))
+        .thenReturn(true);
     RelevantEvents relevantEvents = RelevantEvents.create(config);
     assertTrue(relevantEvents.isRelevant(threadDump));
     assertTrue(relevantEvents.isRelevant(tlab));
@@ -63,7 +64,8 @@ class RelevantEventsTest {
   @Test
   void testTlabNotEnabled() {
     Config config = mock(Config.class);
-    when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED)).thenReturn(false);
+    when(config.getBoolean(Configuration.CONFIG_KEY_TLAB_ENABLED, Configuration.DEFAULT_MEMORY_ENABLED))
+        .thenReturn(false);
     RelevantEvents relevantEvents = RelevantEvents.create(config);
     assertTrue(relevantEvents.isRelevant(threadDump));
     assertFalse(relevantEvents.isRelevant(tlab));


### PR DESCRIPTION
Added `splunk.profiler.memory.enabled` option. Currently the only thing this option does is change the default value of `splunk.profiler.tlab.enabled` option.

Changed the behavior of `ConfigurationLogger` to get value of `splunk.profiler.logs-endpoint` from `getConfigUrl` to reflect that the config option value is inherited in case it is `null`. Same is done for the `splunk.profiler.tlab.enabled` and `splunk.profiler.memory.enabled`.