### PR TITLE
profiler: Explain splunk.profiler.enabled behavior in readme

### DIFF
--- a/profiler/README.md
+++ b/profiler/README.md
@@ -57,9 +57,10 @@ property or as environment variables (by making them uppercase and replacing dot
 |`splunk.profiler.period.{eventName}`      | n/a                    | DEPRECATED. Use `splunk.profiler.call.stack.interval` instead.
 
 If the `splunk.profiler.enabled` option is not enabled, all profiling features are disabled. For 
-example, setting `splunk.profiler.memory.enabled` to `true`has no effect if `splunk.profiler.enabled`
-is set to `false`. Similarly, there is no separate toggle for periodic collection of call stacks (thread dumps),
-as this feature is enabled only when the profiler is enabled.
+example, setting `splunk.profiler.memory.enabled` to `true` has no effect if 
+`splunk.profiler.enabled` is set to `false`. Similarly, there is no separate toggle for periodic 
+collection of call stacks (thread dumps), as this feature is enabled only when the profiler is 
+enabled.
 
 # Escape hatch
 

--- a/profiler/README.md
+++ b/profiler/README.md
@@ -56,10 +56,10 @@ property or as environment variables (by making them uppercase and replacing dot
 |`splunk.profiler.tracing.stacks.only`     | false                  | set to `true` to include only stack traces that are linked to a span context |
 |`splunk.profiler.period.{eventName}`      | n/a                    | DEPRECATED. Use `splunk.profiler.call.stack.interval` instead.
 
-If the `splunk.profiler.enabled` option is not enabled, all profiling features are disabled. For 
-example, setting `splunk.profiler.memory.enabled` to `true` has no effect if 
-`splunk.profiler.enabled` is set to `false`. Similarly, there is no separate toggle for periodic 
-collection of call stacks (thread dumps), as this feature is enabled only when the profiler is 
+If the `splunk.profiler.enabled` option is not enabled, all profiling features are disabled. For
+example, setting `splunk.profiler.memory.enabled` to `true` has no effect if
+`splunk.profiler.enabled` is set to `false`. Similarly, there is no separate toggle for periodic
+collection of call stacks (thread dumps), as this feature is enabled only when the profiler is
 enabled.
 
 # Escape hatch

--- a/profiler/README.md
+++ b/profiler/README.md
@@ -56,6 +56,11 @@ property or as environment variables (by making them uppercase and replacing dot
 |`splunk.profiler.tracing.stacks.only`     | false                  | set to `true` to include only stack traces that are linked to a span context |
 |`splunk.profiler.period.{eventName}`      | n/a                    | DEPRECATED. Use `splunk.profiler.call.stack.interval` instead.
 
+If `splunk.profiler.enabled` option is not set to `true`, all profiling features will be disabled,
+even if something else is explicitly enabled. For example, setting `splunk.profiler.memory.enabled`
+to `true` will have no effect in that case. There is no separate toggle for periodic collection of
+call stacks (thread dumps) - this is always enabled when profiler is enabled.
+
 # Escape hatch
 
 The profiler limits its own behavior under two conditions:

--- a/profiler/README.md
+++ b/profiler/README.md
@@ -56,10 +56,10 @@ property or as environment variables (by making them uppercase and replacing dot
 |`splunk.profiler.tracing.stacks.only`     | false                  | set to `true` to include only stack traces that are linked to a span context |
 |`splunk.profiler.period.{eventName}`      | n/a                    | DEPRECATED. Use `splunk.profiler.call.stack.interval` instead.
 
-If `splunk.profiler.enabled` option is not set to `true`, all profiling features will be disabled,
-even if something else is explicitly enabled. For example, setting `splunk.profiler.memory.enabled`
-to `true` will have no effect in that case. There is no separate toggle for periodic collection of
-call stacks (thread dumps) - this is always enabled when profiler is enabled.
+If the `splunk.profiler.enabled` option is not enabled, all profiling features are disabled. For 
+example, setting `splunk.profiler.memory.enabled` to `true`has no effect if `splunk.profiler.enabled`
+is set to `false`. Similarly, there is no separate toggle for periodic collection of call stacks (thread dumps),
+as this feature is enabled only when the profiler is enabled.
 
 # Escape hatch
 


### PR DESCRIPTION
There are some corner cases regarding `splunk.profiler.enabled` option which can be confusing and were not properly explained in the README before:

- Can you specific features (like `splunk.profiler.memory.enabled`) without enabling the main profiler toggle (`splunk.profiler.enabled`)? - answer is currently NO
- Is it possible to enable memory profiling but not call stack/thread dump collection? - answer is currently NO

This is intended as a clarification of the current behavior without any actual changes. There will probably be a follow-up to this to allow disabling call stack collection, at which point this explanation in the readme will be changed to reflect that.