### PR TITLE
Add support for SPLUNK_REALM environment variable/property

### DIFF
--- a/custom/src/main/java/com/splunk/opentelemetry/RealmAccessTokenChecker.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/RealmAccessTokenChecker.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.instrumentation.api.config.Config;
+import io.opentelemetry.javaagent.extension.AgentListener;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@AutoService(AgentListener.class)
+public class RealmAccessTokenChecker implements AgentListener {
+  private static final Logger log = LoggerFactory.getLogger(RealmAccessTokenChecker.class);
+
+  private final Consumer<String> logWarn;
+
+  @SuppressWarnings("unused")
+  public RealmAccessTokenChecker() {
+    this(log::warn);
+  }
+
+  // visible for tests
+  RealmAccessTokenChecker(Consumer<String> logWarn) {
+    this.logWarn = logWarn;
+  }
+
+  @Override
+  public void beforeAgent(
+      Config config, AutoConfiguredOpenTelemetrySdk autoConfiguredOpenTelemetrySdk) {
+    if (isRealmConfigured(config) && !isAccessTokenConfigured(config)) {
+      logWarn.accept(
+          "Splunk realm is defined, which sets the default endpoint URLs to Splunk ingest URLs. However, access token is not defined, which is required for those endpoints. Please set the access token using the 'SPLUNK_ACCESS_TOKEN' environment variable or the 'splunk.access.token' system property.");
+    }
+  }
+
+  // make sure this listener is one of the first things run by the agent
+  @Override
+  public int order() {
+    return -100;
+  }
+
+  private static boolean isRealmConfigured(Config config) {
+    String realm =
+        config.getString(
+            SplunkConfiguration.SPLUNK_REALM_PROPERTY, SplunkConfiguration.SPLUNK_REALM_NONE);
+    return !realm.equals(SplunkConfiguration.SPLUNK_REALM_NONE);
+  }
+
+  private static boolean isAccessTokenConfigured(Config config) {
+    return config.getString(SplunkConfiguration.SPLUNK_ACCESS_TOKEN, null) != null;
+  }
+}

