### PR TITLE
Change metric names for memory allocation/reclaim.

### DIFF
--- a/custom/src/main/java/com/splunk/opentelemetry/micrometer/OtelNamingConvention.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/micrometer/OtelNamingConvention.java
@@ -50,7 +50,8 @@ class OtelNamingConvention implements NamingConvention {
   }
 
   private boolean shouldStripJvmToKeepName(String name) {
-    return name.startsWith("jvm.process.runtime.jvm.memory.") && name.endsWith(".cumulative");
+    return "jvm.process.runtime.jvm.memory.reclaimed".equals(name) ||
+          "jvm.process.runtime.jvm.memory.allocated".equals(name);
   }
 
   @Override

--- a/custom/src/main/java/com/splunk/opentelemetry/micrometer/OtelNamingConvention.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/micrometer/OtelNamingConvention.java
@@ -40,10 +40,17 @@ class OtelNamingConvention implements NamingConvention {
 
   @Override
   public String name(String name, Meter.Type type, String baseUnit) {
+    if(shouldStripJvmToKeepName(name)){
+      return delegate.name(name.substring(4), type, baseUnit);
+    }
     if (name.startsWith("jvm.")) {
       name = "runtime." + name;
     }
     return delegate.name(name, type, baseUnit);
+  }
+
+  private boolean shouldStripJvmToKeepName(String name) {
+    return name.startsWith("jvm.process.runtime.jvm.memory.") && name.endsWith(".cumulative");
   }
 
   @Override

--- a/custom/src/main/java/com/splunk/opentelemetry/micrometer/OtelNamingConvention.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/micrometer/OtelNamingConvention.java
@@ -40,7 +40,7 @@ class OtelNamingConvention implements NamingConvention {
 
   @Override
   public String name(String name, Meter.Type type, String baseUnit) {
-    if(shouldStripJvmToKeepName(name)){
+    if (shouldStripJvmToKeepName(name)) {
       return delegate.name(name.substring(4), type, baseUnit);
     }
     if (name.startsWith("jvm.")) {

--- a/custom/src/main/java/com/splunk/opentelemetry/micrometer/OtelNamingConvention.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/micrometer/OtelNamingConvention.java
@@ -50,8 +50,8 @@ class OtelNamingConvention implements NamingConvention {
   }
 
   private boolean shouldStripJvmToKeepName(String name) {
-    return "jvm.process.runtime.jvm.memory.reclaimed".equals(name) ||
-          "jvm.process.runtime.jvm.memory.allocated".equals(name);
+    return "jvm.process.runtime.jvm.memory.reclaimed".equals(name)
+        || "jvm.process.runtime.jvm.memory.allocated".equals(name);
   }
 
   @Override

--- a/custom/src/test/java/com/splunk/opentelemetry/micrometer/OtelNamingConventionTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/micrometer/OtelNamingConventionTest.java
@@ -66,9 +66,9 @@ class OtelNamingConventionTest {
   @Test
   void keepsProfilingCumulativeMemoryNames() {
     String unit = "unit";
-    String allocated = "process.runtime.jvm.memory.allocated.cumulative";
+    String allocated = "process.runtime.jvm.memory.allocated";
     String sourceAllocated = "jvm." + allocated;
-    String reclaimed = "process.runtime.jvm.memory.reclaimed.cumulative";
+    String reclaimed = "process.runtime.jvm.memory.reclaimed";
     String sourceReclaimed = "jvm." + reclaimed;
 
     doReturn("allocated").when(namingConventionMock).name(allocated, Meter.Type.OTHER, unit);

--- a/custom/src/test/java/com/splunk/opentelemetry/micrometer/OtelNamingConventionTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/micrometer/OtelNamingConventionTest.java
@@ -19,7 +19,6 @@ package com.splunk.opentelemetry.micrometer;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.when;
 
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.config.NamingConvention;

--- a/custom/src/test/java/com/splunk/opentelemetry/micrometer/OtelNamingConventionTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/micrometer/OtelNamingConventionTest.java
@@ -18,6 +18,8 @@ package com.splunk.opentelemetry.micrometer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
 
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.config.NamingConvention;
@@ -60,5 +62,23 @@ class OtelNamingConventionTest {
 
     // then
     assertEquals(finalMeterName, result);
+  }
+
+  @Test
+  void keepsProfilingCumulativeMemoryNames() {
+    String unit = "unit";
+    String allocated = "process.runtime.jvm.memory.allocated.cumulative";
+    String sourceAllocated = "jvm." + allocated;
+    String reclaimed = "process.runtime.jvm.memory.reclaimed.cumulative";
+    String sourceReclaimed = "jvm." + reclaimed;
+
+    doReturn("allocated").when(namingConventionMock).name(allocated, Meter.Type.OTHER, unit);
+    doReturn("reclaimed").when(namingConventionMock).name(reclaimed, Meter.Type.OTHER, unit);
+
+    var otelNamingConvention = new OtelNamingConvention(namingConventionMock);
+
+    // when
+    assertEquals("allocated", otelNamingConvention.name(sourceAllocated, Meter.Type.OTHER, unit));
+    assertEquals("reclaimed", otelNamingConvention.name(sourceReclaimed, Meter.Type.OTHER, unit));
   }
 }

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/AllocatedMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/AllocatedMemoryMetrics.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class AllocatedMemoryMetrics implements MeterBinder {
+  public static final String METRIC_NAME = "process.runtime.jvm.memory.allocated.cumulative";
   private final boolean hasComSunThreadMXBean = hasComSunThreadMXBean();
 
   @Override
@@ -41,9 +42,10 @@ public class AllocatedMemoryMetrics implements MeterBinder {
     }
 
     AllocationTracker allocationTracker = new AllocationTracker();
-    Gauge.builder("jvm.experimental.memory.allocated", allocationTracker::getAllocated)
+    Gauge.builder(METRIC_NAME, allocationTracker::getCumulativeAllocationTotal)
         .description("Approximate sum of heap allocations")
         .baseUnit(BaseUnits.BYTES)
+        .tag("type", "heap")
         .register(registry);
   }
 
@@ -78,7 +80,7 @@ public class AllocatedMemoryMetrics implements MeterBinder {
     // allocated bytes by threads that have terminated
     private long allocatedByDeadThreads = 0;
 
-    long getAllocated() {
+    long getCumulativeAllocationTotal() {
       Set<Long> threads = new HashSet<>();
       long allocatedByLiveThreads = 0;
       long[] threadIds = threadBean.getAllThreadIds();

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/AllocatedMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/AllocatedMemoryMetrics.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class AllocatedMemoryMetrics implements MeterBinder {
-  public static final String METRIC_NAME = "process.runtime.jvm.memory.allocated.cumulative";
+  public static final String METRIC_NAME = "process.runtime.jvm.memory.allocated";
   private final boolean hasComSunThreadMXBean = hasComSunThreadMXBean();
 
   @Override

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/GcMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/GcMemoryMetrics.java
@@ -40,7 +40,7 @@ import javax.management.NotificationListener;
 import javax.management.openmbean.CompositeData;
 
 public class GcMemoryMetrics implements MeterBinder, AutoCloseable {
-  public static final String METRIC_NAME = "process.runtime.jvm.memory.reclaimed.cumulative";
+  public static final String METRIC_NAME = "process.runtime.jvm.memory.reclaimed";
   private final boolean managementExtensionsPresent = isManagementExtensionsPresent();
 
   private final List<Runnable> notificationListenerCleanUpRunnables = new CopyOnWriteArrayList<>();

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/GcMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/GcMemoryMetrics.java
@@ -40,6 +40,7 @@ import javax.management.NotificationListener;
 import javax.management.openmbean.CompositeData;
 
 public class GcMemoryMetrics implements MeterBinder, AutoCloseable {
+  public static final String METRIC_NAME = "process.runtime.jvm.memory.reclaimed.cumulative";
   private final boolean managementExtensionsPresent = isManagementExtensionsPresent();
 
   private final List<Runnable> notificationListenerCleanUpRunnables = new CopyOnWriteArrayList<>();
@@ -55,7 +56,7 @@ public class GcMemoryMetrics implements MeterBinder, AutoCloseable {
     GcMetricsNotificationListener gcNotificationListener =
         new GcMetricsNotificationListener(registry);
 
-    Gauge.builder("jvm.experimental.gc.memory.reclaimed", deltaSum, AtomicLong::get)
+    Gauge.builder(METRIC_NAME, deltaSum, AtomicLong::get)
         .description("Sum of heap size differences before and after gc")
         .baseUnit(BaseUnits.BYTES)
         .register(registry);

--- a/instrumentation/jvm-metrics/src/test/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/JvmMetricsTest.java
+++ b/instrumentation/jvm-metrics/src/test/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/JvmMetricsTest.java
@@ -41,8 +41,8 @@ class JvmMetricsTest {
     // thread metrics
     assertTrue(meterNames.contains("jvm.threads.peak"));
     // allocated memory metrics
-    assertTrue(meterNames.contains("jvm.experimental.memory.allocated"));
+    assertTrue(meterNames.contains(AllocatedMemoryMetrics.METRIC_NAME));
     // Our custom GC metrics
-    assertTrue(meterNames.contains("jvm.experimental.gc.memory.reclaimed"));
+    assertTrue(meterNames.contains(GcMemoryMetrics.METRIC_NAME));
   }
 }


### PR DESCRIPTION
This changes the profiling memory allocation metrics names. It wasn't immediately clear from the names that these metrics are monotonically increasing (cumulative) values, so I added `cumulative` and removed the `experimental` namespace.

I am not married to these names, so please feel free to suggest some improvements. The goal was to keep them in line with the [otel spec jvm metric names](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/runtime-environment-metrics.md#jvm-metrics), even tho these are not yet present.