### PR TITLE
Add deprecation notice and remove mention from front readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,7 @@ This distribution comes with the following defaults:
   exporter](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/README.md)
   configured to send spans to a locally running [Splunk OpenTelemetry
   Collector](https://github.com/signalfx/splunk-otel-collector)
-  (`http://localhost:4317`); [Jaeger Thrift
-  exporter](https://github.com/signalfx/splunk-otel-java/blob/main/docs/advanced-config.md#trace-exporters)
-  available for [Smart Agent](https://github.com/signalfx/signalfx-agent)
-  (`http://localhost:9080/v1/trace`).
+  (`http://localhost:4317`)
 - Unlimited default limits for [configuration
   options](docs/advanced-config.md#trace-configuration) to support
   full-fidelity traces.

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -39,6 +39,8 @@ export SPLUNK_METRICS_ENDPOINT=https://ingest.us0.signalfx.com
 | `otel.exporter.jaeger.endpoint` | `OTEL_EXPORTER_JAEGER_ENDPOINT` | `http://localhost:9080/v1/trace` | Stable  | The Jaeger endpoint to connect to. Setting this will override the `splunk.realm` property.                                               |
 | `otel.traces.exporter`          | `OTEL_TRACES_EXPORTER`          | `otlp`                           | Stable  | Select the traces exporter to use. We recommend using either the OTLP exporter (`otlp`) or the Jaeger exporter (`jaeger-thrift-splunk`). |
 
+:warning: **Support for the `jaeger-thrift-splunk` exporter will be removed after December 17th, 2022. See the [deprecation notice](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md) on the SmartAgent for details. ** :warning:
+
 The Splunk Distribution of OpenTelemetry Java uses the OTLP traces exporter as the default setting. Please note that the
 OTLP format is neither supported by the (now
 deprecated) [SignalFx Smart Agent](https://github.com/signalfx/signalfx-agent) nor by the Splunk ingest. If you're still


### PR DESCRIPTION
I assume we will want to keep support for `jaeger-thrift` until the SmartAgent is deprecated in December. Once that happens, we can remove `jaeger-thrift` from our distro. 

This change just adds a deprecation notice about that and removes the mention from the front page (to discourage creating new user dependencies on it).