### PR TITLE
Install docker in CD release step

### DIFF
--- a/scripts/install-release-deps.sh
+++ b/scripts/install-release-deps.sh
@@ -2,8 +2,16 @@
 
 set -e
 
+apt-get update
+apt-get -y install ca-certificates curl gnupg lsb-release
+
 # instructions from https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-apt
 curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+
+# install docker
+curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
 apt-get update
-apt-get -y install zip gh
+apt-get -y install zip gh docker-ce docker-ce-cli containerd.io


### PR DESCRIPTION
The previous release job failed as it did not have docker installed. This PR installs docker as a release dependency. 
