### PR TITLE
Change deprecated import

### DIFF
--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/otel/JvmMemory.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/otel/JvmMemory.java
@@ -33,13 +33,13 @@
 
 package com.splunk.opentelemetry.instrumentation.jvmmetrics.otel;
 
-import javax.annotation.Nullable;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryType;
 import java.lang.management.MemoryUsage;
 import java.util.function.ToLongFunction;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 
 /** This class is copied from micrometer. */
 class JvmMemory {

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/otel/JvmMemory.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/otel/JvmMemory.java
@@ -33,7 +33,7 @@
 
 package com.splunk.opentelemetry.instrumentation.jvmmetrics.otel;
 
-import io.micrometer.core.lang.Nullable;
+import javax.annotation.Nullable;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryType;


### PR DESCRIPTION
New Micrometer was issuing deprecation warnings for this import, which I'm sure was just an auto-import mistake. Change to `javax.annotation.Nullable`.