### PR TITLE
Add memory allocation and gc metrics

### DIFF
--- a/instrumentation/jvm-metrics/build.gradle.kts
+++ b/instrumentation/jvm-metrics/build.gradle.kts
@@ -2,8 +2,13 @@ plugins {
   id("splunk.instrumentation-conventions")
 }
 
+dependencies {
+  compileOnly(project(":custom"))
+}
+
 tasks {
   test {
     jvmArgs("-Dsplunk.metrics.enabled=true")
+    jvmArgs("-Dsplunk.metrics.experimental.enabled=true")
   }
 }

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/AllocatedMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/AllocatedMemoryMetrics.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.instrumentation.jvmmetrics;
+
+import com.sun.management.ThreadMXBean;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.BaseUnits;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import java.lang.management.ManagementFactory;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class AllocatedMemoryMetrics implements MeterBinder {
+  private final boolean hasComSunThreadMXBean = hasComSunThreadMXBean();
+
+  @Override
+  public void bindTo(MeterRegistry registry) {
+    if (!hasComSunThreadMXBean) {
+      return;
+    }
+
+    if (!isThreadAllocatedMemoryEnabled()) {
+      return;
+    }
+
+    AllocationTracker allocationTracker = new AllocationTracker();
+    Gauge.builder("jvm.experimental.memory.allocated", allocationTracker::getAllocated)
+        .description("Approximate sum of heap allocations")
+        .baseUnit(BaseUnits.BYTES)
+        .register(registry);
+  }
+
+  private static boolean hasComSunThreadMXBean() {
+    try {
+      Class.forName(
+          "com.sun.management.ThreadMXBean", false, AllocatedMemoryMetrics.class.getClassLoader());
+      return true;
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
+  }
+
+  private static boolean isThreadAllocatedMemoryEnabled() {
+    ThreadMXBean threadBean = (ThreadMXBean) ManagementFactory.getThreadMXBean();
+
+    try {
+      threadBean.getAllThreadIds();
+      return threadBean.isThreadAllocatedMemorySupported()
+          && threadBean.isThreadAllocatedMemoryEnabled();
+    } catch (Error error) {
+      // An error will be thrown for unsupported operations
+      // e.g. SubstrateVM does not support getAllThreadIds
+      return false;
+    }
+  }
+
+  private static class AllocationTracker {
+    private final ThreadMXBean threadBean = (ThreadMXBean) ManagementFactory.getThreadMXBean();
+    // map from thread id -> last measured allocated bytes
+    private final Map<Long, Long> allocatedByThread = new HashMap<>();
+    // allocated bytes by threads that have terminated
+    private long allocatedByDeadThreads = 0;
+
+    long getAllocated() {
+      Set<Long> threads = new HashSet<>();
+      long allocatedByLiveThreads = 0;
+      long[] threadIds = threadBean.getAllThreadIds();
+      for (long threadId : threadIds) {
+        long size = threadBean.getThreadAllocatedBytes(threadId);
+        if (size != -1) {
+          threads.add(threadId);
+          allocatedByThread.put(threadId, size);
+          allocatedByLiveThreads += size;
+        }
+      }
+
+      // find dead threads
+      Set<Long> deadThreads = new HashSet<>(allocatedByThread.keySet());
+      deadThreads.removeAll(threads);
+      for (Long threadId : deadThreads) {
+        // remove dead thread and accumulate its allocated bytes
+        long size = allocatedByThread.remove(threadId);
+        allocatedByDeadThreads += size;
+      }
+
+      return allocatedByLiveThreads + allocatedByDeadThreads;
+    }
+  }
+}

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/GcMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/GcMemoryMetrics.java
@@ -44,8 +44,7 @@ public class GcMemoryMetrics implements MeterBinder, AutoCloseable {
 
   private final List<Runnable> notificationListenerCleanUpRunnables = new CopyOnWriteArrayList<>();
   private final Set<String> heapPoolNames = new HashSet<>();
-  private AtomicLong deltaSum = new AtomicLong();
-  private GcMetricsNotificationListener gcNotificationListener;
+  private final AtomicLong deltaSum = new AtomicLong();
 
   @Override
   public void bindTo(MeterRegistry registry) {
@@ -53,9 +52,10 @@ public class GcMemoryMetrics implements MeterBinder, AutoCloseable {
       return;
     }
 
-    gcNotificationListener = new GcMetricsNotificationListener(registry);
+    GcMetricsNotificationListener gcNotificationListener =
+        new GcMetricsNotificationListener(registry);
 
-    Gauge.builder("jvm.experimental.gc.memory.delta.sum", deltaSum, AtomicLong::get)
+    Gauge.builder("jvm.experimental.gc.memory.reclaimed", deltaSum, AtomicLong::get)
         .description("Sum of heap size differences before and after gc")
         .baseUnit(BaseUnits.BYTES)
         .register(registry);

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/GcMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/GcMemoryMetrics.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.instrumentation.jvmmetrics;
+
+import com.sun.management.GarbageCollectionNotificationInfo;
+import com.sun.management.GcInfo;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.BaseUnits;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryType;
+import java.lang.management.MemoryUsage;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.management.ListenerNotFoundException;
+import javax.management.Notification;
+import javax.management.NotificationEmitter;
+import javax.management.NotificationListener;
+import javax.management.openmbean.CompositeData;
+
+public class GcMemoryMetrics implements MeterBinder, AutoCloseable {
+  private final boolean managementExtensionsPresent = isManagementExtensionsPresent();
+
+  private final List<Runnable> notificationListenerCleanUpRunnables = new CopyOnWriteArrayList<>();
+  private final Set<String> heapPoolNames = new HashSet<>();
+  private AtomicLong deltaSum = new AtomicLong();
+  private GcMetricsNotificationListener gcNotificationListener;
+
+  @Override
+  public void bindTo(MeterRegistry registry) {
+    if (!this.managementExtensionsPresent) {
+      return;
+    }
+
+    gcNotificationListener = new GcMetricsNotificationListener(registry);
+
+    Gauge.builder("jvm.experimental.gc.memory.delta.sum", deltaSum, AtomicLong::get)
+        .description("Sum of heap size differences before and after gc")
+        .baseUnit(BaseUnits.BYTES)
+        .register(registry);
+
+    ManagementFactory.getMemoryPoolMXBeans().stream()
+        .filter(pool -> MemoryType.HEAP.equals(pool.getType()))
+        .map(MemoryPoolMXBean::getName)
+        .forEach(heapPoolNames::add);
+
+    for (GarbageCollectorMXBean gcBean : ManagementFactory.getGarbageCollectorMXBeans()) {
+      if (!(gcBean instanceof NotificationEmitter)) {
+        continue;
+      }
+      NotificationEmitter notificationEmitter = (NotificationEmitter) gcBean;
+      notificationEmitter.addNotificationListener(
+          gcNotificationListener,
+          notification ->
+              notification
+                  .getType()
+                  .equals(GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION),
+          null);
+      notificationListenerCleanUpRunnables.add(
+          () -> {
+            try {
+              notificationEmitter.removeNotificationListener(gcNotificationListener);
+            } catch (ListenerNotFoundException ignore) {
+            }
+          });
+    }
+  }
+
+  @Override
+  public void close() {
+    notificationListenerCleanUpRunnables.forEach(Runnable::run);
+  }
+
+  class GcMetricsNotificationListener implements NotificationListener {
+    private final MeterRegistry registry;
+
+    GcMetricsNotificationListener(MeterRegistry registry) {
+      this.registry = registry;
+    }
+
+    @Override
+    public void handleNotification(Notification notification, Object ref) {
+      CompositeData cd = (CompositeData) notification.getUserData();
+      GarbageCollectionNotificationInfo notificationInfo =
+          GarbageCollectionNotificationInfo.from(cd);
+
+      GcInfo gcInfo = notificationInfo.getGcInfo();
+      final Map<String, MemoryUsage> before = gcInfo.getMemoryUsageBeforeGc();
+      final Map<String, MemoryUsage> after = gcInfo.getMemoryUsageAfterGc();
+
+      long usageBefore = sumMemoryUsage(before);
+      long usageAfter = sumMemoryUsage(after);
+
+      deltaSum.addAndGet(usageBefore - usageAfter);
+    }
+
+    private long sumMemoryUsage(Map<String, MemoryUsage> memoryUsageMap) {
+      long result = 0;
+      for (Map.Entry<String, MemoryUsage> entry : memoryUsageMap.entrySet()) {
+        String poolName = entry.getKey();
+        MemoryUsage memoryUsage = entry.getValue();
+        if (!heapPoolNames.contains(poolName)) {
+          continue;
+        }
+
+        result += memoryUsage.getUsed();
+      }
+      return result;
+    }
+  }
+
+  // copied from micrometer JvmGcMetrics
+  private static boolean isManagementExtensionsPresent() {
+    if (ManagementFactory.getMemoryPoolMXBeans().isEmpty()) {
+      // Substrate VM, for example, doesn't provide or support these beans (yet)
+      return false;
+    }
+
+    try {
+      Class.forName(
+          "com.sun.management.GarbageCollectionNotificationInfo",
+          false,
+          MemoryPoolMXBean.class.getClassLoader());
+      return true;
+    } catch (Throwable e) {
+      // We are operating in a JVM without access to this level of detail
+      return false;
+    }
+  }
+}

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/JvmMetricsInstaller.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/JvmMetricsInstaller.java
@@ -16,6 +16,7 @@
 
 package com.splunk.opentelemetry.instrumentation.jvmmetrics;
 
+import static com.splunk.opentelemetry.SplunkConfiguration.PROFILER_MEMORY_ENABLED_PROPERTY;
 import static java.util.Collections.singleton;
 
 import com.google.auto.service.AutoService;
@@ -42,7 +43,12 @@ public class JvmMetricsInstaller implements AgentListener {
     new JvmGcMetrics().bindTo(Metrics.globalRegistry);
     new JvmMemoryMetrics().bindTo(Metrics.globalRegistry);
     new JvmThreadMetrics().bindTo(Metrics.globalRegistry);
-    new AllocatedMemoryMetrics().bindTo(Metrics.globalRegistry);
-    new GcMemoryMetrics().bindTo(Metrics.globalRegistry);
+
+    // Following metrics are experimental, we'll enable them only when memory profiling is enabled
+    if (config.getBoolean(PROFILER_MEMORY_ENABLED_PROPERTY, false)
+        || config.getBoolean("splunk.metrics.experimental.enabled", false)) {
+      new AllocatedMemoryMetrics().bindTo(Metrics.globalRegistry);
+      new GcMemoryMetrics().bindTo(Metrics.globalRegistry);
+    }
   }
 }

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/JvmMetricsInstaller.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/JvmMetricsInstaller.java
@@ -42,5 +42,7 @@ public class JvmMetricsInstaller implements AgentListener {
     new JvmGcMetrics().bindTo(Metrics.globalRegistry);
     new JvmMemoryMetrics().bindTo(Metrics.globalRegistry);
     new JvmThreadMetrics().bindTo(Metrics.globalRegistry);
+    new AllocatedMemoryMetrics().bindTo(Metrics.globalRegistry);
+    new GcMemoryMetrics().bindTo(Metrics.globalRegistry);
   }
 }

--- a/instrumentation/jvm-metrics/src/test/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/JvmMetricsTest.java
+++ b/instrumentation/jvm-metrics/src/test/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/JvmMetricsTest.java
@@ -38,5 +38,9 @@ class JvmMetricsTest {
     assertTrue(meterNames.contains("jvm.memory.used"));
     // thread metrics
     assertTrue(meterNames.contains("jvm.threads.peak"));
+    // allocated memory metrics
+    assertTrue(meterNames.contains("jvm.memory.allocated"));
+    // Our custom GC metrics
+    assertTrue(meterNames.contains("jvm.gc.memory.delta.sum"));
   }
 }

