### PR TITLE
Split out smoke-tests in nightly build

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -24,7 +24,7 @@ jobs:
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
 
       - name: Build and test
-        run: ./gradlew build --scan --no-daemon
+        run: ./gradlew build -x :smoke-tests:test --scan --no-daemon
 
   setup-muzzle-matrix:
     runs-on: ubuntu-20.04
@@ -80,9 +80,53 @@ jobs:
           max_attempts: 3
           command: ./gradlew ${{ matrix.module }}:muzzle --stacktrace --no-daemon
 
+  smoke-test:
+    runs-on: ${{ matrix.os }}
+    permissions:
+      packages: read
+    strategy:
+      matrix:
+        os: [ windows-2019, ubuntu-20.04 ]
+        suite: [ "glassfish", "jboss", "jetty", "liberty", "profiler", "tomcat", "tomee", "weblogic", "websphere", "wildfly", "other" ]
+        exclude:
+          - os: windows-2019
+            suite: websphere
+          - os: windows-2019
+            suite: profiler
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2.4.0
+
+      - name: Set up JDK 11 for running Gradle
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 11.0.11+9
+
+      - name: Cache Gradle Wrapper
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        if: startsWith(matrix.os, 'ubuntu')
+
+      - name: Pull proprietary images
+        run: ./gradlew pullProprietaryTestImages --scan --no-daemon
+        if: startsWith(matrix.os, 'ubuntu')
+
+      - name: Test
+        run: ./gradlew :smoke-tests:test -PsmokeTestSuite=${{ matrix.suite }} --scan --no-daemon
+
   issue:
     name: Open issue on failure
-    needs: [ build, muzzle ]
+    needs: [ build, muzzle, smoke-test ]
     runs-on: ubuntu-20.04
     permissions:
       issues: write


### PR DESCRIPTION
Fixes #662 
Fixes #661 
🤞 

I suspect our smoke tests just take too long for the night build to finish; let's split them out (same as in CI/PR builds) and hope that'll fix the issue.