### PR TITLE
Rename allocation size attribute

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/TLABProcessor.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/TLABProcessor.java
@@ -36,8 +36,7 @@ import jdk.jfr.consumer.RecordedStackTrace;
 public class TLABProcessor implements Consumer<RecordedEvent> {
   public static final String NEW_TLAB_EVENT_NAME = "jdk.ObjectAllocationInNewTLAB";
   public static final String OUTSIDE_TLAB_EVENT_NAME = "jdk.ObjectAllocationOutsideTLAB";
-  static final AttributeKey<Long> ALLOCATION_SIZE_KEY = AttributeKey.longKey("allocationSize");
-  static final AttributeKey<Long> TLAB_SIZE_KEY = AttributeKey.longKey("tlabSize");
+  static final AttributeKey<Long> ALLOCATION_SIZE_KEY = AttributeKey.longKey("memory.allocated");
 
   private final boolean enabled;
   private final StackSerializer stackSerializer;
@@ -70,10 +69,6 @@ public class TLABProcessor implements Consumer<RecordedEvent> {
     AttributesBuilder builder =
         commonAttributes.build(event.getEventType().getName()).toBuilder()
             .put(ALLOCATION_SIZE_KEY, event.getLong("allocationSize"));
-
-    if (event.hasField("tlabSize")) {
-      builder.put(TLAB_SIZE_KEY, event.getLong("tlabSize"));
-    }
     Attributes attributes = builder.build();
 
     LogData logData =

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/TLABProcessorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/TLABProcessorTest.java
@@ -21,7 +21,6 @@ import static com.splunk.opentelemetry.profiler.Configuration.DEFAULT_MEMORY_ENA
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SOURCE_EVENT_NAME;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SOURCE_TYPE;
 import static com.splunk.opentelemetry.profiler.TLABProcessor.ALLOCATION_SIZE_KEY;
-import static com.splunk.opentelemetry.profiler.TLABProcessor.TLAB_SIZE_KEY;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -139,11 +138,6 @@ class TLABProcessorTest {
     assertEquals("otel.profiling", seenLogData.get().getAttributes().get(SOURCE_TYPE));
     assertEquals("tee-lab", seenLogData.get().getAttributes().get(SOURCE_EVENT_NAME));
     assertEquals(ONE_MB, seenLogData.get().getAttributes().get(ALLOCATION_SIZE_KEY));
-    if (tlabSize == null) {
-      assertNull(seenLogData.get().getAttributes().get(TLAB_SIZE_KEY));
-    } else {
-      assertEquals(tlabSize, seenLogData.get().getAttributes().get(TLAB_SIZE_KEY));
-    }
     assertFalse(seenLogData.get().getSpanContext().isValid());
   }
 


### PR DESCRIPTION
rename `allocationSize` -> `memory.allocated` and remove `tlabSize`