### PR TITLE
Profiler: Smoke test matrix image publishing

### DIFF
--- a/.github/workflows/publish-profiling-petclinic-base.yml
+++ b/.github/workflows/publish-profiling-petclinic-base.yml
@@ -1,9 +1,12 @@
 name: publish-profiling-petclinic-base-image
 on: workflow_dispatch
 jobs:
-  push_to_registry:
-    name: publish custom spring-petclinic base image for profiling
+  push_to_registry_linux:
+    name: publish custom linux spring-petclinic base image for profiling
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        jdk_version: [8, 11, 17]
     permissions:
       packages: write
       contents: read
@@ -21,5 +24,33 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          file: smoke-tests/profiling-petclinic-base/Dockerfile
-          tags: ghcr.io/signalfx/splunk-otel-java/profiling-petclinic-base:latest
+          file: smoke-tests/profiling-petclinic-base/linux/Dockerfile
+          build-args: |
+            jdkVersion=${{ matrix.jdk_version }}
+          tags: ghcr.io/signalfx/splunk-otel-java/profiling-petclinic-base-linux-jdk${{ matrix.jdk_version }}:latest
+  push_to_registry_windows:
+    name: publish custom windows spring-petclinic base image for profiling
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        jdk_version: [8, 11, 17]
+    defaults:
+      run:
+        shell: bash
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Support longpaths
+        run: git config --system core.longpaths true
+      - name: check out the repo
+        uses: actions/checkout@v2.4.0
+      - name: Login to GitHub Container Registry
+        uses: azure/docker-login@v1
+        with:
+          login-server: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build & push docker image
+        run: ./build.sh ${{ matrix.jdk_version }}
+        working-directory: smoke-tests/profiling-base-petclinic/windows

--- a/smoke-tests/profiling-base-petclinic/linux/Dockerfile
+++ b/smoke-tests/profiling-base-petclinic/linux/Dockerfile
@@ -1,6 +1,8 @@
 # Dockerfile for the application under test
-# Builds petclinic-rest in a java 8 container new enough to support JFR
-FROM adoptopenjdk:8
+# Builds petclinic-rest using the specified JDK version (minimum is 8 for JFR)
+ARG jdkVersion=8
+
+FROM adoptopenjdk:${jdkVersion}
 
 RUN apt update && apt install -y git
 RUN git clone https://github.com/spring-petclinic/spring-petclinic-rest.git /src

--- a/smoke-tests/profiling-base-petclinic/windows/Dockerfile
+++ b/smoke-tests/profiling-base-petclinic/windows/Dockerfile
@@ -1,0 +1,19 @@
+# Dockerfile for the application under test
+# Builds petclinic-rest using the specified JDK version (minimum is 8 for JFR)
+ARG jdkVersion=8
+
+FROM eclipse-temurin:${jdkVersion}-windowsservercore-1809 as builder
+
+ADD https://github.com/spring-petclinic/spring-petclinic-rest/archive/refs/heads/master.zip /src.zip
+RUN ["powershell", "-Command", "expand-archive -Path /src.zip -DestinationPath /src"]
+
+WORKDIR /src/spring-petclinic-rest-master/
+RUN ["/src/spring-petclinic-rest-master/mvnw.cmd", "-Dmaven.test.skip=true", "package"]
+WORKDIR /src/spring-petclinic-rest-master/target
+RUN ["powershell", "-Command", "Get-ChildItem -Path spring-petclinic-rest-*.jar | ForEach { Rename-Item $_.FullName -NewName spring-petclinic-rest.jar }"]
+
+FROM eclipse-temurin:${jdkVersion}-windowsservercore-1809
+
+RUN ["powershell", "-Command", "New-Item -ItemType directory -Path /app"]
+COPY --from=builder /src/spring-petclinic-rest-master/target/spring-petclinic-rest.jar /app/spring-petclinic-rest.jar
+WORKDIR /app

--- a/smoke-tests/profiling-base-petclinic/windows/build.sh
+++ b/smoke-tests/profiling-base-petclinic/windows/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+IMAGE_NAME="ghcr.io/signalfx/splunk-otel-java/profiling-petclinic-base-windows-jdk$1:latest"
+
+echo "Building image ${IMAGE_NAME} ..."
+
+docker build --build-arg jdkVersion=$1 -t "$IMAGE_NAME" .
+docker push "$IMAGE_NAME"


### PR DESCRIPTION
Added workflows for publishing Windows and Linux versions of the profiler smoke test base Petclinic image for each of JDK 8, 11 and 17.