### PR TITLE
Remove deprecated splunk.profiler.period.{eventName} config setting

### DIFF
--- a/profiler/README.md
+++ b/profiler/README.md
@@ -54,7 +54,6 @@ property or as environment variables (by making them uppercase and replacing dot
 |`splunk.profiler.memory.sampler.interval` | 1                      | set to `2` or larger to enable sampling every Nth allocation event where N is the value of this property |
 |`splunk.profiler.include.internal.stacks` | false                  | set to `true` to include stack traces of agent internal threads and stack traces with only JDK internal frames |
 |`splunk.profiler.tracing.stacks.only`     | false                  | set to `true` to include only stack traces that are linked to a span context |
-|`splunk.profiler.period.{eventName}`      | n/a                    | DEPRECATED. Use `splunk.profiler.call.stack.interval` instead.
 
 If the `splunk.profiler.enabled` option is not enabled, all profiling features are disabled. For
 example, setting `splunk.profiler.memory.enabled` to `true` has no effect if

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
@@ -51,8 +51,6 @@ public class Configuration implements ConfigCustomizer {
   private static final String CONFIG_KEY_MEMORY_DATA_FORMAT = "splunk.profiler.memory.data.format";
   public static final String CONFIG_KEY_TLAB_ENABLED = "splunk.profiler.tlab.enabled";
   public static final String CONFIG_KEY_CALL_STACK_INTERVAL = "splunk.profiler.call.stack.interval";
-  public static final String CONFIG_KEY_DEPRECATED_THREADDUMP_PERIOD =
-      "splunk.profiler.period.threaddump";
   public static final String CONFIG_KEY_INCLUDE_AGENT_INTERNALS =
       "splunk.profiler.include.agent.internals";
   // Include stacks where every frame starts with jvm/sun/jdk

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/ConfigurationLogger.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/ConfigurationLogger.java
@@ -17,7 +17,6 @@
 package com.splunk.opentelemetry.profiler;
 
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_CALL_STACK_INTERVAL;
-import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_DEPRECATED_THREADDUMP_PERIOD;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_ENABLE_PROFILER;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_INCLUDE_INTERNAL_STACKS;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_INGEST_URL;
@@ -59,7 +58,6 @@ public class ConfigurationLogger {
         CONFIG_KEY_INCLUDE_INTERNAL_STACKS,
         (it) -> config.getBoolean(it, DEFAULT_INCLUDE_INTERNAL_STACKS));
     log(CONFIG_KEY_TRACING_STACKS_ONLY, (it) -> Configuration.getTracingStacksOnly(config));
-    log(CONFIG_KEY_DEPRECATED_THREADDUMP_PERIOD, (it) -> config.getDuration(it, null));
     logger.info("-----------------------");
   }
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrSettingsOverrides.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrSettingsOverrides.java
@@ -17,7 +17,6 @@
 package com.splunk.opentelemetry.profiler;
 
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_CALL_STACK_INTERVAL;
-import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_DEPRECATED_THREADDUMP_PERIOD;
 
 import io.opentelemetry.instrumentation.api.config.Config;
 import java.time.Duration;
@@ -54,14 +53,7 @@ class JfrSettingsOverrides {
     if (customInterval != Duration.ZERO) {
       return customInterval;
     }
-    Duration duration = config.getDuration(CONFIG_KEY_DEPRECATED_THREADDUMP_PERIOD, Duration.ZERO);
-    if (duration != Duration.ZERO) {
-      logger.warn(
-          "Using DEPRECATED configuration {}, please switch to {}",
-          CONFIG_KEY_DEPRECATED_THREADDUMP_PERIOD,
-          CONFIG_KEY_CALL_STACK_INTERVAL);
-    }
-    return duration;
+    return Duration.ZERO;
   }
 
   private Map<String, String> maybeEnableTLABs(Map<String, String> settings) {

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationLoggerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationLoggerTest.java
@@ -17,7 +17,6 @@
 package com.splunk.opentelemetry.profiler;
 
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_CALL_STACK_INTERVAL;
-import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_DEPRECATED_THREADDUMP_PERIOD;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_ENABLE_PROFILER;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_INCLUDE_INTERNAL_STACKS;
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_INGEST_URL;
@@ -65,8 +64,6 @@ class ConfigurationLoggerTest {
         .thenReturn(true);
     when(config.getBoolean(CONFIG_KEY_TRACING_STACKS_ONLY, DEFAULT_TRACING_STACKS_ONLY))
         .thenReturn(true);
-    when(config.getDuration(CONFIG_KEY_DEPRECATED_THREADDUMP_PERIOD, null))
-        .thenReturn(Duration.ofMillis(500));
 
     ConfigurationLogger configurationLogger = new ConfigurationLogger();
 
@@ -85,7 +82,6 @@ class ConfigurationLoggerTest {
     log.assertContains("    splunk.profiler.call.stack.interval : PT21S");
     log.assertContains("splunk.profiler.include.internal.stacks : true");
     log.assertContains("    splunk.profiler.tracing.stacks.only : true");
-    log.assertContains("      splunk.profiler.period.threaddump : PT0.5S");
   }
 
   @Test

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrSettingsOverridesTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrSettingsOverridesTest.java
@@ -17,7 +17,6 @@
 package com.splunk.opentelemetry.profiler;
 
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_CALL_STACK_INTERVAL;
-import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_DEPRECATED_THREADDUMP_PERIOD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.mockito.Mockito.mock;
@@ -48,20 +47,5 @@ class JfrSettingsOverridesTest {
     assertEquals("163 ms", result.get("jdk.ThreadDump#period"));
     assertEquals("true", result.get("jdk.ObjectAllocationInNewTLAB#enabled"));
     assertEquals("true", result.get("jdk.ObjectAllocationOutsideTLAB#enabled"));
-  }
-
-  @Test
-  void fallBackToDeprecatedConfig() {
-    Config config = mock(Config.class);
-    when(config.getDuration(CONFIG_KEY_DEPRECATED_THREADDUMP_PERIOD, Duration.ZERO))
-        .thenReturn(Duration.ofMillis(999));
-    JfrSettingsOverrides overrides = new JfrSettingsOverrides(config);
-    Map<String, String> jfrSettings =
-        Map.of(
-            "jdk.ThreadDump#period", "12",
-            "jdk.ThreadDump#enabled", "true");
-    Map<String, String> result = overrides.apply(jfrSettings);
-    assertNotSame(result, jfrSettings);
-    assertEquals("999 ms", result.get("jdk.ThreadDump#period"));
   }
 }


### PR DESCRIPTION
This config setting has been deprecated for some time. Time to remove it.