### PR TITLE
Revert "Bump gradle-plugins from 1.21.0-alpha-SNAPSHOT to 1.22.0-alpha-SNAPSHOT"

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
   implementation(gradleApi())
 
   implementation("com.diffplug.spotless:spotless-plugin-gradle:6.12.0")
-  implementation("io.opentelemetry.instrumentation:gradle-plugins:1.22.0-alpha-SNAPSHOT")
+  implementation("io.opentelemetry.instrumentation:gradle-plugins:1.21.0-alpha-SNAPSHOT")
   implementation("io.spring.gradle:dependency-management-plugin:1.1.0")
 
   // keep these versions in sync with settings.gradle.kts


### PR DESCRIPTION
Reverts signalfx/splunk-otel-java#1031

Fixes #1032 
Fixes #1035

We'll need to update this to the latest snapshot version together with the upstream agent; the `muzzle` module has changed a bit since the release, and it affects the plugins.