### PR TITLE
Disable building docker images in the release build

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -96,6 +96,6 @@ login_to_quay_io() {
 import_gpg_keys
 build_project
 create_gh_release
-build_docker_image
-login_to_quay_io
-publish_docker_image
+#build_docker_image
+#login_to_quay_io
+#publish_docker_image


### PR DESCRIPTION
This failed our release build in GL:
```
./scripts/release.sh: line 82: docker: command not found
```
Fortunately, the artifacts were uploaded earlier, and the GH release was already created by then.

CC @owais 