### PR TITLE
Update the upstream instrumentation version and prepare for patch rel…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ## Unreleased
 
+## v1.6.1 - 2022-01-12
+
+### General
+
+- OpenTelemetry Instrumentation for Java has been updated to version 1.9.2.
+
+### Bugfixes
+
+- Fixed the connection leak in the reactor-netty upstream instrumentation.
+
 ## v1.6.0 - 2021-12-01
 
 ### General

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 
 <p align="center">
   <img alt="Stable" src="https://img.shields.io/badge/status-stable-informational?style=for-the-badge">
-  <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.9.1">
-    <img alt="OpenTelemetry Instrumentation for Java Version" src="https://img.shields.io/badge/otel-1.9.1-blueviolet?style=for-the-badge">
+  <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.9.2">
+    <img alt="OpenTelemetry Instrumentation for Java Version" src="https://img.shields.io/badge/otel-1.9.2-blueviolet?style=for-the-badge">
   </a>
   <a href="https://github.com/signalfx/gdi-specification/releases/tag/v1.2.0">
     <img alt="Splunk GDI specification" src="https://img.shields.io/badge/GDI-1.2.0-blueviolet?style=for-the-badge">
@@ -159,11 +159,11 @@ To extend the instrumentation with the OpenTelemetry Instrumentation for Java,
 you have to use a compatible API version.
 
 <!-- IMPORTANT: do not change comments or break those lines below -->
-The Splunk Distribution of OpenTelemetry Java version <!--SPLUNK_VERSION-->1.6.0<!--SPLUNK_VERSION--> is compatible
+The Splunk Distribution of OpenTelemetry Java version <!--SPLUNK_VERSION-->1.6.1<!--SPLUNK_VERSION--> is compatible
 with:
 
 * OpenTelemetry API version <!--OTEL_VERSION-->1.9.1<!--OTEL_VERSION-->
-* OpenTelemetry Instrumentation for Java version <!--OTEL_INSTRUMENTATION_VERSION-->1.9.1<!--OTEL_INSTRUMENTATION_VERSION-->
+* OpenTelemetry Instrumentation for Java version <!--OTEL_INSTRUMENTATION_VERSION-->1.9.2<!--OTEL_INSTRUMENTATION_VERSION-->
 * Micrometer version 1.8.0
 
 ## Snapshot builds

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
   implementation(gradleApi())
 
   implementation("com.diffplug.spotless:spotless-plugin-gradle:5.16.0")
-  implementation("io.opentelemetry.instrumentation:gradle-plugins:1.9.1-alpha")
+  implementation("io.opentelemetry.instrumentation:gradle-plugins:1.9.2-alpha")
   implementation("io.spring.gradle:dependency-management-plugin:1.0.11.RELEASE")
 
   // keep these versions in sync with settings.gradle.kts

--- a/buildSrc/src/main/kotlin/splunk.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.java-conventions.gradle.kts
@@ -16,8 +16,8 @@ repositories {
 val otelVersion = "1.9.1"
 val otelAlphaVersion = "1.9.1-alpha"
 val otelContribAlphaVersion = "1.7.0-alpha"
-val otelInstrumentationVersion = "1.9.1"
-val otelInstrumentationAlphaVersion = "1.9.1-alpha"
+val otelInstrumentationVersion = "1.9.2"
+val otelInstrumentationAlphaVersion = "1.9.2-alpha"
 val micrometerVersion = "1.8.0"
 
 // instrumentation version is used to compute Implementation-Version manifest attribute

--- a/deployments/cloudfoundry/buildpack/README.md
+++ b/deployments/cloudfoundry/buildpack/README.md
@@ -40,7 +40,7 @@ If you want to use a specific version of the Java agent in your application, you
 environment variable before application deployment, either using `cf set-env` or the `manifest.yml` file:
 
 ```sh
-$ cf set-env SPLUNK_OTEL_JAVA_VERSION 1.6.0
+$ cf set-env SPLUNK_OTEL_JAVA_VERSION 1.6.1
 ```
 
 By default, the [latest](https://github.com/signalfx/splunk-otel-java/releases/latest) available agent version is used.


### PR DESCRIPTION
…ease

Upstream v1.9.2 contains a reactor-netty fix that we need to release.