### PR TITLE
Disable service name detection test on jboss eap

### DIFF
--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/JBossEapSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/JBossEapSmokeTest.java
@@ -44,7 +44,9 @@ public class JBossEapSmokeTest extends AppServerTest {
 
   @Override
   protected boolean shouldAutodetectServiceName() {
-    return true;
+    // web.xml in jboss eap test image doesn't have a display-name tag, enable after
+    // matrix/src/main/webapp/WEB-INF/web.xml is updated and image is rebuilt
+    return false;
   }
 
   @ParameterizedTest(name = "[{index}] {0}")


### PR DESCRIPTION
Resolves https://github.com/signalfx/splunk-otel-java/issues/896