### PR TITLE
Fix local build prompting for gradle enterprise 👎🏻 

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,12 +13,10 @@ plugins {
   id("com.gradle.enterprise") version "3.11.3"
 }
 
-if (System.getenv("CI") != null) {
-  gradleEnterprise {
-    buildScan {
-      termsOfServiceUrl = "https://gradle.com/terms-of-service"
-      termsOfServiceAgree = "yes"
-    }
+gradleEnterprise {
+  buildScan {
+    termsOfServiceUrl = "https://gradle.com/terms-of-service"
+    termsOfServiceAgree = if (System.getenv("CI") != null) "yes" else "no"
   }
 }
 


### PR DESCRIPTION
With the upgrade to `3.11.3` in #977, local builds began prompting to accept the license agreement. This looked especially strange in IntelliJ, where it seemed like builds were just hung (which I guess they were, hung waiting for human input).

Anyway, this short circuits the prompt for local builds.