### PR TITLE
Remove host.name resource attribute

### DIFF
--- a/custom/src/main/java/com/splunk/opentelemetry/HostNameRemovingCustomizer.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/HostNameRemovingCustomizer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+
+@AutoService(AutoConfigurationCustomizerProvider.class)
+public class HostNameRemovingCustomizer implements AutoConfigurationCustomizerProvider {
+
+  @Override
+  public void customize(AutoConfigurationCustomizer autoConfiguration) {
+    autoConfiguration.addResourceCustomizer(HostNameRemovingCustomizer::removeHostName);
+  }
+
+  private static Resource removeHostName(Resource resource, ConfigProperties config) {
+    return Resource.create(
+        resource.getAttributes().toBuilder().remove(ResourceAttributes.HOST_NAME).build(),
+        resource.getSchemaUrl());
+  }
+}

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/SpringBootSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/SpringBootSmokeTest.java
@@ -73,6 +73,9 @@ public class SpringBootSmokeTest extends AppServerTest {
     // verify that correct service name is set in the resource
     assertTrue(traces.resourceExists("service.name", "smoke-test"));
     assertTrue(traces.resourceExists("splunk.distro.version", v -> !v.isEmpty()));
+
+    // verify that host.name is removed
+    assertTrue(traces.resourceDoesNotExist("host.name"));
   }
 
   protected void assertMetrics(MetricsInspector metrics) {

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/TraceInspector.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/TraceInspector.java
@@ -80,6 +80,14 @@ public class TraceInspector {
             kv -> kv.getKey().equals(key) && valuePredicate.test(kv.getValue().getStringValue()));
   }
 
+  public boolean resourceDoesNotExist(String key) {
+    return traces.stream()
+        .flatMap(it -> it.getResourceSpansList().stream())
+        .map(ResourceSpans::getResource)
+        .flatMap(resource -> resource.getAttributesList().stream())
+        .noneMatch(kv -> kv.getKey().equals(key));
+  }
+
   public int countTraceIds() {
     return getTraceIds().size();
   }


### PR DESCRIPTION
The `host.name` attribute was incorrectly detected in cloud environments (AWS, Azure, ...) so as a quick fix it was decided to just remove it.