### PR TITLE
Use splunkdev for docker

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ include:
     file: '/templates/.whitesource.yml'
 
 image:
-  name: "openjdk:11.0.11-9-jdk"
+  name: "docker-hub.repo.splunkdev.net/openjdk:11.0.11-9-jdk"
 
 stages:
   - build


### PR DESCRIPTION
Since we run CI in gitlab, let's use our internal read-thru caching repository to prevent overwhelming dockerhub (and failing our own builds)