--- a/instrumentation/jvm-metrics/src/test/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/JvmMetricsTest.java
+++ b/instrumentation/jvm-metrics/src/test/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/JvmMetricsTest.java
@@ -39,8 +39,8 @@ class JvmMetricsTest {
     // thread metrics
     assertTrue(meterNames.contains("jvm.threads.peak"));
     // allocated memory metrics
-    assertTrue(meterNames.contains("jvm.memory.allocated"));
+    assertTrue(meterNames.contains("jvm.experimental.memory.allocated"));
     // Our custom GC metrics
-    assertTrue(meterNames.contains("jvm.gc.memory.delta.sum"));
+    assertTrue(meterNames.contains("jvm.experimental.gc.memory.delta.sum"));
   }
 }

--- a/instrumentation/jvm-metrics/src/test/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/JvmMetricsTest.java
+++ b/instrumentation/jvm-metrics/src/test/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/JvmMetricsTest.java
@@ -41,6 +41,6 @@ class JvmMetricsTest {
     // allocated memory metrics
     assertTrue(meterNames.contains("jvm.experimental.memory.allocated"));
     // Our custom GC metrics
-    assertTrue(meterNames.contains("jvm.experimental.gc.memory.delta.sum"));
+    assertTrue(meterNames.contains("jvm.experimental.gc.memory.reclaimed"));
   }
 }


### PR DESCRIPTION
This pr adds two new metrics
- total amount of memory allocated. When plotted with `rateofchange` function this should show memory allocation rate. It is similar to existing `runtime.jvm.gc.memory.allocated` metric. Allocated memory is computed using `ThreadMXBean`, short lived threads are not tracked.
- sum of heap usage before gc - heap usage after gc