### PR TITLE
Update GDI spec version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
   <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.14.0">
     <img alt="OpenTelemetry Instrumentation for Java Version" src="https://img.shields.io/badge/otel-1.14.0-blueviolet?style=for-the-badge">
   </a>
-  <a href="https://github.com/signalfx/gdi-specification/releases/tag/v1.2.0">
-    <img alt="Splunk GDI specification" src="https://img.shields.io/badge/GDI-1.2.0-blueviolet?style=for-the-badge">
+  <a href="https://github.com/signalfx/gdi-specification/releases/tag/v1.3.0">
+    <img alt="Splunk GDI specification" src="https://img.shields.io/badge/GDI-1.3.0-blueviolet?style=for-the-badge">
   </a>
   <a href="https://github.com/signalfx/splunk-otel-java/releases">
     <img alt="GitHub release (latest SemVer)" src="https://img.shields.io/github/v/release/signalfx/splunk-otel-java?include_prereleases&style=for-the-badge">


### PR DESCRIPTION
Looks like the only major thing was `SPLUNK_REALM`, and we've implemented that already.