### PR TITLE
Publish agent as docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox 
+
+ADD dist/splunk-otel-javaagent-all.jar /

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -74,6 +74,24 @@ create_gh_release() {
     --title "Release $release_tag"
 }
 
+build_docker_image() {
+  docker build -t splunk-otel-instrumentation-java .
+  docker tag splunk-otel-instrumentation-java quay.io/signalfx/splunk-otel-instrumentation-java:$release_tag
+  docker tag splunk-otel-instrumentation-java quay.io/signalfx/splunk-otel-instrumentation-java:latest
+}
+
+publish_docker_image() {
+  docker push quay.io/signalfx/splunk-otel-instrumentation-java:latest
+  docker push quay.io/signalfx/splunk-otel-instrumentation-java:$release_tag
+}
+
+login_to_quay_io() {
+  docker login -u $QUAY_USERNAME -p $QUAY_PASSWORD quay.io
+}
+
 import_gpg_keys
 build_project
 create_gh_release
+build_docker_image
+login_to_quay_io
+publish_docker_image


### PR DESCRIPTION
This is needed by auto-instrumentation in environments like kubernetes.