### PR TITLE
Make jfr file readable before attempting to open it

### DIFF
--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/ProfilerSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/ProfilerSmokeTest.java
@@ -204,6 +204,9 @@ public abstract class ProfilerSmokeTest {
   }
 
   private boolean contextEventHasStackTrace(Path path) {
+    if (!Files.isReadable(path)) {
+      makeReadable(path);
+    }
     try {
       return RecordingFile.readAllEvents(path).stream()
           .filter(ProfilerSmokeTest::isContextAttachedEvent)


### PR DESCRIPTION
Hopefully fixes sporadic profiling test failures. Jfr files are read in `spanThreadContextEventsFound` and `contextEventsHaveStackTraces` the latter is called right after the former. `spanThreadContextEventsFound` already makes the file readable. If a jfr file is created after `spanThreadContextEventsFound` and before `contextEventsHaveStackTraces` then `contextEventsHaveStackTraces` could observe a jfr file that is not readable.