### PR TITLE
Kotlin warnings

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 spotless {
   kotlinGradle {
-    ktlint().editorConfigOverride(mapOf("indent_size" to "2", "continuation_indent_size" to "2", "disabled_rules" to "no-wildcard-imports"))
+    ktlint().editorConfigOverride(mapOf("indent_size" to "2", "continuation_indent_size" to "2"))
     target("**/*.gradle.kts")
   }
 }
@@ -24,7 +24,7 @@ repositories {
 dependencies {
   implementation(gradleApi())
 
-  implementation("com.diffplug.spotless:spotless-plugin-gradle:6.9.0")
+  implementation("com.diffplug.spotless:spotless-plugin-gradle:6.11.0")
   implementation("io.opentelemetry.instrumentation:gradle-plugins:1.20.0-alpha-SNAPSHOT")
   implementation("io.spring.gradle:dependency-management-plugin:1.0.14.RELEASE")
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   `kotlin-dsl`
 
   // When updating, update below in dependencies too
-  id("com.diffplug.spotless") version "6.9.0"
+  id("com.diffplug.spotless") version "6.11.0"
 }
 
 spotless {

--- a/buildSrc/src/main/kotlin/splunk.spotless-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.spotless-conventions.gradle.kts
@@ -16,7 +16,7 @@ extensions.configure<SpotlessExtension>("spotless") {
     licenseHeaderFile(rootProject.file("gradle/spotless.license.java"), "(package|import|public|// Includes work from:)")
   }
   kotlinGradle {
-    ktlint().editorConfigOverride(mapOf("indent_size" to "2", "continuation_indent_size" to "2", "disabled_rules" to "no-wildcard-imports"))
+    ktlint().editorConfigOverride(mapOf("indent_size" to "2", "continuation_indent_size" to "2"))
   }
   format("misc") {
     // not using "**/..." to help keep spotless fast

--- a/instrumentation/khttp/src/main/java/com/splunk/opentelemetry/instrumentation/khttp/KHttpHttpClientNetAttributesGetter.java
+++ b/instrumentation/khttp/src/main/java/com/splunk/opentelemetry/instrumentation/khttp/KHttpHttpClientNetAttributesGetter.java
@@ -30,7 +30,7 @@ final class KHttpHttpClientNetAttributesGetter
 
   @Nullable
   @Override
-  public String peerName(RequestWrapper requestWrapper, @Nullable Response response) {
+  public String peerName(RequestWrapper requestWrapper) {
     if (requestWrapper.parsedUri != null) {
       return requestWrapper.parsedUri.getHost();
     }
@@ -39,7 +39,7 @@ final class KHttpHttpClientNetAttributesGetter
 
   @Nullable
   @Override
-  public Integer peerPort(RequestWrapper requestWrapper, @Nullable Response response) {
+  public Integer peerPort(RequestWrapper requestWrapper) {
     if (requestWrapper.parsedUri != null && requestWrapper.parsedUri.getPort() > 0) {
       return requestWrapper.parsedUri.getPort();
     }

--- a/profiler/build.gradle.kts
+++ b/profiler/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.google.protobuf.gradle.*
 
 plugins {
   id("com.google.protobuf") version "0.9.1"


### PR DESCRIPTION
I noticed a few warnings in the builds for #959 and #956, so this addresses those. The only wildcard import in kts files was in the profiling build script, and it wasn't even used so I just removed it.
