### PR TITLE
profiler: Use temurin as base image for profiler smoke test

### DIFF
--- a/smoke-tests/profiling-base-petclinic/linux/Dockerfile
+++ b/smoke-tests/profiling-base-petclinic/linux/Dockerfile
@@ -2,7 +2,7 @@
 # Builds petclinic-rest using the specified JDK version (minimum is 8 for JFR)
 ARG jdkVersion=8
 
-FROM adoptopenjdk:${jdkVersion}
+FROM eclipse-temurin:${jdkVersion}
 
 RUN apt update && apt install -y git
 RUN git clone https://github.com/spring-petclinic/spring-petclinic-rest.git /src


### PR DESCRIPTION
The legacy adoptopenjdk images don't have JDK 17, which caused building of that version of the image to fail.