### PR TITLE
Profiler - Fix TLAB stack format

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/TLABProcessor.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/TLABProcessor.java
@@ -30,15 +30,11 @@ import io.opentelemetry.sdk.logs.LogProcessor;
 import io.opentelemetry.sdk.logs.data.LogData;
 import io.opentelemetry.sdk.logs.data.LogDataBuilder;
 import io.opentelemetry.sdk.resources.Resource;
-
-import java.nio.file.FileSystems;
-import java.nio.file.Path;
 import java.time.Instant;
 import java.util.function.Consumer;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordedStackTrace;
 import jdk.jfr.consumer.RecordedThread;
-import jdk.jfr.consumer.RecordingFile;
 
 public class TLABProcessor implements Consumer<RecordedEvent> {
   public static final String NEW_TLAB_EVENT_NAME = "jdk.ObjectAllocationInNewTLAB";
@@ -107,9 +103,8 @@ public class TLABProcessor implements Consumer<RecordedEvent> {
   }
 
   private String buildThreadLine(String name, long id) {
-    String sb = "\"" + name + "\"" +
-            " #" + id +
-            " prio=0 os_prio=0 cpu=0ms elapsed=0s tid=0 nid=0 unknown";
+    String sb =
+        "\"" + name + "\"" + " #" + id + " prio=0 os_prio=0 cpu=0ms elapsed=0s tid=0 nid=0 unknown";
     return sb;
   }
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/TLABProcessor.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/TLABProcessor.java
@@ -104,7 +104,7 @@ public class TLABProcessor implements Consumer<RecordedEvent> {
   }
 
   static class Builder {
-    private boolean enabled;
+    private final boolean enabled;
     private StackSerializer stackSerializer = new StackSerializer();
     private LogProcessor logProcessor;
     private LogDataCommonAttributes commonAttributes;

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/util/StackSerializer.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/util/StackSerializer.java
@@ -54,8 +54,13 @@ public class StackSerializer {
     String className = method.getType().getName();
     String methodName = method.getName();
     int lineNumber = frame.getInt("lineNumber");
-    return sb.append("\tat ").append(className).append(".").append(methodName)
-            .append("(unknown:").append(lineNumber).append(")");
+    return sb.append("\tat ")
+        .append(className)
+        .append(".")
+        .append(methodName)
+        .append("(unknown:")
+        .append(lineNumber)
+        .append(")");
   }
 
   private StringBuilder maybeNewline(StringBuilder sb) {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/util/StackSerializer.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/util/StackSerializer.java
@@ -37,21 +37,20 @@ public class StackSerializer {
   public String serialize(RecordedStackTrace stack) {
     List<RecordedFrame> frames = stack.getFrames();
     int skipNum = Math.max(0, frames.size() - maxDepth);
-    return frames.stream()
-        .skip(skipNum)
-        .limit(maxDepth)
-        .reduce(
-            new StringBuilder(), this::serializeFrame, (sb1, sb2) -> sb1.append("\n").append(sb2))
-        .toString();
+    StringBuilder sb = new StringBuilder();
+    sb.append("   ");
+    serializeFrame(sb, frames.get(skipNum));
+    for (int i = skipNum + 1; i < frames.size(); i++) {
+      sb.append("\n\tat ");
+      serializeFrame(sb, frames.get(i));
+    }
+    return sb.toString();
   }
 
   private StringBuilder serializeFrame(StringBuilder sb, RecordedFrame frame) {
     RecordedMethod method = frame.getMethod();
     if (method == null) {
-      return sb;
-    }
-    if (sb.length() > 0) {
-      sb.append("\n");
+      return sb.append("unknown.unknown(unknown)");
     }
     String className = method.getType().getName();
     String methodName = method.getName();

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/util/StackSerializer.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/util/StackSerializer.java
@@ -54,7 +54,8 @@ public class StackSerializer {
     String className = method.getType().getName();
     String methodName = method.getName();
     int lineNumber = frame.getInt("lineNumber");
-    return sb.append("\tat ").append(className).append(".").append(methodName).append(":").append(lineNumber);
+    return sb.append("\tat ").append(className).append(".").append(methodName)
+            .append("(unknown:").append(lineNumber).append(")");
   }
 
   private StringBuilder maybeNewline(StringBuilder sb) {

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/TLABProcessorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/TLABProcessorTest.java
@@ -99,9 +99,10 @@ class TLABProcessorTest {
     Instant now = Instant.now();
     AtomicReference<LogData> seenLogData = new AtomicReference<>();
     LogProcessor consumer = seenLogData::set;
-    String stackAsString = "\"mockingbird\" #606 prio=0 os_prio=0 cpu=0ms elapsed=0s tid=0 nid=0 unknown\n" +
-            "   java.lang.Thread.State: UNKNOWN\n" +
-            "i am a serialized stack believe me";
+    String stackAsString =
+        "\"mockingbird\" #606 prio=0 os_prio=0 cpu=0ms elapsed=0s tid=0 nid=0 unknown\n"
+            + "   java.lang.Thread.State: UNKNOWN\n"
+            + "i am a serialized stack believe me";
 
     StackSerializer serializer = mock(StackSerializer.class);
     LogDataCommonAttributes commonAttrs = new LogDataCommonAttributes(new EventPeriods(x -> null));

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/TLABProcessorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/TLABProcessorTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import jdk.jfr.EventType;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordedStackTrace;
+import jdk.jfr.consumer.RecordedThread;
 import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -98,7 +99,9 @@ class TLABProcessorTest {
     Instant now = Instant.now();
     AtomicReference<LogData> seenLogData = new AtomicReference<>();
     LogProcessor consumer = seenLogData::set;
-    String stackAsString = "i am a serialized stack believe me";
+    String stackAsString = "\"mockingbird\" #606 prio=0 os_prio=0 cpu=0ms elapsed=0s tid=0 nid=0 unknown\n" +
+            "   java.lang.Thread.State: UNKNOWN\n" +
+            "i am a serialized stack believe me";
 
     StackSerializer serializer = mock(StackSerializer.class);
     LogDataCommonAttributes commonAttrs = new LogDataCommonAttributes(new EventPeriods(x -> null));
@@ -135,11 +138,15 @@ class TLABProcessorTest {
     RecordedEvent event = mock(RecordedEvent.class);
     RecordedStackTrace stack = mock(RecordedStackTrace.class);
     EventType eventType = mock(EventType.class);
+    RecordedThread mockThread = mock(RecordedThread.class);
 
     when(event.getStartTime()).thenReturn(now);
     when(event.getStackTrace()).thenReturn(stack);
     when(event.getEventType()).thenReturn(eventType);
     when(event.getLong("allocationSize")).thenReturn(ONE_MB);
+    when(event.getThread()).thenReturn(mockThread);
+    when(mockThread.getJavaThreadId()).thenReturn(606L);
+    when(mockThread.getJavaName()).thenReturn("mockingbird");
 
     when(event.hasField("tlabSize")).thenReturn(tlabSize != null);
     if (tlabSize == null) {

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/util/StackSerializerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/util/StackSerializerTest.java
@@ -46,9 +46,9 @@ class StackSerializerTest {
 
     String result = serializer.serialize(stack);
     String expected =
-        "io.test.MyClass.action:123\n"
-            + "io.test.MyClass.silver:456\n"
-            + "io.test.Framewerk.root:66";
+        "   io.test.MyClass.action:123\n"
+            + "\tat io.test.MyClass.silver:456\n"
+            + "\tat io.test.Framewerk.root:66";
     assertEquals(expected, result);
   }
 
@@ -60,7 +60,9 @@ class StackSerializerTest {
     when(stack.getFrames()).thenReturn(framesWithNullMethod);
 
     String result = serializer.serialize(stack);
-    String expected = "io.test.MyClass.action:123\n" + "io.test.Framewerk.root:66";
+    String expected = "   io.test.MyClass.action:123\n" +
+            "\tat unknown.unknown(unknown)\n" +
+            "\tat io.test.Framewerk.root:66";
     assertEquals(expected, result);
   }
 
@@ -72,7 +74,8 @@ class StackSerializerTest {
     when(stack.getFrames()).thenReturn(frames);
 
     String result = serializer.serialize(stack);
-    String expected = "io.test.MyClass.silver:456\n" + "io.test.Framewerk.root:66";
+    String expected = "   io.test.MyClass.silver:456\n" +
+            "\tat io.test.Framewerk.root:66";
     assertEquals(expected, result);
   }
 

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/util/StackSerializerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/util/StackSerializerTest.java
@@ -46,9 +46,9 @@ class StackSerializerTest {
 
     String result = serializer.serialize(stack);
     String expected =
-              "\tat io.test.MyClass.action:123\n"
-            + "\tat io.test.MyClass.silver:456\n"
-            + "\tat io.test.Framewerk.root:66";
+              "\tat io.test.MyClass.action(unknown:123)\n"
+            + "\tat io.test.MyClass.silver(unknown:456)\n"
+            + "\tat io.test.Framewerk.root(unknown:66)";
     assertEquals(expected, result);
   }
 
@@ -60,9 +60,9 @@ class StackSerializerTest {
     when(stack.getFrames()).thenReturn(framesWithNullMethod);
 
     String result = serializer.serialize(stack);
-    String expected = "\tat io.test.MyClass.action:123\n" +
+    String expected = "\tat io.test.MyClass.action(unknown:123)\n" +
             "\tat unknown.unknown(unknown)\n" +
-            "\tat io.test.Framewerk.root:66";
+            "\tat io.test.Framewerk.root(unknown:66)";
     assertEquals(expected, result);
   }
 
@@ -74,8 +74,8 @@ class StackSerializerTest {
     when(stack.getFrames()).thenReturn(frames);
 
     String result = serializer.serialize(stack);
-    String expected = "\tat io.test.MyClass.silver:456\n" +
-            "\tat io.test.Framewerk.root:66";
+    String expected = "\tat io.test.MyClass.silver(unknown:456)\n" +
+            "\tat io.test.Framewerk.root(unknown:66)";
     assertEquals(expected, result);
   }
 

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/util/StackSerializerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/util/StackSerializerTest.java
@@ -46,7 +46,7 @@ class StackSerializerTest {
 
     String result = serializer.serialize(stack);
     String expected =
-              "\tat io.test.MyClass.action(unknown:123)\n"
+        "\tat io.test.MyClass.action(unknown:123)\n"
             + "\tat io.test.MyClass.silver(unknown:456)\n"
             + "\tat io.test.Framewerk.root(unknown:66)";
     assertEquals(expected, result);
@@ -60,9 +60,10 @@ class StackSerializerTest {
     when(stack.getFrames()).thenReturn(framesWithNullMethod);
 
     String result = serializer.serialize(stack);
-    String expected = "\tat io.test.MyClass.action(unknown:123)\n" +
-            "\tat unknown.unknown(unknown)\n" +
-            "\tat io.test.Framewerk.root(unknown:66)";
+    String expected =
+        "\tat io.test.MyClass.action(unknown:123)\n"
+            + "\tat unknown.unknown(unknown)\n"
+            + "\tat io.test.Framewerk.root(unknown:66)";
     assertEquals(expected, result);
   }
 
@@ -74,8 +75,8 @@ class StackSerializerTest {
     when(stack.getFrames()).thenReturn(frames);
 
     String result = serializer.serialize(stack);
-    String expected = "\tat io.test.MyClass.silver(unknown:456)\n" +
-            "\tat io.test.Framewerk.root(unknown:66)";
+    String expected =
+        "\tat io.test.MyClass.silver(unknown:456)\n" + "\tat io.test.Framewerk.root(unknown:66)";
     assertEquals(expected, result);
   }
 

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/util/StackSerializerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/util/StackSerializerTest.java
@@ -46,7 +46,7 @@ class StackSerializerTest {
 
     String result = serializer.serialize(stack);
     String expected =
-        "   io.test.MyClass.action:123\n"
+              "\tat io.test.MyClass.action:123\n"
             + "\tat io.test.MyClass.silver:456\n"
             + "\tat io.test.Framewerk.root:66";
     assertEquals(expected, result);
@@ -60,7 +60,7 @@ class StackSerializerTest {
     when(stack.getFrames()).thenReturn(framesWithNullMethod);
 
     String result = serializer.serialize(stack);
-    String expected = "   io.test.MyClass.action:123\n" +
+    String expected = "\tat io.test.MyClass.action:123\n" +
             "\tat unknown.unknown(unknown)\n" +
             "\tat io.test.Framewerk.root:66";
     assertEquals(expected, result);
@@ -74,7 +74,7 @@ class StackSerializerTest {
     when(stack.getFrames()).thenReturn(frames);
 
     String result = serializer.serialize(stack);
-    String expected = "   io.test.MyClass.silver:456\n" +
+    String expected = "\tat io.test.MyClass.silver:456\n" +
             "\tat io.test.Framewerk.root:66";
     assertEquals(expected, result);
   }

--- a/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/profiler/ProfilerSmokeTest.java
+++ b/testing/profiler-tests/src/test/java/com/splunk/opentelemetry/profiler/ProfilerSmokeTest.java
@@ -176,7 +176,8 @@ public class ProfilerSmokeTest {
     assertThat(countTLABs(logs)).isGreaterThan(0);
     assertAllThreadDumps(justTLABs(logs), log -> getLongAttr(log, "memory.allocated") > 0);
     assertAllThreadDumps(justTLABs(logs), log -> log.getBody().getStringValue().startsWith("\""));
-    assertAllThreadDumps(justTLABs(logs), log -> log.getBody().getStringValue().split("\n").length > 2);
+    assertAllThreadDumps(
+        justTLABs(logs), log -> log.getBody().getStringValue().split("\n").length > 2);
   }
 
   @Test


### PR DESCRIPTION
The format of stacks coming in for TLAB events didn't conform to GDI spec, so this fixes that up. They should look much more like the other stack traces now. Also added a few more checks in the smoke tests around the data contained in the tlab logs.