### PR TITLE
Memory profiling implies metrics

### DIFF
--- a/custom/src/main/java/com/splunk/opentelemetry/SplunkConfiguration.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/SplunkConfiguration.java
@@ -26,6 +26,7 @@ public class SplunkConfiguration implements ConfigPropertySource {
   public static final String SPLUNK_ACCESS_TOKEN = "splunk.access.token";
   public static final String OTEL_EXPORTER_JAEGER_ENDPOINT = "otel.exporter.jaeger.endpoint";
   public static final String PROFILER_ENABLED_PROPERTY = "splunk.profiler.enabled";
+  public static final String PROFILER_MEMORY_ENABLED_PROPERTY = "splunk.profiler.memory.enabled";
 
   @Override
   public Map<String, String> getProperties() {

--- a/custom/src/main/java/com/splunk/opentelemetry/micrometer/SplunkMetricsConfig.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/micrometer/SplunkMetricsConfig.java
@@ -16,7 +16,7 @@
 
 package com.splunk.opentelemetry.micrometer;
 
-import static com.splunk.opentelemetry.SplunkConfiguration.PROFILER_ENABLED_PROPERTY;
+import static com.splunk.opentelemetry.SplunkConfiguration.PROFILER_MEMORY_ENABLED_PROPERTY;
 import static com.splunk.opentelemetry.SplunkConfiguration.SPLUNK_ACCESS_TOKEN;
 import static io.micrometer.core.instrument.config.MeterRegistryConfigValidator.checkAll;
 
@@ -55,7 +55,7 @@ class SplunkMetricsConfig implements SignalFxConfig {
   @Override
   public boolean enabled() {
     return config.getBoolean(METRICS_ENABLED_PROPERTY, false)
-        || config.getBoolean(PROFILER_ENABLED_PROPERTY, false);
+        || config.getBoolean(PROFILER_MEMORY_ENABLED_PROPERTY, false);
   }
 
   @Override

--- a/custom/src/test/java/com/splunk/opentelemetry/micrometer/SplunkMetricsConfigTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/micrometer/SplunkMetricsConfigTest.java
@@ -16,7 +16,7 @@
 
 package com.splunk.opentelemetry.micrometer;
 
-import static com.splunk.opentelemetry.SplunkConfiguration.PROFILER_ENABLED_PROPERTY;
+import static com.splunk.opentelemetry.SplunkConfiguration.PROFILER_MEMORY_ENABLED_PROPERTY;
 import static com.splunk.opentelemetry.SplunkConfiguration.SPLUNK_ACCESS_TOKEN;
 import static com.splunk.opentelemetry.micrometer.SplunkMetricsConfig.DEFAULT_METRICS_ENDPOINT;
 import static com.splunk.opentelemetry.micrometer.SplunkMetricsConfig.METRICS_ENABLED_PROPERTY;
@@ -114,7 +114,7 @@ class SplunkMetricsConfigTest {
     var javaagentConfig =
         Config.builder()
             .readProperties(
-                Map.of(METRICS_ENABLED_PROPERTY, "false", PROFILER_ENABLED_PROPERTY, "true"))
+                Map.of(METRICS_ENABLED_PROPERTY, "false", PROFILER_MEMORY_ENABLED_PROPERTY, "true"))
             .build();
     var config = new SplunkMetricsConfig(javaagentConfig, Resource.getDefault());
     assertTrue(config.enabled());

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
@@ -16,8 +16,10 @@
 
 package com.splunk.opentelemetry.profiler;
 
+import static com.splunk.opentelemetry.SplunkConfiguration.PROFILER_ENABLED_PROPERTY;
+import static com.splunk.opentelemetry.SplunkConfiguration.PROFILER_MEMORY_ENABLED_PROPERTY;
+
 import com.google.auto.service.AutoService;
-import com.splunk.opentelemetry.SplunkConfiguration;
 import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.javaagent.extension.config.ConfigPropertySource;
 import java.time.Duration;
@@ -32,14 +34,13 @@ public class Configuration implements ConfigPropertySource {
   public static final int DEFAULT_MEMORY_SAMPLING_INTERVAL = 1;
   public static final Duration DEFAULT_CALL_STACK_INTERVAL = Duration.ofSeconds(10);
 
-  public static final String CONFIG_KEY_ENABLE_PROFILER =
-      SplunkConfiguration.PROFILER_ENABLED_PROPERTY;
+  public static final String CONFIG_KEY_ENABLE_PROFILER = PROFILER_ENABLED_PROPERTY;
   public static final String CONFIG_KEY_PROFILER_DIRECTORY = "splunk.profiler.directory";
   public static final String CONFIG_KEY_RECORDING_DURATION = "splunk.profiler.recording.duration";
   public static final String CONFIG_KEY_KEEP_FILES = "splunk.profiler.keep-files";
   public static final String CONFIG_KEY_INGEST_URL = "splunk.profiler.logs-endpoint";
   public static final String CONFIG_KEY_OTEL_OTLP_URL = "otel.exporter.otlp.endpoint";
-  public static final String CONFIG_KEY_MEMORY_ENABLED = "splunk.profiler.memory.enabled";
+  public static final String CONFIG_KEY_MEMORY_ENABLED = PROFILER_MEMORY_ENABLED_PROPERTY;
   public static final String CONFIG_KEY_MEMORY_SAMPLER_INTERVAL =
       "splunk.profiler.memory.sampler.interval";
   public static final String CONFIG_KEY_TLAB_ENABLED = "splunk.profiler.tlab.enabled";


### PR DESCRIPTION
Turn on metrics automatically but only when _memory_ profiling is enabled. cpu profiling doesn't need it yet.

#604 was too aggressive, this relaxes it just to memory profiling.