### PR TITLE
Bump signalfx-java version (and jackson-databind transitively)

### DIFF
--- a/buildSrc/src/main/kotlin/splunk.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.java-conventions.gradle.kts
@@ -29,7 +29,7 @@ extensions.configure<DependencyManagementExtension>("dependencyManagement") {
     dependency("org.assertj:assertj-core:3.23.1")
     dependency("org.awaitility:awaitility:4.2.0")
     dependency("io.jaegertracing:jaeger-client:1.8.1")
-    dependency("com.signalfx.public:signalfx-java:1.0.23")
+    dependency("com.signalfx.public:signalfx-java:1.0.25")
 
     dependencySet("com.github.docker-java:3.2.11") {
       entry("docker-java-core")


### PR DESCRIPTION
This will bump the `jackson-databind` dependency version to 2.13.4.2

Fixes #945 