### PR TITLE
profiler: Unified option for enabling internal stacks, fix logic of enabling separately

### DIFF
--- a/profiler/README.md
+++ b/profiler/README.md
@@ -52,7 +52,7 @@ property or as environment variables (by making them uppercase and replacing dot
 |`splunk.profiler.memory.enabled`          | false                  | set to `true` to enable all other memory profiling options unless explicitly disabled |
 |`splunk.profiler.tlab.enabled`            | `splunk.profiler.memory.enabled` | set to `true` to enable TLAB events even if `splunk.profiler.memory.enabled` is `false` |
 |`splunk.profiler.memory.sampler.interval` | 1                      | set to `2` or larger to enable sampling every Nth allocation event where N is the value of this property |
-|`splunk.profiler.include.agent.internals` | false                  | set to `true` to include agent internal call stacks |
+|`splunk.profiler.include.internal.stacks` | false                  | set to `true` to include stack traces of agent internal threads and stack traces with only JDK internal frames |
 |`splunk.profiler.period.{eventName}`      | n/a                    | DEPRECATED. Use `splunk.profiler.call.stack.interval` instead.
 
 # Escape hatch

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
@@ -33,6 +33,7 @@ public class Configuration implements ConfigPropertySource {
   public static final boolean DEFAULT_MEMORY_ENABLED = false;
   public static final int DEFAULT_MEMORY_SAMPLING_INTERVAL = 1;
   public static final Duration DEFAULT_CALL_STACK_INTERVAL = Duration.ofSeconds(10);
+  public static final boolean DEFAULT_INCLUDE_INTERNAL_STACKS = false;
 
   public static final String CONFIG_KEY_ENABLE_PROFILER = PROFILER_ENABLED_PROPERTY;
   public static final String CONFIG_KEY_PROFILER_DIRECTORY = "splunk.profiler.directory";
@@ -52,6 +53,8 @@ public class Configuration implements ConfigPropertySource {
   // Include stacks where every frame starts with jvm/sun/jdk
   public static final String CONFIG_KEY_INCLUDE_JVM_INTERNALS =
       "splunk.profiler.include.jvm.internals";
+  public static final String CONFIG_KEY_INCLUDE_INTERNAL_STACKS =
+      "splunk.profiler.include.internal.stacks";
 
   @Override
   public Map<String, String> getProperties() {
@@ -83,5 +86,17 @@ public class Configuration implements ConfigPropertySource {
 
   public static Duration getCallStackInterval(Config config) {
     return config.getDuration(CONFIG_KEY_CALL_STACK_INTERVAL, DEFAULT_CALL_STACK_INTERVAL);
+  }
+
+  public static boolean getIncludeAgentInternalStacks(Config config) {
+    boolean includeInternals =
+        config.getBoolean(CONFIG_KEY_INCLUDE_INTERNAL_STACKS, DEFAULT_INCLUDE_INTERNAL_STACKS);
+    return config.getBoolean(CONFIG_KEY_INCLUDE_AGENT_INTERNALS, includeInternals);
+  }
+
+  public static boolean getIncludeJvmInternalStacks(Config config) {
+    boolean includeInternals =
+        config.getBoolean(CONFIG_KEY_INCLUDE_INTERNAL_STACKS, DEFAULT_INCLUDE_INTERNAL_STACKS);
+    return config.getBoolean(CONFIG_KEY_INCLUDE_JVM_INTERNALS, includeInternals);
   }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/ConfigurationLogger.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/ConfigurationLogger.java
@@ -19,6 +19,7 @@ package com.splunk.opentelemetry.profiler;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_CALL_STACK_INTERVAL;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_DEPRECATED_THREADDUMP_PERIOD;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_ENABLE_PROFILER;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_INCLUDE_INTERNAL_STACKS;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_INGEST_URL;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_KEEP_FILES;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_MEMORY_ENABLED;
@@ -27,6 +28,7 @@ import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_OTEL_OT
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PROFILER_DIRECTORY;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_RECORDING_DURATION;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_TLAB_ENABLED;
+import static com.splunk.opentelemetry.profiler.Configuration.DEFAULT_INCLUDE_INTERNAL_STACKS;
 import static com.splunk.opentelemetry.profiler.Configuration.DEFAULT_MEMORY_ENABLED;
 
 import io.opentelemetry.instrumentation.api.config.Config;
@@ -52,6 +54,9 @@ public class ConfigurationLogger {
     log(CONFIG_KEY_TLAB_ENABLED, (it) -> Configuration.getTLABEnabled(config));
     log(CONFIG_KEY_MEMORY_SAMPLER_INTERVAL, (it) -> Configuration.getMemorySamplerInterval(config));
     log(CONFIG_KEY_CALL_STACK_INTERVAL, (it) -> Configuration.getCallStackInterval(config));
+    log(
+        CONFIG_KEY_INCLUDE_INTERNAL_STACKS,
+        (it) -> config.getBoolean(it, DEFAULT_INCLUDE_INTERNAL_STACKS));
     log(CONFIG_KEY_DEPRECATED_THREADDUMP_PERIOD, (it) -> config.getDuration(it, null));
     logger.info("-----------------------");
   }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
@@ -17,8 +17,6 @@
 package com.splunk.opentelemetry.profiler;
 
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_ENABLE_PROFILER;
-import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_INCLUDE_AGENT_INTERNALS;
-import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_INCLUDE_JVM_INTERNALS;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_KEEP_FILES;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PROFILER_DIRECTORY;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_RECORDING_DURATION;
@@ -175,9 +173,9 @@ public class JfrActivator implements AgentListener {
 
   /** May filter out agent internal call stacks based on the config. */
   private StackTraceFilter buildStackTraceFilter(Config config) {
-    boolean includeAgentInternals = config.getBoolean(CONFIG_KEY_INCLUDE_AGENT_INTERNALS, false);
-    boolean includeJVMInternals = config.getBoolean(CONFIG_KEY_INCLUDE_JVM_INTERNALS, false);
-    return new StackTraceFilter(includeAgentInternals, includeJVMInternals);
+    boolean includeAgentInternalStacks = Configuration.getIncludeAgentInternalStacks(config);
+    boolean includeJVMInternalStacks = Configuration.getIncludeJvmInternalStacks(config);
+    return new StackTraceFilter(includeAgentInternalStacks, includeJVMInternalStacks);
   }
 
   private Map<String, String> buildJfrSettings(Config config) {

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationLoggerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationLoggerTest.java
@@ -19,6 +19,7 @@ package com.splunk.opentelemetry.profiler;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_CALL_STACK_INTERVAL;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_DEPRECATED_THREADDUMP_PERIOD;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_ENABLE_PROFILER;
+import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_INCLUDE_INTERNAL_STACKS;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_INGEST_URL;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_KEEP_FILES;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_MEMORY_ENABLED;
@@ -27,6 +28,7 @@ import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_PROFILE
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_RECORDING_DURATION;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_TLAB_ENABLED;
 import static com.splunk.opentelemetry.profiler.Configuration.DEFAULT_CALL_STACK_INTERVAL;
+import static com.splunk.opentelemetry.profiler.Configuration.DEFAULT_INCLUDE_INTERNAL_STACKS;
 import static com.splunk.opentelemetry.profiler.Configuration.DEFAULT_MEMORY_ENABLED;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -57,6 +59,8 @@ class ConfigurationLoggerTest {
     when(config.getBoolean(CONFIG_KEY_TLAB_ENABLED, false)).thenReturn(true);
     when(config.getDuration(CONFIG_KEY_CALL_STACK_INTERVAL, DEFAULT_CALL_STACK_INTERVAL))
         .thenReturn(Duration.ofSeconds(21));
+    when(config.getBoolean(CONFIG_KEY_INCLUDE_INTERNAL_STACKS, DEFAULT_INCLUDE_INTERNAL_STACKS))
+        .thenReturn(true);
     when(config.getDuration(CONFIG_KEY_DEPRECATED_THREADDUMP_PERIOD, null))
         .thenReturn(Duration.ofMillis(500));
 
@@ -75,6 +79,7 @@ class ConfigurationLoggerTest {
     log.assertContains("         splunk.profiler.memory.enabled : false");
     log.assertContains("           splunk.profiler.tlab.enabled : true");
     log.assertContains("    splunk.profiler.call.stack.interval : PT21S");
+    log.assertContains("splunk.profiler.include.internal.stacks : true");
     log.assertContains("      splunk.profiler.period.threaddump : PT0.5S");
   }
 

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/StackTraceFilterTest.java
@@ -36,6 +36,15 @@ class StackTraceFilterTest {
           + "\tat java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/Thr\n"
           + "\tat java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)\n";
 
+  public static final String AGENT_INTERNAL_STACK =
+      "\"Batched Logs Exporter\" #15 daemon prio=5 os_prio=0 cpu=267.95ms elapsed=436.16s tid=0x00007f5194044800 nid=0xd9 waiting on condition  [0x00007f51d0467000]\n"
+          + "   java.lang.Thread.State: TIMED_WAITING (parking)\n"
+          + "\tat jdk.internal.misc.Unsafe.park(java.base@11.0.12/Native Method)\n"
+          + "\t- parking to wait for  <0x00000000c3a14ba8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)\n"
+          + "\tat java.util.concurrent.locks.LockSupport.parkNanos(java.base@11.0.12/LockSupport.java:234)\n"
+          + "\tat java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(java.base@11.0.12/AbstractQueuedSynchronizer.java:2123)\n"
+          + "\t[...]";
+
   @Test
   void oneLiners() {
     StackTraceFilter filter = new StackTraceFilter(false);
@@ -61,11 +70,11 @@ class StackTraceFilterTest {
     String stack =
         "\"Batched Logs Exporter\" #15 daemon prio=5 os_prio=0 cpu=267.95ms elapsed=436.16s tid=0x00007f5194044800 nid=0xd9 waiting on condition  [0x00007f51d0467000]\n"
             + "   java.lang.Thread.State: TIMED_WAITING (parking)\n"
-            + "        at jdk.internal.misc.Unsafe.park(java.base@11.0.12/Native Method)\n"
-            + "        - parking to wait for  <0x00000000c3a14ba8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)\n"
-            + "        at java.util.concurrent.locks.LockSupport.parkNanos(java.base@11.0.12/LockSupport.java:234)\n"
-            + "        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(java.base@11.0.12/AbstractQueuedSynchronizer.java:2123)\n"
-            + "        [...]";
+            + "\tat jdk.internal.misc.Unsafe.park(java.base@11.0.12/Native Method)\n"
+            + "\t- parking to wait for  <0x00000000c3a14ba8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)\n"
+            + "\tat java.util.concurrent.locks.LockSupport.parkNanos(java.base@11.0.12/LockSupport.java:234)\n"
+            + "\tat java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(java.base@11.0.12/AbstractQueuedSynchronizer.java:2123)\n"
+            + "\t[...]";
     StackTraceFilter filter = new StackTraceFilter(false);
     assertFalse(filter.test(stack, 0, stack.length() - 1));
   }
@@ -75,9 +84,9 @@ class StackTraceFilterTest {
     String stack =
         "\"BatchSpanProcessor_WorkerThread-1\" #12 daemon prio=5 os_prio=0 cpu=21.68ms elapsed=437.90s tid=0x00007f5200a8f000 nid=0xd4 waiting on condition  [0x00007f51d12ab000]\n"
             + "   java.lang.Thread.State: TIMED_WAITING (parking)\n"
-            + "        at jdk.internal.misc.Unsafe.park(java.base@11.0.12/Native Method)\n"
-            + "        - parking to wait for  <0x00000000c3401f88> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)\n"
-            + "        [...]";
+            + "\tat jdk.internal.misc.Unsafe.park(java.base@11.0.12/Native Method)\n"
+            + "\t- parking to wait for  <0x00000000c3401f88> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)\n"
+            + "\t[...]";
     StackTraceFilter filter = new StackTraceFilter(false);
     assertFalse(filter.test(stack, 0, stack.length() - 1));
   }
@@ -92,8 +101,8 @@ class StackTraceFilterTest {
     stack =
         "\"JFR Periodic Tasks\" #17 daemon prio=5 os_prio=0 cpu=171.78ms elapsed=435.78s tid=0x00007f5194ecd800 nid=0xdb in Object.wait()  [0x00007f5187dfe000]\n"
             + "   java.lang.Thread.State: TIMED_WAITING (on object monitor)\n"
-            + "        at java.lang.Object.wait(java.base@11.0.12/Native Method)\n"
-            + "        [...]";
+            + "\tat java.lang.Object.wait(java.base@11.0.12/Native Method)\n"
+            + "\t[...]";
     assertFalse(filter.test(stack, 0, stack.length() - 1));
   }
 
@@ -102,19 +111,19 @@ class StackTraceFilterTest {
     String stack =
         "\"JFR Recording Scheduler\" #28 daemon prio=5 os_prio=31 cpu=0.11ms elapsed=320.50s tid=0x00007fb9cefc2000 nid=0x7203 in Object.wait()  [0x00007000126c5000]\n"
             + "   java.lang.Thread.State: WAITING (on object monitor)\n"
-            + "        at java.lang.Object.wait(java.base@11.0.9.1/Native Method)\n"
-            + "        - waiting on <0x0000000600ca4e70> (a java.util.TaskQueue)\n"
-            + "        at java.lang.Object.wait(java.base@11.0.9.1/Object.java:328)\n"
-            + "        at java.util.TimerThread.mainLoop(java.base@11.0.9.1/Timer.java:527)\n"
-            + "        - waiting to re-lock in wait() <0x0000000600ca4e70> (a java.util.TaskQueue)\n"
-            + "        at java.util.TimerThread.run(java.base@11.0.9.1/Timer.java:506)";
-    StackTraceFilter filter = new StackTraceFilter(true);
+            + "\tat java.lang.Object.wait(java.base@11.0.9.1/Native Method)\n"
+            + "\t- waiting on <0x0000000600ca4e70> (a java.util.TaskQueue)\n"
+            + "\tat java.lang.Object.wait(java.base@11.0.9.1/Object.java:328)\n"
+            + "\tat java.util.TimerThread.mainLoop(java.base@11.0.9.1/Timer.java:527)\n"
+            + "\t- waiting to re-lock in wait() <0x0000000600ca4e70> (a java.util.TaskQueue)\n"
+            + "\tat java.util.TimerThread.run(java.base@11.0.9.1/Timer.java:506)";
+    StackTraceFilter filter = new StackTraceFilter(true, true);
     assertTrue(filter.test(stack, 0, stack.length() - 1));
     stack =
         "\"JFR Periodic Tasks\" #17 daemon prio=5 os_prio=0 cpu=171.78ms elapsed=435.78s tid=0x00007f5194ecd800 nid=0xdb in Object.wait()  [0x00007f5187dfe000]\n"
             + "   java.lang.Thread.State: TIMED_WAITING (on object monitor)\n"
-            + "        at java.lang.Object.wait(java.base@11.0.12/Native Method)\n"
-            + "        [...]";
+            + "\tat java.lang.Object.wait(java.base@11.0.12/Native Method)\n"
+            + "\t[...]";
     assertTrue(filter.test(stack, 0, stack.length() - 1));
   }
 
@@ -145,10 +154,10 @@ class StackTraceFilterTest {
     String stack =
         "\"logback-7\" #75 daemon prio=5 os_prio=31 cpu=0.25ms elapsed=173.79s tid=0x00007fb98f0ad000 nid=0xd30b waiting on condiion  [0x0000700014a2e000]\n"
             + "   java.lang.Thread.State: WAITING (parking)\n"
-            + "        at jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)\n"
-            + "        - parking to wait for  <0x00000006127b80f8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)\n"
-            + "        at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)\n"
-            + "        at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)\n";
+            + "\tat jdk.internal.misc.Unsafe.park(java.base@11.0.9.1/Native Method)\n"
+            + "\t- parking to wait for  <0x00000006127b80f8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)\n"
+            + "\tat java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)\n"
+            + "\tat java.lang.Thread.run(java.base@11.0.9.1/Thread.java:834)\n";
 
     String beforeStack = "something above\n";
     String afterStack = "something below\n";
@@ -161,18 +170,34 @@ class StackTraceFilterTest {
   }
 
   @Test
-  void omitStacksEntirelyJvmInternal() {
-    String stack = JVM_INTERNAL_STACK;
-    StackTraceFilter filter = new StackTraceFilter(false);
+  void canIncludeOnlyAgentInternalStacks() {
+    String stack = AGENT_INTERNAL_STACK;
+    StackTraceFilter filter = new StackTraceFilter(true, false);
+    boolean result = filter.test(stack, 0, stack.length() - 1);
+    assertTrue(result);
+  }
+
+  @Test
+  void canExcludeOnlyAgentInternalStacks() {
+    String stack = AGENT_INTERNAL_STACK;
+    StackTraceFilter filter = new StackTraceFilter(false, true);
     boolean result = filter.test(stack, 0, stack.length() - 1);
     assertFalse(result);
   }
 
   @Test
-  void canIncludeJvmInternalStacks() {
+  void canIncludeOnlyJvmInternalStacks() {
     String stack = JVM_INTERNAL_STACK;
     StackTraceFilter filter = new StackTraceFilter(false, true);
     boolean result = filter.test(stack, 0, stack.length() - 1);
     assertTrue(result);
+  }
+
+  @Test
+  void canExcludeOnlyJvmInternalStacks() {
+    String stack = JVM_INTERNAL_STACK;
+    StackTraceFilter filter = new StackTraceFilter(true, false);
+    boolean result = filter.test(stack, 0, stack.length() - 1);
+    assertFalse(result);
   }
 }


### PR DESCRIPTION
Since having to separately assign two options for enabling internal stack traces (agent internals vs JVM internals) can be confusing, there is now an option that toggles both: `splunk.profiler.include.internal.stacks`. The previous options still exist internally, but the new option is the default value for them if they are not explicitly specified. As setting them separately could only have very corner case uses, the documentation now only mentions the unified toggle.

Previously the option to enable agent internal stack traces also made JVM internal traces be reported. This was rather unintuitive, and therefore changed it so that JVM internal traces can still stay excluded even if agent internal traces are included.

Fixed tests using a different stack trace format (whitespace difference) than we really have, causing those to be never considered as JVM internal traces even if they would have otherwise qualified.