### PR TITLE
Fix ref name for fossa scan

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ include:
     ref: latest
     file: '/templates/.sast_scan.yml'
   - project: 'ci-cd/templates'
-    ref: latest
+    ref: master
     file: '/prodsec/.oss-scan.yml'
 
 image:


### PR DESCRIPTION
We have to use this ref name for now.