### PR TITLE
Update logback and slf api

### DIFF
--- a/smoke-tests/build.gradle.kts
+++ b/smoke-tests/build.gradle.kts
@@ -16,7 +16,8 @@ dependencies {
   testImplementation("io.opentelemetry.proto:opentelemetry-proto")
   testImplementation("io.opentelemetry:opentelemetry-api")
   testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api")
-  testImplementation("ch.qos.logback:logback-classic:1.2.11")
+  testImplementation("ch.qos.logback:logback-classic:1.4.0")
+  testImplementation("org.slf4j:slf4j-api:2.0.0")
   testImplementation("com.github.docker-java:docker-java-core")
   testImplementation("com.github.docker-java:docker-java-transport-httpclient5")
 }


### PR DESCRIPTION
Going to see if this work better than #888. It looks like, according to [the docs](https://www.slf4j.org/codes.html#StaticLoggerBinder), 

> Backends such as logback 1.3 and later which target slf4j-api 2.x, do not ship with org.slf4j.impl.StaticLoggerBinder. If you place a logging backend which targets slf4j-api 2.0.x, you need slf4j-api-2.x.jar on the classpath.

So I think adding slf-api 2.0.0 into the test runtime classpath should help.