### PR TITLE
Fix bug related to iteration over PriorityQueue

### DIFF
--- a/instrumentation/khttp/src/main/java/com/splunk/opentelemetry/instrumentation/khttp/KHttpHttpClientHttpAttributesGetter.java
+++ b/instrumentation/khttp/src/main/java/com/splunk/opentelemetry/instrumentation/khttp/KHttpHttpClientHttpAttributesGetter.java
@@ -19,71 +19,70 @@ package com.splunk.opentelemetry.instrumentation.khttp;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesGetter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.List;
 import khttp.responses.Response;
 import org.jetbrains.annotations.Nullable;
 
-final class KHttpHttpClientHttpAttributesExtractor
-    extends HttpClientAttributesExtractor<RequestWrapper, Response> {
+final class KHttpHttpClientHttpAttributesGetter
+    implements HttpClientAttributesGetter<RequestWrapper, Response> {
   @Nullable
   @Override
-  protected String url(RequestWrapper requestWrapper) {
+  public String url(RequestWrapper requestWrapper) {
     return requestWrapper.uri;
   }
 
   @Nullable
   @Override
-  protected String flavor(RequestWrapper requestWrapper, @Nullable Response response) {
+  public String flavor(RequestWrapper requestWrapper, @Nullable Response response) {
     return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
   }
 
   @Nullable
   @Override
-  protected String method(RequestWrapper requestWrapper) {
+  public String method(RequestWrapper requestWrapper) {
     return requestWrapper.method;
   }
 
   @Override
-  protected List<String> requestHeader(RequestWrapper requestWrapper, String name) {
+  public List<String> requestHeader(RequestWrapper requestWrapper, String name) {
     String header = requestWrapper.headers.get(name);
     return header != null ? singletonList(header) : emptyList();
   }
 
   @Nullable
   @Override
-  protected Long requestContentLength(RequestWrapper requestWrapper, @Nullable Response response) {
+  public Long requestContentLength(RequestWrapper requestWrapper, @Nullable Response response) {
     return null;
   }
 
   @Nullable
   @Override
-  protected Long requestContentLengthUncompressed(
+  public Long requestContentLengthUncompressed(
       RequestWrapper requestWrapper, @Nullable Response response) {
     return null;
   }
 
   @Override
-  protected Integer statusCode(RequestWrapper requestWrapper, Response response) {
+  public Integer statusCode(RequestWrapper requestWrapper, Response response) {
     return response.getStatusCode();
   }
 
   @Nullable
   @Override
-  protected Long responseContentLength(RequestWrapper requestWrapper, Response response) {
+  public Long responseContentLength(RequestWrapper requestWrapper, Response response) {
     return null;
   }
 
   @Nullable
   @Override
-  protected Long responseContentLengthUncompressed(
-      RequestWrapper requestWrapper, Response response) {
+  public Long responseContentLengthUncompressed(RequestWrapper requestWrapper, Response response) {
     return null;
   }
 
   @Override
-  protected List<String> responseHeader(
+  public List<String> responseHeader(
       RequestWrapper requestWrapper, Response response, String name) {
     String header = response.getHeaders().get(name);
     return header != null ? singletonList(header) : emptyList();

--- a/instrumentation/khttp/src/main/java/com/splunk/opentelemetry/instrumentation/khttp/KHttpSingletons.java
+++ b/instrumentation/khttp/src/main/java/com/splunk/opentelemetry/instrumentation/khttp/KHttpSingletons.java
@@ -20,6 +20,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.PeerServiceAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
@@ -32,18 +33,18 @@ public final class KHttpSingletons {
   private static final Instrumenter<RequestWrapper, Response> INSTRUMENTER;
 
   static {
-    HttpClientAttributesExtractor<RequestWrapper, Response> httpAttributesExtractor =
-        new KHttpHttpClientHttpAttributesExtractor();
     KHttpHttpClientNetAttributesGetter netAttributesGetter =
         new KHttpHttpClientNetAttributesGetter();
+    HttpClientAttributesGetter<RequestWrapper, Response> httpAttributesGetter =
+        new KHttpHttpClientHttpAttributesGetter();
 
     INSTRUMENTER =
         Instrumenter.<RequestWrapper, Response>builder(
                 GlobalOpenTelemetry.get(),
                 INSTRUMENTATION_NAME,
-                HttpSpanNameExtractor.create(httpAttributesExtractor))
-            .setSpanStatusExtractor(HttpSpanStatusExtractor.create(httpAttributesExtractor))
-            .addAttributesExtractor(httpAttributesExtractor)
+                HttpSpanNameExtractor.create(httpAttributesGetter))
+            .setSpanStatusExtractor(HttpSpanStatusExtractor.create(httpAttributesGetter))
+            .addAttributesExtractor(HttpClientAttributesExtractor.create(httpAttributesGetter))
             .addAttributesExtractor(NetClientAttributesExtractor.create(netAttributesGetter))
             .addAttributesExtractor(PeerServiceAttributesExtractor.create(netAttributesGetter))
             .addRequestMetrics(HttpClientMetrics.get())

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/EventProcessingChain.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/EventProcessingChain.java
@@ -22,7 +22,6 @@ import com.splunk.opentelemetry.profiler.events.ContextAttached;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -38,7 +37,7 @@ class EventProcessingChain {
   private final SpanContextualizer spanContextualizer;
   private final ThreadDumpProcessor threadDumpProcessor;
   private final TLABProcessor tlabProcessor;
-  private final List<RecordedEvent> buffer = new LinkedList<>();
+  private final List<RecordedEvent> buffer = new ArrayList<>();
   private final EventStats eventStats =
       logger.isDebugEnabled() ? new EventStatsImpl() : new NoOpEventStats();
   private final ChunkTracker chunkTracker;

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/EventProcessingChainTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/EventProcessingChainTest.java
@@ -74,8 +74,8 @@ class EventProcessingChainTest {
     InOrder inOrder = inOrder(contextualizer, threadDumpProcessor, tlabProcessor);
     inOrder.verify(threadDumpProcessor).accept(threadDump);
     inOrder.verify(tlabProcessor).accept(tlab1);
-    inOrder.verify(tlabProcessor).accept(tlab2);
     inOrder.verify(contextualizer).updateContext(contextEvent);
+    inOrder.verify(tlabProcessor).accept(tlab2);
     inOrder.verifyNoMoreInteractions();
   }
 

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/EventProcessingChainTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/EventProcessingChainTest.java
@@ -16,7 +16,9 @@
 
 package com.splunk.opentelemetry.profiler;
 
+import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -155,6 +157,38 @@ class EventProcessingChainTest {
     }
   }
 
+  @Test
+  void eventsDispatchedInTimeOrder() {
+    EventType contextAttachedType = newEventType(ContextAttached.EVENT_NAME);
+    EventType threadDumpType = newEventType(ThreadDumpProcessor.EVENT_NAME);
+    Instant now = Instant.now();
+    RecordedEvent event1 = newEvent(contextAttachedType, now.plus(1, SECONDS));
+    RecordedEvent event2 = newEvent(contextAttachedType, now.plus(2, SECONDS));
+    RecordedEvent event3 = newEvent(threadDumpType, now.plus(3, SECONDS));
+    RecordedEvent event4 = newEvent(null, null);
+
+    // Our events are in time order: context1, context2, threadDump1, threadDump2.
+    // However, we will send them to the chain out of order: context2, context1, threadDump.
+    // Expectation is that we see them dispatched in the correct order.
+    // The "chunk" is finished only after event4, and event4 is part of a new chunk so is not
+    // dispatched.
+
+    EventProcessingChain.ChunkTracker chunkTracker = mock(EventProcessingChain.ChunkTracker.class);
+    when(chunkTracker.isNewChunk(isA(RecordedEvent.class))).thenReturn(false, false, false, true);
+    EventProcessingChain chain =
+        new EventProcessingChain(contextualizer, threadDumpProcessor, tlabProcessor, chunkTracker);
+    chain.accept(event2); // Out of order
+    chain.accept(event1); // Out of order
+    chain.accept(event3);
+    chain.accept(event4);
+
+    InOrder ordered = inOrder(contextualizer, threadDumpProcessor);
+    ordered.verify(contextualizer).updateContext(event1);
+    ordered.verify(contextualizer).updateContext(event2);
+    ordered.verify(threadDumpProcessor).accept(event3);
+    ordered.verifyNoMoreInteractions();
+  }
+
   private EventType newEventType(String name) {
     EventType type = mock(EventType.class);
     when(type.getName()).thenReturn(name);
@@ -163,7 +197,9 @@ class EventProcessingChainTest {
 
   private RecordedEvent newEvent(EventType eventType, Instant startTime) {
     RecordedEvent event = mock(RecordedEvent.class);
-    when(event.getEventType()).thenReturn(eventType);
+    if (eventType != null) {
+      when(event.getEventType()).thenReturn(eventType);
+    }
     if (startTime != null) {
       when(event.getStartTime()).thenReturn(startTime);
     }


### PR DESCRIPTION
PriorityQueue does not have a guarantee ordered iteration. This caused a bug that prevented the JFR events from being dispatched in time order. This has considerable consequences. 

The PriorityQueue was well intentioned as part comments in of #467 (commit d7fb40ac84b8a965bc746299ca155e916acf81dc), but ultimately introduced this problem.

Note: The test is only a loose guarantee. It is possible to reorder the events and still have the test pass, due to the inconsistency of iteration.