### PR TITLE
remove -all suffix from agent jars

### DIFF
--- a/deployments/cloudfoundry/index.yml
+++ b/deployments/cloudfoundry/index.yml
@@ -1,5 +1,5 @@
 # Index of all versions available to the upstream Cloud Foundry java buildpack.
 ---
-1.14.2: https://github.com/signalfx/splunk-otel-java/releases/download/v1.14.2/splunk-otel-javaagent-all.jar
-1.15.0: https://github.com/signalfx/splunk-otel-java/releases/download/v1.15.0/splunk-otel-javaagent-all.jar
-1.16.0: https://github.com/signalfx/splunk-otel-java/releases/download/v1.16.0/splunk-otel-javaagent-all.jar
+1.14.2: https://github.com/signalfx/splunk-otel-java/releases/download/v1.14.2/splunk-otel-javaagent.jar
+1.15.0: https://github.com/signalfx/splunk-otel-java/releases/download/v1.15.0/splunk-otel-javaagent.jar
+1.16.0: https://github.com/signalfx/splunk-otel-java/releases/download/v1.16.0/splunk-otel-javaagent.jar

--- a/scripts/update-version-after-release.sh
+++ b/scripts/update-version-after-release.sh
@@ -62,4 +62,4 @@ rm dev_docs_warning.md.tmp
 
 # update main cloudfoundry buildpack index with new released version
 CF_INDEX=deployments/cloudfoundry/index.yml
-echo "${splunk_current_version}: https://github.com/signalfx/splunk-otel-java/releases/download/v${splunk_current_version}/splunk-otel-javaagent-all.jar" >> "${CF_INDEX}"
+echo "${splunk_current_version}: https://github.com/signalfx/splunk-otel-java/releases/download/v${splunk_current_version}/splunk-otel-javaagent.jar" >> "${CF_INDEX}"


### PR DESCRIPTION
Realized that we don't need the `-all` suffix on the jar URLs.

I can rebase this after #920.