### PR TITLE
Change default `splunk.profiler.directory` 

### DIFF
--- a/profiler/README.md
+++ b/profiler/README.md
@@ -41,21 +41,21 @@ property or as environment variables (by making them uppercase and replacing dot
 
 > We strongly recommend using defaults for the following settings.
 
-| Setting                                   | Default                                               | Description                                                                                                                |
-|-------------------------------------------|-------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
-| `splunk.profiler.enabled`                 | false                                                 | set to true to enable the profiler                                                                                         |
-| `splunk.profiler.directory`               | "."                                                   | location of jfr files                                                                                                      |
-| `splunk.profiler.recording.duration`      | 20s                                                   | recording unit duration                                                                                                    |
-| `splunk.profiler.keep-files`              | false                                                 | leave JFR files on disk id `true`                                                                                          |
-| `splunk.profiler.logs-endpoint`           | `otel.exporter.otlp.endpoint` or http://localhost:4317 | where to send OTLP logs                                                                                                   |
-| `splunk.profiler.call.stack.interval`     | 10000ms                                               | how often to sample call stacks                                                                                            |
-| `splunk.profiler.memory.enabled`          | false                                                 | set to `true` to enable all other memory profiling options unless explicitly disabled                                      |
-| `splunk.profiler.tlab.enabled`            | `splunk.profiler.memory.enabled`                      | set to `true` to enable TLAB events even if `splunk.profiler.memory.enabled` is `false`                                    |
-| `splunk.profiler.memory.sampler.interval` | 1                                                     | set to `2` or larger to enable sampling every Nth allocation event where N is the value of this property                   |
-| `splunk.profiler.include.internal.stacks` | false                                                 | set to `true` to include stack traces of agent internal threads and stack traces with only JDK internal frames             |
-| `splunk.profiler.tracing.stacks.only`     | false                                                 | set to `true` to include only stack traces that are linked to a span context                                               |
-| `splunk.profiler.cpu.data.format`         | `pprof-gzip-base64`                                   | controls the format of CPU call stack data sent to the collector. Must be `pprof-gzip-base64` or `text`                    |
-| `splunk.profiler.memory.data.format`      | `pprof-gzip-base64`                                   | controls the format of memory allocation call site stack data sent to the collector. Must be `pprof-gzip-base64` or `text` |
+| Setting                                   | Default                                                | Description                                                                                                                |
+|-------------------------------------------|--------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| `splunk.profiler.enabled`                 | false                                                  | set to true to enable the profiler                                                                                         |
+| `splunk.profiler.directory`               | system temp directory                                  | location of JFR files, defaults to `System.getProperty("java.io.tmpdir")`                                                  |
+| `splunk.profiler.recording.duration`      | 20s                                                    | recording unit duration                                                                                                    |
+| `splunk.profiler.keep-files`              | false                                                  | leave JFR files on disk id `true`                                                                                          |
+| `splunk.profiler.logs-endpoint`           | `otel.exporter.otlp.endpoint` or http://localhost:4317 | where to send OTLP logs                                                                                                    |
+| `splunk.profiler.call.stack.interval`     | 10000ms                                                | how often to sample call stacks                                                                                            |
+| `splunk.profiler.memory.enabled`          | false                                                  | set to `true` to enable all other memory profiling options unless explicitly disabled                                      |
+| `splunk.profiler.tlab.enabled`            | `splunk.profiler.memory.enabled`                       | set to `true` to enable TLAB events even if `splunk.profiler.memory.enabled` is `false`                                    |
+| `splunk.profiler.memory.sampler.interval` | 1                                                      | set to `2` or larger to enable sampling every Nth allocation event where N is the value of this property                   |
+| `splunk.profiler.include.internal.stacks` | false                                                  | set to `true` to include stack traces of agent internal threads and stack traces with only JDK internal frames             |
+| `splunk.profiler.tracing.stacks.only`     | false                                                  | set to `true` to include only stack traces that are linked to a span context                                               |
+| `splunk.profiler.cpu.data.format`         | `pprof-gzip-base64`                                    | controls the format of CPU call stack data sent to the collector. Must be `pprof-gzip-base64` or `text`                    |
+| `splunk.profiler.memory.data.format`      | `pprof-gzip-base64`                                    | controls the format of memory allocation call site stack data sent to the collector. Must be `pprof-gzip-base64` or `text` |
 
 If the `splunk.profiler.enabled` option is not enabled, all profiling features are disabled. For
 example, setting `splunk.profiler.memory.enabled` to `true` has no effect if

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
@@ -70,7 +70,7 @@ public class Configuration implements AutoConfigurationCustomizerProvider {
   Map<String, String> defaultProperties() {
     HashMap<String, String> config = new HashMap<>();
     config.put(CONFIG_KEY_ENABLE_PROFILER, "false");
-    config.put(CONFIG_KEY_PROFILER_DIRECTORY, ".");
+    config.put(CONFIG_KEY_PROFILER_DIRECTORY, System.getProperty("java.io.tmpdir"));
     config.put(CONFIG_KEY_RECORDING_DURATION, DEFAULT_RECORDING_DURATION);
     config.put(CONFIG_KEY_KEEP_FILES, "false");
     config.put(CONFIG_KEY_MEMORY_ENABLED, String.valueOf(DEFAULT_MEMORY_ENABLED));


### PR DESCRIPTION
Some users have permissions issues when writing to the current working directory. This changes the default location to System.getProperty("java.io.tmpdir") which is the system temp dir. We think more users will have success with this instead.