### PR TITLE
Use collector instead of connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -338,7 +338,7 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
   default OTLP exporter endpoint is `http://localhost:4317`. You can still use the Jaeger exporter by
   setting `OTEL_TRACES_EXPORTER=jaeger-thrift-splunk`.
 - We have also changed the default endpoint of the SignalFx metrics exporter: it now points to `http://localhost:9943`,
-  which is the default endpoint of [Splunk OpenTelemetry Connector](https://github.com/signalfx/splunk-otel-collector)
+  which is the default endpoint of [Splunk OpenTelemetry Collector](https://github.com/signalfx/splunk-otel-collector)
   deployed on `localhost`.
 - The agent now uses [W3C `tracecontext`](https://www.w3.org/TR/trace-context/) as the default trace propagation
   mechanism; [W3C Baggage](https://w3c.github.io/baggage/) is also enabled by default. You can switch to the previous B3

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This distribution comes with the following defaults:
 - [OTLP gRPC
   exporter](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/README.md)
   configured to send spans to a locally running [Splunk OpenTelemetry
-  Connector](https://github.com/signalfx/splunk-otel-collector)
+  Collector](https://github.com/signalfx/splunk-otel-collector)
   (`http://localhost:4317`); [Jaeger Thrift
   exporter](https://github.com/signalfx/splunk-otel-java/blob/main/docs/advanced-config.md#trace-exporters)
   available for [Smart Agent](https://github.com/signalfx/signalfx-agent)
@@ -138,7 +138,7 @@ Follow these steps to automatically instrument your application using the Java a
 
 > **Tip**: To generate a snippet that includes all the basic install commands for your environment and service, open the Splunk Observability Cloud wizard in **Data Setup > APM Instrumentation > Java > Add Connection**.
 
-When you run your application with the Java agent, trace data goes to Observability Cloud through the Splunk OTel connector. If no data
+When you run your application with the Java agent, trace data goes to Observability Cloud through the Splunk OTel collector. If no data
 appears in **Observability > APM**, see [Troubleshooting](#troubleshooting).
 
 For full install instructions, including K8s and Lambda snippets, see [Instrument Java services for Observability Cloud](https://docs.splunk.com/Observability/gdi/get-data-in/application/java/get-started.html) in the official Splunk documentation.

--- a/profiler/README.md
+++ b/profiler/README.md
@@ -19,7 +19,7 @@ events each time a span context change occurs. These context changes are then tr
 during replay so that a call stack can be associated with the appropriate span.
 
 Stack trace data is embedded as a string inside of an OTLP logs payload. The
-[Splunk OpenTelemetry Connector](https://github.com/signalfx/splunk-otel-collector)
+[Splunk OpenTelemetry Collector](https://github.com/signalfx/splunk-otel-collector)
 will detect this profiling data inside of OTLP logs and will help it along
 its ingest path.
 
@@ -27,7 +27,7 @@ its ingest path.
 
 * Java 8 above 8u262, or Java 11+
 * 100 MB of free disk space
-* [Splunk OpenTelemetry Connector](https://github.com/signalfx/splunk-otel-collector) version 0.33.1 or higher. _Sending profiling data directly to ingest is not supported at this time_.
+* [Splunk OpenTelemetry Collector](https://github.com/signalfx/splunk-otel-collector) version 0.33.1 or higher. _Sending profiling data directly to ingest is not supported at this time_.
 * Profiler is enabled at startup (disabled by default, see the Configuration section)
 
 # Enable the profiler
@@ -127,11 +127,11 @@ Check for the following common issues:
 at startup (see above).
 * Verify that a collector is actually running at that endpoint and that the
 application host/container can resolve any hostnames and actually connect to the given OTLP port (default: 4317)
-* Make sure you are running the [Splunk OpenTelemetry Connector](https://github.com/signalfx/splunk-otel-collector)
+* Make sure you are running the [Splunk OpenTelemetry Collector](https://github.com/signalfx/splunk-otel-collector)
 and that the version is 0.33.1 or greater. Other collector distributions may not be able to route the log
 data containing profiles correctly.
 * Make sure that the collector is configured correctly to handle profiling data. By default, the
-[Splunk OpenTelemetry Connector](https://github.com/signalfx/splunk-otel-collector) handles this, but
+[Splunk OpenTelemetry Collector](https://github.com/signalfx/splunk-otel-collector) handles this, but
 a custom configuration might have overridden some settings. Make sure that an OTLP _receiver_ is configured in the collector
 and that an exporter is configured for `splunk_hec` export. Ensure that the `token` and `endpoint` fields
 are [correctly configured](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/splunkhecreceiver#configuration).


### PR DESCRIPTION
I believe that doc team decided that it should be called Splunk OpenTelemetry Collector a while ago