### PR TITLE
Rename profiler thread dump config setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ## Unreleased
 
+* DEPRECATE `splunk.profiler.period.threaddump` config setting in favor of GDI-spec 
+  compatible `splunk.profiler.call.stack.interval`.  
+
 ## v1.6.0 - 2021-12-01
 
 ### General

--- a/profiler/README.md
+++ b/profiler/README.md
@@ -41,17 +41,18 @@ property or as environment variables (by making them uppercase and replacing dot
 
 > We strongly recommend using defaults for the following settings.
 
-| Setting                                     | Default                | Description                               |
+| Setting                                  | Default                | Description                               |
 |------------------------------------------|------------------------|-------------------------------------------|
 |`splunk.profiler.enabled`                 | false                  | set to true to enable the profiler        |
 |`splunk.profiler.directory`               | "."                    | location of jfr files                     |
 |`splunk.profiler.recording.duration`      | 20s                    | recording unit duration                   |
 |`splunk.profiler.keep-files`              | false                  | leave JFR files on disk id `true`         |
 |`splunk.profiler.logs-endpoint`           | `otel.exporter.otlp.endpoint` or http://localhost:4317  | where to send OTLP logs                   |
-|`splunk.profiler.period.{eventName}`      | n/a                    | customize period (in ms) for a specific jfr event. For example, to set the ThreadDump frequency to 1s (1000ms): `-Dsplunk.profiler.period.threaddump=1000` |
+|`splunk.profiler.call.stack.interval`     | 10000ms                | how often to sample call stacks           |
 |`splunk.profiler.memory.enabled`          | false                  | set to `true` to enable all other memory profiling options unless explicitly disabled |
 |`splunk.profiler.tlab.enabled`            | `splunk.profiler.memory.enabled` | set to `true` to enable TLAB events even if `splunk.profiler.memory.enabled` is `false` |
 |`splunk.profiler.include.agent.internals` | false                  | set to `true` to include agent internal call stacks |
+|`splunk.profiler.period.{eventName}`      | n/a                    | DEPRECATED. Use `splunk.profiler.call.stack.interval` instead.
 
 # Escape hatch
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
@@ -55,7 +55,7 @@ public class Configuration implements ConfigPropertySource {
     config.put(CONFIG_KEY_RECORDING_DURATION, DEFAULT_RECORDING_DURATION);
     config.put(CONFIG_KEY_KEEP_FILES, "false");
     config.put(CONFIG_KEY_MEMORY_ENABLED, String.valueOf(DEFAULT_MEMORY_ENABLED));
-    config.put(CONFIG_KEY_CALL_STACK_INTERVAL, DEFAULT_CALL_STACK_INTERVAL + " ms");
+    config.put(CONFIG_KEY_CALL_STACK_INTERVAL, DEFAULT_CALL_STACK_INTERVAL.toMillis() + " ms");
     return config;
   }
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
@@ -19,6 +19,7 @@ package com.splunk.opentelemetry.profiler;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.javaagent.extension.config.ConfigPropertySource;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,6 +28,7 @@ public class Configuration implements ConfigPropertySource {
 
   private static final String DEFAULT_RECORDING_DURATION = "20s";
   public static final boolean DEFAULT_MEMORY_ENABLED = false;
+  public static final Duration DEFAULT_CALL_STACK_INTERVAL = Duration.ofSeconds(10);
 
   public static final String CONFIG_KEY_ENABLE_PROFILER = "splunk.profiler.enabled";
   public static final String CONFIG_KEY_PROFILER_DIRECTORY = "splunk.profiler.directory";
@@ -34,9 +36,11 @@ public class Configuration implements ConfigPropertySource {
   public static final String CONFIG_KEY_KEEP_FILES = "splunk.profiler.keep-files";
   public static final String CONFIG_KEY_INGEST_URL = "splunk.profiler.logs-endpoint";
   public static final String CONFIG_KEY_OTEL_OTLP_URL = "otel.exporter.otlp.endpoint";
-  public static final String CONFIG_KEY_PERIOD_PREFIX = "splunk.profiler.period";
   public static final String CONFIG_KEY_MEMORY_ENABLED = "splunk.profiler.memory.enabled";
   public static final String CONFIG_KEY_TLAB_ENABLED = "splunk.profiler.tlab.enabled";
+  public static final String CONFIG_KEY_CALL_STACK_INTERVAL = "splunk.profiler.call.stack.interval";
+  public static final String CONFIG_KEY_DEPRECATED_THREADDUMP_PERIOD =
+      "splunk.profiler.period.threaddump";
   public static final String CONFIG_KEY_INCLUDE_AGENT_INTERNALS =
       "splunk.profiler.include.agent.internals";
   // Include stacks where every frame starts with jvm/sun/jdk
@@ -51,6 +55,7 @@ public class Configuration implements ConfigPropertySource {
     config.put(CONFIG_KEY_RECORDING_DURATION, DEFAULT_RECORDING_DURATION);
     config.put(CONFIG_KEY_KEEP_FILES, "false");
     config.put(CONFIG_KEY_MEMORY_ENABLED, String.valueOf(DEFAULT_MEMORY_ENABLED));
+    config.put(CONFIG_KEY_CALL_STACK_INTERVAL, DEFAULT_CALL_STACK_INTERVAL + " ms");
     return config;
   }
 
@@ -62,5 +67,9 @@ public class Configuration implements ConfigPropertySource {
   public static boolean getTLABEnabled(Config config) {
     boolean memoryEnabled = config.getBoolean(CONFIG_KEY_MEMORY_ENABLED, DEFAULT_MEMORY_ENABLED);
     return config.getBoolean(CONFIG_KEY_TLAB_ENABLED, memoryEnabled);
+  }
+
+  public static Duration getCallStackInterval(Config config) {
+    return config.getDuration(CONFIG_KEY_CALL_STACK_INTERVAL, DEFAULT_CALL_STACK_INTERVAL);
   }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
@@ -55,7 +55,7 @@ public class Configuration implements ConfigPropertySource {
     config.put(CONFIG_KEY_RECORDING_DURATION, DEFAULT_RECORDING_DURATION);
     config.put(CONFIG_KEY_KEEP_FILES, "false");
     config.put(CONFIG_KEY_MEMORY_ENABLED, String.valueOf(DEFAULT_MEMORY_ENABLED));
-    config.put(CONFIG_KEY_CALL_STACK_INTERVAL, DEFAULT_CALL_STACK_INTERVAL.toMillis() + " ms");
+    config.put(CONFIG_KEY_CALL_STACK_INTERVAL, DEFAULT_CALL_STACK_INTERVAL.toMillis() + "ms");
     return config;
   }
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/ConfigurationLogger.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/ConfigurationLogger.java
@@ -16,12 +16,13 @@
 
 package com.splunk.opentelemetry.profiler;
 
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_CALL_STACK_INTERVAL;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_DEPRECATED_THREADDUMP_PERIOD;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_ENABLE_PROFILER;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_INGEST_URL;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_KEEP_FILES;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_MEMORY_ENABLED;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_OTEL_OTLP_URL;
-import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PERIOD_PREFIX;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PROFILER_DIRECTORY;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_RECORDING_DURATION;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_TLAB_ENABLED;
@@ -48,7 +49,8 @@ public class ConfigurationLogger {
     log(CONFIG_KEY_OTEL_OTLP_URL, (it) -> config.getString(it, null));
     log(CONFIG_KEY_MEMORY_ENABLED, (it) -> config.getBoolean(it, DEFAULT_MEMORY_ENABLED));
     log(CONFIG_KEY_TLAB_ENABLED, (it) -> Configuration.getTLABEnabled(config));
-    log(CONFIG_KEY_PERIOD_PREFIX + "." + "threaddump", (it) -> config.getDuration(it, null));
+    log(CONFIG_KEY_CALL_STACK_INTERVAL, (it) -> Configuration.getCallStackInterval(config));
+    log(CONFIG_KEY_DEPRECATED_THREADDUMP_PERIOD, (it) -> config.getDuration(it, null));
     logger.info("-----------------------");
   }
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrRecorder.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrRecorder.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
 
 /** Responsible for starting a single JFR recording. */
 class JfrRecorder {
-  private static final Logger logger = LoggerFactory.getLogger(JfrRecorder.class.getName());
+  private static final Logger logger = LoggerFactory.getLogger(JfrRecorder.class);
   static final String RECORDING_NAME = "otel_agent_jfr_profiler";
   private final Map<String, String> settings;
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrSettingsOverrides.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrSettingsOverrides.java
@@ -16,9 +16,11 @@
 
 package com.splunk.opentelemetry.profiler;
 
-import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PERIOD_PREFIX;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_CALL_STACK_INTERVAL;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_DEPRECATED_THREADDUMP_PERIOD;
 
 import io.opentelemetry.instrumentation.api.config.Config;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -40,23 +42,19 @@ class JfrSettingsOverrides {
 
   Map<String, String> apply(Map<String, String> jfrSettings) {
     Map<String, String> settings = new HashMap<>(jfrSettings);
-    jfrSettings.keySet().stream()
-        .filter(key -> key.endsWith("#period"))
-        .forEach(
-            key -> {
-              String[] parts = key.split("#");
-              String eventName = parts[0];
-              String shortEventName = eventName.replaceFirst("^jdk.", "");
-              String configKey = CONFIG_KEY_PERIOD_PREFIX + "." + shortEventName.toLowerCase();
-              String customSetting = config.getString(configKey);
-              if (customSetting != null) {
-                String jfrFormattedDuration = customSetting + " ms";
-                logger.info(
-                    "Custom JFR period configured for {} :: {}", eventName, jfrFormattedDuration);
-                settings.put(key, jfrFormattedDuration);
-              }
-            });
+    Duration customInterval = getCustomInterval();
+    if (customInterval != Duration.ZERO) {
+      settings.put("jdk.ThreadDump#period", customInterval.toMillis() + " ms");
+    }
     return maybeEnableTLABs(settings);
+  }
+
+  private Duration getCustomInterval() {
+    Duration customInterval = config.getDuration(CONFIG_KEY_CALL_STACK_INTERVAL, Duration.ZERO);
+    if (customInterval != Duration.ZERO) {
+      return customInterval;
+    }
+    return config.getDuration(CONFIG_KEY_DEPRECATED_THREADDUMP_PERIOD, Duration.ZERO);
   }
 
   private Map<String, String> maybeEnableTLABs(Map<String, String> settings) {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrSettingsOverrides.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrSettingsOverrides.java
@@ -54,7 +54,14 @@ class JfrSettingsOverrides {
     if (customInterval != Duration.ZERO) {
       return customInterval;
     }
-    return config.getDuration(CONFIG_KEY_DEPRECATED_THREADDUMP_PERIOD, Duration.ZERO);
+    Duration duration = config.getDuration(CONFIG_KEY_DEPRECATED_THREADDUMP_PERIOD, Duration.ZERO);
+    if (duration != Duration.ZERO) {
+      logger.warn(
+          "Using DEPRECATED configuration {}, please switch to {}",
+          CONFIG_KEY_DEPRECATED_THREADDUMP_PERIOD,
+          CONFIG_KEY_CALL_STACK_INTERVAL);
+    }
+    return duration;
   }
 
   private Map<String, String> maybeEnableTLABs(Map<String, String> settings) {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordingSequencer.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/RecordingSequencer.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  * recording, it consults with a RecordingEscapeHatch to make sure that it is safe/relevant to do.
  */
 class RecordingSequencer {
-  private static final Logger logger = LoggerFactory.getLogger(RecordingSequencer.class.getName());
+  private static final Logger logger = LoggerFactory.getLogger(RecordingSequencer.class);
   // The overlap factor causes recordings to be shorter than the requested duration.
   // This forces overlap between recordings and ensures data is continuous when deduplicated.
   public static final double OVERLAP_FACTOR = 0.8;

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationLoggerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationLoggerTest.java
@@ -16,15 +16,17 @@
 
 package com.splunk.opentelemetry.profiler;
 
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_CALL_STACK_INTERVAL;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_DEPRECATED_THREADDUMP_PERIOD;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_ENABLE_PROFILER;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_INGEST_URL;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_KEEP_FILES;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_MEMORY_ENABLED;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_OTEL_OTLP_URL;
-import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PERIOD_PREFIX;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PROFILER_DIRECTORY;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_RECORDING_DURATION;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_TLAB_ENABLED;
+import static com.splunk.opentelemetry.profiler.Configuration.DEFAULT_CALL_STACK_INTERVAL;
 import static com.splunk.opentelemetry.profiler.Configuration.DEFAULT_MEMORY_ENABLED;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -53,7 +55,9 @@ class ConfigurationLoggerTest {
         .thenReturn("http://example.com");
     when(config.getBoolean(CONFIG_KEY_MEMORY_ENABLED, DEFAULT_MEMORY_ENABLED)).thenReturn(false);
     when(config.getBoolean(CONFIG_KEY_TLAB_ENABLED, false)).thenReturn(true);
-    when(config.getDuration(CONFIG_KEY_PERIOD_PREFIX + ".threaddump", null))
+    when(config.getDuration(CONFIG_KEY_CALL_STACK_INTERVAL, DEFAULT_CALL_STACK_INTERVAL))
+        .thenReturn(Duration.ofSeconds(21));
+    when(config.getDuration(CONFIG_KEY_DEPRECATED_THREADDUMP_PERIOD, null))
         .thenReturn(Duration.ofMillis(500));
 
     ConfigurationLogger configurationLogger = new ConfigurationLogger();
@@ -70,6 +74,7 @@ class ConfigurationLoggerTest {
     log.assertContains("            otel.exporter.otlp.endpoint : http://otel.example.com");
     log.assertContains("         splunk.profiler.memory.enabled : false");
     log.assertContains("           splunk.profiler.tlab.enabled : true");
+    log.assertContains("    splunk.profiler.call.stack.interval : PT21S");
     log.assertContains("      splunk.profiler.period.threaddump : PT0.5S");
   }
 


### PR DESCRIPTION
Resolves #572 
GDI spec is updated, so we should now use `splunk.profiler.call.stack.interval`. To be backwards compatible, the old setting is marked deprecated but still functions.