### PR TITLE
Enable Windows+profiler CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,8 +116,6 @@ jobs:
         exclude:
           - os: windows-2019
             suite: websphere
-          - os: windows-2019
-            suite: profiler
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -91,8 +91,6 @@ jobs:
         exclude:
           - os: windows-2019
             suite: websphere
-          - os: windows-2019
-            suite: profiler
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -111,8 +111,6 @@ jobs:
         exclude:
           - os: windows-2019
             suite: websphere
-          - os: windows-2019
-            suite: profiler
       fail-fast: false
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Merging Windows profiler CI workflows into a branch because that allows manually testing that they succeed (with "Run workflow from") before merging them to main.