--- a/custom/src/main/java/com/splunk/opentelemetry/SplunkConfiguration.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/SplunkConfiguration.java
@@ -57,10 +57,9 @@ public class SplunkConfiguration implements ConfigPropertySource {
 
     String realm = getRealm();
     if (!SPLUNK_REALM_NONE.equals(realm)) {
-      config.put("otel.exporter.otlp.traces.protocol", "http/protobuf");
       config.put(
           "otel.exporter.otlp.traces.endpoint",
-          "https://ingest." + realm + ".signalfx.com/v2/trace/otlp");
+          "https://ingest." + realm + ".signalfx.com");
       config.put(
           OTEL_EXPORTER_JAEGER_ENDPOINT, "https://ingest." + realm + ".signalfx.com/v2/trace");
     } else {

--- a/custom/src/main/java/com/splunk/opentelemetry/SplunkConfiguration.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/SplunkConfiguration.java
@@ -57,9 +57,7 @@ public class SplunkConfiguration implements ConfigPropertySource {
 
     String realm = getRealm();
     if (!SPLUNK_REALM_NONE.equals(realm)) {
-      config.put(
-          "otel.exporter.otlp.traces.endpoint",
-          "https://ingest." + realm + ".signalfx.com");
+      config.put("otel.exporter.otlp.traces.endpoint", "https://ingest." + realm + ".signalfx.com");
       config.put(
           OTEL_EXPORTER_JAEGER_ENDPOINT, "https://ingest." + realm + ".signalfx.com/v2/trace");
     } else {

--- a/custom/src/main/java/com/splunk/opentelemetry/SplunkConfiguration.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/SplunkConfiguration.java
@@ -20,6 +20,7 @@ import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.config.ConfigPropertySource;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 @AutoService(ConfigPropertySource.class)
 public class SplunkConfiguration implements ConfigPropertySource {
@@ -27,6 +28,23 @@ public class SplunkConfiguration implements ConfigPropertySource {
   public static final String OTEL_EXPORTER_JAEGER_ENDPOINT = "otel.exporter.jaeger.endpoint";
   public static final String PROFILER_ENABLED_PROPERTY = "splunk.profiler.enabled";
   public static final String PROFILER_MEMORY_ENABLED_PROPERTY = "splunk.profiler.memory.enabled";
+  public static final String SPLUNK_REALM_PROPERTY = "splunk.realm";
+  public static final String SPLUNK_REALM_NONE = "none";
+
+  private final Function<String, String> systemPropertyProvider;
+  private final Function<String, String> envVariableProvider;
+
+  public SplunkConfiguration() {
+    this(System::getProperty, System::getenv);
+  }
+
+  // visible for tests
+  SplunkConfiguration(
+      Function<String, String> systemPropertyProvider,
+      Function<String, String> envVariableProvider) {
+    this.systemPropertyProvider = systemPropertyProvider;
+    this.envVariableProvider = envVariableProvider;
+  }
 
   @Override
   public Map<String, String> getProperties() {
@@ -37,9 +55,19 @@ public class SplunkConfiguration implements ConfigPropertySource {
     // by default no metrics are exported
     config.put("otel.metrics.exporter", "none");
 
-    // http://localhost:9080/v1/trace is the default endpoint for SmartAgent
-    // http://localhost:14268/api/traces is the default endpoint for otel-collector
-    config.put(OTEL_EXPORTER_JAEGER_ENDPOINT, "http://localhost:9080/v1/trace");
+    String realm = getRealm();
+    if (!SPLUNK_REALM_NONE.equals(realm)) {
+      config.put("otel.exporter.otlp.traces.protocol", "http/protobuf");
+      config.put(
+          "otel.exporter.otlp.traces.endpoint",
+          "https://ingest." + realm + ".signalfx.com/v2/trace/otlp");
+      config.put(
+          OTEL_EXPORTER_JAEGER_ENDPOINT, "https://ingest." + realm + ".signalfx.com/v2/trace");
+    } else {
+      // http://localhost:9080/v1/trace is the default endpoint for SmartAgent
+      // http://localhost:14268/api/traces is the default endpoint for otel-collector
+      config.put(OTEL_EXPORTER_JAEGER_ENDPOINT, "http://localhost:9080/v1/trace");
+    }
 
     // instrumentation settings
 
@@ -61,5 +89,16 @@ public class SplunkConfiguration implements ConfigPropertySource {
     config.put("otel.instrumentation.spring-batch.item.enabled", "true");
 
     return config;
+  }
+
+  private String getRealm() {
+    String value = systemPropertyProvider.apply(SPLUNK_REALM_PROPERTY);
+    if (value == null) {
+      value = envVariableProvider.apply("SPLUNK_REALM");
+    }
+    if (value == null) {
+      return SPLUNK_REALM_NONE;
+    }
+    return value;
   }
 }

--- a/custom/src/main/java/com/splunk/opentelemetry/micrometer/SplunkMetricsConfig.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/micrometer/SplunkMetricsConfig.java
@@ -18,8 +18,10 @@ package com.splunk.opentelemetry.micrometer;
 
 import static com.splunk.opentelemetry.SplunkConfiguration.PROFILER_MEMORY_ENABLED_PROPERTY;
 import static com.splunk.opentelemetry.SplunkConfiguration.SPLUNK_ACCESS_TOKEN;
+import static com.splunk.opentelemetry.SplunkConfiguration.SPLUNK_REALM_NONE;
 import static io.micrometer.core.instrument.config.MeterRegistryConfigValidator.checkAll;
 
+import com.splunk.opentelemetry.SplunkConfiguration;
 import io.micrometer.core.instrument.config.validate.Validated;
 import io.micrometer.core.instrument.step.StepRegistryConfig;
 import io.opentelemetry.instrumentation.api.config.Config;
@@ -64,7 +66,7 @@ class SplunkMetricsConfig implements CustomSignalFxConfig {
 
   @Override
   public String uri() {
-    return config.getString(METRICS_ENDPOINT_PROPERTY, DEFAULT_METRICS_ENDPOINT);
+    return config.getString(METRICS_ENDPOINT_PROPERTY, getDefaultEndpoint());
   }
 
   @Override
@@ -96,5 +98,13 @@ class SplunkMetricsConfig implements CustomSignalFxConfig {
         c -> StepRegistryConfig.validate(c),
         c -> Validated.valid("splunk.metrics.endpoint", c.uri()).required().nonBlank(),
         c -> Validated.valid("otel.service.name", c.source()).required().nonBlank());
+  }
+
+  private String getDefaultEndpoint() {
+    String realm = config.getString(SplunkConfiguration.SPLUNK_REALM_PROPERTY, SPLUNK_REALM_NONE);
+    if (SPLUNK_REALM_NONE.equals(realm)) {
+      return DEFAULT_METRICS_ENDPOINT;
+    }
+    return "https://ingest." + realm + ".signalfx.com";
   }
 }

--- a/custom/src/test/java/com/splunk/opentelemetry/RealmAccessTokenCheckerTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/RealmAccessTokenCheckerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry;
+
+import static com.splunk.opentelemetry.SplunkConfiguration.SPLUNK_ACCESS_TOKEN;
+import static com.splunk.opentelemetry.SplunkConfiguration.SPLUNK_REALM_NONE;
+import static com.splunk.opentelemetry.SplunkConfiguration.SPLUNK_REALM_PROPERTY;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.opentelemetry.instrumentation.api.config.Config;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RealmAccessTokenCheckerTest {
+  @Mock Consumer<String> logWarn;
+  @Mock AutoConfiguredOpenTelemetrySdk autoConfiguredSdk;
+
+  @Test
+  void shouldNotLogWarnWhenNoRealmSet() {
+    // given
+    var config = Config.builder().build();
+    var underTest = new RealmAccessTokenChecker(logWarn);
+
+    // when
+    underTest.beforeAgent(config, autoConfiguredSdk);
+
+    // then
+    verifyNoInteractions(logWarn);
+  }
+
+  @Test
+  void shouldNotLogWarnWhenRealmIsNone() {
+    // given
+    var config = Config.builder().addProperty(SPLUNK_REALM_PROPERTY, SPLUNK_REALM_NONE).build();
+    var underTest = new RealmAccessTokenChecker(logWarn);
+
+    // when
+    underTest.beforeAgent(config, autoConfiguredSdk);
+
+    // then
+    verifyNoInteractions(logWarn);
+  }
+
+  @Test
+  void shouldNotLogWarnWhenAccessTokenIsConfigured() {
+    // given
+    var config =
+        Config.builder()
+            .addProperty(SPLUNK_REALM_PROPERTY, "test0")
+            .addProperty(SPLUNK_ACCESS_TOKEN, "token")
+            .build();
+    var underTest = new RealmAccessTokenChecker(logWarn);
+
+    // when
+    underTest.beforeAgent(config, autoConfiguredSdk);
+
+    // then
+    verifyNoInteractions(logWarn);
+  }
+
+  @Test
+  void shouldLogWarnWhenOnlyRealmIsConfigured() {
+    // given
+    var config = Config.builder().addProperty(SPLUNK_REALM_PROPERTY, "test0").build();
+    var underTest = new RealmAccessTokenChecker(logWarn);
+
+    // when
+    underTest.beforeAgent(config, autoConfiguredSdk);
+
+    // then
+    verify(logWarn).accept(anyString());
+  }
+}

--- a/custom/src/test/java/com/splunk/opentelemetry/SplunkConfigurationTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/SplunkConfigurationTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry;
+
+import static com.splunk.opentelemetry.SplunkConfiguration.OTEL_EXPORTER_JAEGER_ENDPOINT;
+import static com.splunk.opentelemetry.SplunkConfiguration.SPLUNK_REALM_NONE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SplunkConfigurationTest {
+  private static final String TEST_REALM = "test0";
+  private static final String OTLP_PROTOCOL = "otel.exporter.otlp.traces.protocol";
+  private static final String OTLP_ENDPOINT = "otel.exporter.otlp.traces.endpoint";
+
+  @Test
+  void usesRealmIngestUrlsIfRealmDefined() {
+    assertRealmDefaults(configuration(TEST_REALM, null));
+    assertRealmDefaults(configuration(null, TEST_REALM));
+  }
+
+  @Test
+  void systemPropertyTakesPrecedence() {
+    assertRealmDefaults(configuration("test1", TEST_REALM));
+  }
+
+  @Test
+  void usesLocalIngestIfRealmIsNullOrNone() {
+    assertLocalDefaults(configuration(null, null));
+    assertLocalDefaults(configuration(null, SPLUNK_REALM_NONE));
+    assertLocalDefaults(configuration(SPLUNK_REALM_NONE, null));
+    assertLocalDefaults(configuration(SPLUNK_REALM_NONE, SPLUNK_REALM_NONE));
+  }
+
+  @Test
+  void realmIsNotHardcoded() {
+    var properties = configuration("test1", null);
+    assertEquals(
+        "https://ingest.test1.signalfx.com/v2/trace",
+        properties.get(OTEL_EXPORTER_JAEGER_ENDPOINT));
+    assertEquals("https://ingest.test1.signalfx.com/v2/trace/otlp", properties.get(OTLP_ENDPOINT));
+  }
+
+  private static void assertLocalDefaults(Map<String, String> properties) {
+    assertEquals("http://localhost:9080/v1/trace", properties.get(OTEL_EXPORTER_JAEGER_ENDPOINT));
+    assertNull(properties.get(OTLP_PROTOCOL));
+    assertNull(properties.get(OTLP_ENDPOINT));
+  }
+
+  private static void assertRealmDefaults(Map<String, String> properties) {
+    assertEquals(
+        "https://ingest.test0.signalfx.com/v2/trace",
+        properties.get(OTEL_EXPORTER_JAEGER_ENDPOINT));
+    assertEquals("http/protobuf", properties.get(OTLP_PROTOCOL));
+    assertEquals("https://ingest.test0.signalfx.com/v2/trace/otlp", properties.get(OTLP_ENDPOINT));
+  }
+
+  private static Map<String, String> configuration(String envValue, String propertyValue) {
+    return new SplunkConfiguration(
+            name -> SplunkConfiguration.SPLUNK_REALM_PROPERTY.equals(name) ? propertyValue : null,
+            name -> "SPLUNK_REALM".equals(name) ? envValue : null)
+        .getProperties();
+  }
+}

--- a/custom/src/test/java/com/splunk/opentelemetry/SplunkConfigurationTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/SplunkConfigurationTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 
 class SplunkConfigurationTest {
   private static final String TEST_REALM = "test0";
-  private static final String OTLP_PROTOCOL = "otel.exporter.otlp.traces.protocol";
   private static final String OTLP_ENDPOINT = "otel.exporter.otlp.traces.endpoint";
 
   @Test
@@ -54,12 +53,11 @@ class SplunkConfigurationTest {
     assertEquals(
         "https://ingest.test1.signalfx.com/v2/trace",
         properties.get(OTEL_EXPORTER_JAEGER_ENDPOINT));
-    assertEquals("https://ingest.test1.signalfx.com/v2/trace/otlp", properties.get(OTLP_ENDPOINT));
+    assertEquals("https://ingest.test1.signalfx.com", properties.get(OTLP_ENDPOINT));
   }
 
   private static void assertLocalDefaults(Map<String, String> properties) {
     assertEquals("http://localhost:9080/v1/trace", properties.get(OTEL_EXPORTER_JAEGER_ENDPOINT));
-    assertNull(properties.get(OTLP_PROTOCOL));
     assertNull(properties.get(OTLP_ENDPOINT));
   }
 
@@ -67,8 +65,7 @@ class SplunkConfigurationTest {
     assertEquals(
         "https://ingest.test0.signalfx.com/v2/trace",
         properties.get(OTEL_EXPORTER_JAEGER_ENDPOINT));
-    assertEquals("http/protobuf", properties.get(OTLP_PROTOCOL));
-    assertEquals("https://ingest.test0.signalfx.com/v2/trace/otlp", properties.get(OTLP_ENDPOINT));
+    assertEquals("https://ingest.test0.signalfx.com", properties.get(OTLP_ENDPOINT));
   }
 
   private static Map<String, String> configuration(String envValue, String propertyValue) {

--- a/custom/src/test/java/com/splunk/opentelemetry/micrometer/SplunkMetricsConfigTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/micrometer/SplunkMetricsConfigTest.java
@@ -18,6 +18,8 @@ package com.splunk.opentelemetry.micrometer;
 
 import static com.splunk.opentelemetry.SplunkConfiguration.PROFILER_MEMORY_ENABLED_PROPERTY;
 import static com.splunk.opentelemetry.SplunkConfiguration.SPLUNK_ACCESS_TOKEN;
+import static com.splunk.opentelemetry.SplunkConfiguration.SPLUNK_REALM_NONE;
+import static com.splunk.opentelemetry.SplunkConfiguration.SPLUNK_REALM_PROPERTY;
 import static com.splunk.opentelemetry.micrometer.SplunkMetricsConfig.DEFAULT_METRICS_ENDPOINT;
 import static com.splunk.opentelemetry.micrometer.SplunkMetricsConfig.METRICS_ENABLED_PROPERTY;
 import static com.splunk.opentelemetry.micrometer.SplunkMetricsConfig.METRICS_ENDPOINT_PROPERTY;
@@ -117,5 +119,23 @@ class SplunkMetricsConfigTest {
             .build();
     var config = new SplunkMetricsConfig(javaagentConfig, Resource.getDefault());
     assertTrue(config.enabled());
+  }
+
+  @Test
+  void usesRealmUrlDefaultIfRealmDefined() {
+    var javaagentConfig =
+        Config.builder().addProperties(Map.of(SPLUNK_REALM_PROPERTY, "test0")).build();
+    var config = new SplunkMetricsConfig(javaagentConfig, Resource.getDefault());
+
+    assertEquals(config.uri(), "https://ingest.test0.signalfx.com");
+  }
+
+  @Test
+  void usesLocalUrlDefaultIfRealmIsNone() {
+    var javaagentConfig =
+        Config.builder().addProperties(Map.of(SPLUNK_REALM_PROPERTY, SPLUNK_REALM_NONE)).build();
+    var config = new SplunkMetricsConfig(javaagentConfig, Resource.getDefault());
+
+    assertEquals(config.uri(), DEFAULT_METRICS_ENDPOINT);
   }
 }


### PR DESCRIPTION
Setting a `SPLUNK_REALM` value that is not `none` now changes the default values of the following properties:

- `otel.exporter.otlp.traces.protocol` to `http/protobuf` as the ingest URL only supports protobuf over HTTP, not gRPC.
- `otel.exporter.otlp.traces.endpoint` to `https://ingest.REALM.signalfx.com/v2/trace/otlp`
- `otel.exporter.jaeger.endpoint` to `https://ingest.REALM.signalfx.com/v2/trace`
- Splunk metrics endpoint to `https://ingest.REALM.signalfx.com` (the path is appended in sender implementation)

This is implemented by setting defaults conditionally in `SplunkConfiguration`. The reason why this is not done in `SplunkAgent` like some other configuration options is that it would require conditionally checking that we do not accidentally overwrite any explicitly provided property that realm changes the default of. In `SplunkConfiguration`, these are automatically overridden by environment variables/system properties or any higher priority SPIs, which makes it more foolproof.

Also made a warning get logged if realm is set but access token is not. Profiler was not affected as the ingest log endpoint only accepts HEC which the agent cannot send directly - collector is currently required for that anyway.
