### PR TITLE
Turn off the spring-boot-actuator-autoconfigure instrumentation

### DIFF
--- a/custom/src/main/java/com/splunk/opentelemetry/SplunkConfiguration.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/SplunkConfiguration.java
@@ -16,6 +16,8 @@
 
 package com.splunk.opentelemetry;
 
+import static java.util.Arrays.asList;
+
 import com.google.auto.service.AutoService;
 import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.instrumentation.api.config.ConfigBuilder;
@@ -85,15 +87,20 @@ public class SplunkConfiguration implements ConfigCustomizer {
 
       // disable upstream metrics instrumentations
       // metrics are disabled, or we're still on the micrometer based implementation
-      addIfAbsent(builder, config, "otel.instrumentation.apache-dbcp.enabled", "false");
-      addIfAbsent(builder, config, "otel.instrumentation.c3p0.enabled", "false");
-      addIfAbsent(builder, config, "otel.instrumentation.hikaricp.enabled", "false");
-      addIfAbsent(builder, config, "otel.instrumentation.micrometer.enabled", "false");
-      addIfAbsent(builder, config, "otel.instrumentation.oracle-ucp.enabled", "false");
-      addIfAbsent(builder, config, "otel.instrumentation.oshi.enabled", "false");
-      addIfAbsent(builder, config, "otel.instrumentation.runtime-metrics.enabled", "false");
-      addIfAbsent(builder, config, "otel.instrumentation.tomcat-jdbc.enabled", "false");
-      addIfAbsent(builder, config, "otel.instrumentation.vibur-dbcp.enabled", "false");
+      for (String otelInstrumentationName :
+          asList(
+              "apache-dbcp",
+              "c3p0",
+              "hikaricp",
+              "micrometer",
+              "oracle-ucp",
+              "oshi",
+              "spring-boot-actuator-autoconfigure",
+              "runtime-metrics",
+              "tomcat-jdbc",
+              "vibur-dbcp")) {
+        disableInstrumentation(builder, config, otelInstrumentationName);
+      }
     }
     if ("micrometer".equals(metricsImplementation)) {
       // TODO: warn that micrometer metrics are deprecated
@@ -125,13 +132,17 @@ public class SplunkConfiguration implements ConfigCustomizer {
 
       // disable micrometer metrics, we'll be using the equivalent otel metrics from the upstream
       // agent
-      addIfAbsent(builder, config, "otel.instrumentation.c3p0-splunk.enabled", "false");
-      addIfAbsent(builder, config, "otel.instrumentation.commons-dbcp2-splunk.enabled", "false");
-      addIfAbsent(builder, config, "otel.instrumentation.hikari-splunk.enabled", "false");
-      addIfAbsent(builder, config, "otel.instrumentation.micrometer-splunk.enabled", "false");
-      addIfAbsent(builder, config, "otel.instrumentation.oracle-ucp-splunk.enabled", "false");
-      addIfAbsent(builder, config, "otel.instrumentation.tomcat-jdbc-splunk.enabled", "false");
-      addIfAbsent(builder, config, "otel.instrumentation.vibur-dbcp-splunk.enabled", "false");
+      for (String micrometerInstrumentationName :
+          asList(
+              "c3p0-splunk",
+              "commons-dbcp2-splunk",
+              "hikari-splunk",
+              "micrometer-splunk",
+              "oracle-ucp-splunk",
+              "tomcat-jdbc-splunk",
+              "vibur-dbcp-splunk")) {
+        disableInstrumentation(builder, config, micrometerInstrumentationName);
+      }
     } else {
       throw new IllegalStateException(
           "Invalid metrics implementation: '"
@@ -172,6 +183,12 @@ public class SplunkConfiguration implements ConfigCustomizer {
     }
 
     return builder.build();
+  }
+
+  private static void disableInstrumentation(
+      ConfigBuilder builder, Config config, String instrumentationName) {
+    addIfAbsent(
+        builder, config, "otel.instrumentation." + instrumentationName + ".enabled", "false");
   }
 
   private static void addIfAbsent(ConfigBuilder builder, Config config, String key, String value) {

--- a/custom/src/test/java/com/splunk/opentelemetry/SplunkConfigurationTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/SplunkConfigurationTest.java
@@ -21,6 +21,7 @@ import static com.splunk.opentelemetry.SplunkConfiguration.METRICS_IMPLEMENTATIO
 import static com.splunk.opentelemetry.SplunkConfiguration.OTEL_EXPORTER_JAEGER_ENDPOINT;
 import static com.splunk.opentelemetry.SplunkConfiguration.PROFILER_MEMORY_ENABLED_PROPERTY;
 import static com.splunk.opentelemetry.SplunkConfiguration.SPLUNK_REALM_NONE;
+import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -146,24 +147,37 @@ class SplunkConfigurationTest {
   }
 
   private static void verifyThatOtelMetricsInstrumentationsAreDisabled(Config config) {
-    assertFalse(config.getBoolean("otel.instrumentation.apache-dbcp.enabled", false));
-    assertFalse(config.getBoolean("otel.instrumentation.c3p0.enabled", false));
-    assertFalse(config.getBoolean("otel.instrumentation.hikaricp.enabled", false));
-    assertFalse(config.getBoolean("otel.instrumentation.micrometer.enabled", false));
-    assertFalse(config.getBoolean("otel.instrumentation.oracle-ucp.enabled", false));
-    assertFalse(config.getBoolean("otel.instrumentation.oshi.enabled", false));
-    assertFalse(config.getBoolean("otel.instrumentation.runtime-metrics.enabled", false));
-    assertFalse(config.getBoolean("otel.instrumentation.tomcat-jdbc.enabled", false));
-    assertFalse(config.getBoolean("otel.instrumentation.vibur-dbcp.enabled", false));
+    for (String instrumentationName :
+        asList(
+            "apache-dbcp",
+            "c3p0",
+            "hikaricp",
+            "micrometer",
+            "oracle-ucp",
+            "oshi",
+            "runtime-metrics",
+            "spring-boot-autoconfigure",
+            "tomcat-jdbc",
+            "vibur-dbcp")) {
+      assertInstrumentationDisabled(config, instrumentationName);
+    }
   }
 
   private static void verifyThatMicrometerInstrumentationsAreDisabled(Config config) {
-    assertFalse(config.getBoolean("otel.instrumentation.c3p0-splunk.enabled", false));
-    assertFalse(config.getBoolean("otel.instrumentation.commons-dbcp2-splunk.enabled", false));
-    assertFalse(config.getBoolean("otel.instrumentation.hikari-splunk.enabled", false));
-    assertFalse(config.getBoolean("otel.instrumentation.micrometer-splunk.enabled", false));
-    assertFalse(config.getBoolean("otel.instrumentation.oracle-ucp-splunk.enabled", false));
-    assertFalse(config.getBoolean("otel.instrumentation.tomcat-jdbc-splunk.enabled", false));
-    assertFalse(config.getBoolean("otel.instrumentation.vibur-dbcp-splunk.enabled", false));
+    for (String instrumentationName :
+        asList(
+            "c3p0-splunk",
+            "commons-dbcp2-splunk",
+            "hikari-splunk",
+            "micrometer-splunk",
+            "oracle-ucp-splunk",
+            "tomcat-jdbc-splunk",
+            "vibut-dbcp-splunk")) {
+      assertInstrumentationDisabled(config, instrumentationName);
+    }
+  }
+
+  private static void assertInstrumentationDisabled(Config config, String name) {
+    assertFalse(config.getBoolean("otel.instrumentation." + name + ".enabled", false));
   }
 }


### PR DESCRIPTION
Turns out we forgot to disable that one, it installs the OTel micrometer registry in Spring Boot.