### PR TITLE
Use counter instead of gauge for allocation metrics

### DIFF
--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/AllocatedMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/AllocatedMemoryMetrics.java
@@ -17,7 +17,7 @@
 package com.splunk.opentelemetry.instrumentation.jvmmetrics;
 
 import com.sun.management.ThreadMXBean;
-import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.BaseUnits;
 import io.micrometer.core.instrument.binder.MeterBinder;
@@ -42,7 +42,8 @@ public class AllocatedMemoryMetrics implements MeterBinder {
     }
 
     AllocationTracker allocationTracker = new AllocationTracker();
-    Gauge.builder(METRIC_NAME, allocationTracker::getCumulativeAllocationTotal)
+    FunctionCounter.builder(
+            METRIC_NAME, allocationTracker, AllocationTracker::getCumulativeAllocationTotal)
         .description("Approximate sum of heap allocations")
         .baseUnit(BaseUnits.BYTES)
         .tag("type", "heap")

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/GcMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/GcMemoryMetrics.java
@@ -18,7 +18,7 @@ package com.splunk.opentelemetry.instrumentation.jvmmetrics;
 
 import com.sun.management.GarbageCollectionNotificationInfo;
 import com.sun.management.GcInfo;
-import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.BaseUnits;
 import io.micrometer.core.instrument.binder.MeterBinder;
@@ -56,7 +56,7 @@ public class GcMemoryMetrics implements MeterBinder, AutoCloseable {
     GcMetricsNotificationListener gcNotificationListener =
         new GcMetricsNotificationListener(registry);
 
-    Gauge.builder(METRIC_NAME, deltaSum, AtomicLong::get)
+    FunctionCounter.builder(METRIC_NAME, deltaSum, AtomicLong::get)
         .description("Sum of heap size differences before and after gc")
         .baseUnit(BaseUnits.BYTES)
         .register(registry);


### PR DESCRIPTION
These counters should produce the same values with rate/sec rollup as we currently get from gauge with rate of change transform. One problem with doing this change is that once an instrument has been change as gauge the change to counter won't be picked up so might need to rename once more.
@gsmirnov-splk your call whether you want these as counter