### PR TITLE
Exclude gson (mitigate CVE-2022-25647)

### DIFF
--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -22,6 +22,8 @@ dependencies {
     // exclude unwanted dependency
     // https://issues.apache.org/jira/browse/THRIFT-5375
     exclude("org.apache.tomcat.embed", "tomcat-embed-core")
+    exclude("com.google.code.gson", "gson")
+    exclude("com.google.code.gson", "gson-parent")
   }
 
   compileOnly("io.micrometer:micrometer-core")

--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
     // https://issues.apache.org/jira/browse/THRIFT-5375
     exclude("org.apache.tomcat.embed", "tomcat-embed-core")
     exclude("com.google.code.gson", "gson")
-    exclude("com.google.code.gson", "gson-parent")
   }
 
   compileOnly("io.micrometer:micrometer-core")


### PR DESCRIPTION
Prevent pulling in gson classes from jaeger dependency.