### PR TITLE
Disable failing build on gradle warning

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
-org.gradle.warning.mode=fail
+# Currently causes failure when importing project in IntelliJ
+# org.gradle.warning.mode=fail


### PR DESCRIPTION
It is commented out in otel agent also. See https://youtrack.jetbrains.com/issue/IDEA-272594/Gradle:-The-CompileOptions.annotationProcessorGeneratedSourcesDi