### PR TITLE
Remove bogus info from allocation stacks

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/TLABProcessor.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/TLABProcessor.java
@@ -112,14 +112,7 @@ public class TLABProcessor implements Consumer<RecordedEvent> {
     RecordedThread thread = event.getThread();
     String name = thread == null ? "unknown" : thread.getJavaName();
     long id = thread == null ? 0 : thread.getJavaThreadId();
-    return "\""
-        + name
-        + "\""
-        + " #"
-        + id
-        + "\n"
-        + "   java.lang.Thread.State: UNKNOWN\n"
-        + stack;
+    return "\"" + name + "\"" + " #" + id + "\n" + "   java.lang.Thread.State: UNKNOWN\n" + stack;
   }
 
   static Builder builder(Config config) {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/TLABProcessor.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/TLABProcessor.java
@@ -117,7 +117,6 @@ public class TLABProcessor implements Consumer<RecordedEvent> {
         + "\""
         + " #"
         + id
-        + " prio=0 os_prio=0 cpu=0ms elapsed=0s tid=0 nid=0 unknown"
         + "\n"
         + "   java.lang.Thread.State: UNKNOWN\n"
         + stack;

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/TLABProcessorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/TLABProcessorTest.java
@@ -110,7 +110,7 @@ class TLABProcessorTest {
     AtomicReference<LogData> seenLogData = new AtomicReference<>();
     LogProcessor consumer = seenLogData::set;
     String stackAsString =
-        "\"mockingbird\" #606 prio=0 os_prio=0 cpu=0ms elapsed=0s tid=0 nid=0 unknown\n"
+        "\"mockingbird\" #606\n"
             + "   java.lang.Thread.State: UNKNOWN\n"
             + "i am a serialized stack believe me";
 


### PR DESCRIPTION
Shouldn't be needed since https://github.com/signalfx/gdi-specification/commit/b09e176ca3771c3ef19fc9d23e8722fc77a3b6e9