### PR TITLE
Wait for weblogic to start

### DIFF
--- a/instrumentation/weblogic/src/main/java/com/splunk/opentelemetry/instrumentation/weblogic/metrics/ServerLifecycleListenerInstrumentation.java
+++ b/instrumentation/weblogic/src/main/java/com/splunk/opentelemetry/instrumentation/weblogic/metrics/ServerLifecycleListenerInstrumentation.java
@@ -39,7 +39,7 @@ public class ServerLifecycleListenerInstrumentation implements TypeInstrumentati
 
   @SuppressWarnings("unused")
   public static class InitializeAdvice {
-    @Advice.OnMethodExit(suppress = Throwable.class)
+    @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void onEnter() {
       ThreadPoolMetrics.initialize();
     }

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/WebLogicSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/WebLogicSmokeTest.java
@@ -18,8 +18,10 @@ package com.splunk.opentelemetry;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.splunk.opentelemetry.helper.TargetWaitStrategy;
 import com.splunk.opentelemetry.helper.TestImage;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
@@ -47,6 +49,12 @@ class WebLogicSmokeTest extends AppServerTest {
         .splunkLinux("12.2.1.4", V12_2_ATTRIBUTES, VMS_HOTSPOT, "8")
         .splunkLinux("14.1.1.0", V14_ATTRIBUTES, VMS_HOTSPOT, "8", "11")
         .stream();
+  }
+
+  @Override
+  protected TargetWaitStrategy getWaitStrategy() {
+    return new TargetWaitStrategy.Log(
+        Duration.ofMinutes(5), ".*<Server state changed to RUNNING.>.*");
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Resolves https://github.com/signalfx/splunk-otel-java/issues/673
Resolves https://github.com/signalfx/splunk-otel-java/issues/668
Resolves https://github.com/signalfx/splunk-otel-java/issues/667
Weblogic metrics are registered fairly late in startup process, waiting until running message is seen should ensure that they are registered before our tests start.