### PR TITLE
Prepare for 1.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,13 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ## Unreleased
 
-- Micrometer dependency has been updated to version 1.10.2. (#1018)
+## v1.19.0 - 2022-12-16
 
+### General
+
+- OpenTelemetry Java SDK and OpenTelemetry Instrumentation for Java dependencies have been updated to version 1.21.0. (#1029)
+- Micrometer dependency has been updated to version 1.10.2. (#1018)
+- Comply with [GDI spec version 1.4.0](https://github.com/signalfx/gdi-specification/releases/tag/v1.4.0)
 
 ## v1.18.0 - 2022-11-23
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
 
 <p align="center">
   <img alt="Stable" src="https://img.shields.io/badge/status-stable-informational?style=for-the-badge">
-  <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.18.0">
-    <img alt="OpenTelemetry Instrumentation for Java Version" src="https://img.shields.io/badge/otel-1.18.0-blueviolet?style=for-the-badge">
+  <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.21.0">
+    <img alt="OpenTelemetry Instrumentation for Java Version" src="https://img.shields.io/badge/otel-1.21.0-blueviolet?style=for-the-badge">
   </a>
-  <a href="https://github.com/signalfx/gdi-specification/releases/tag/v1.3.0">
-    <img alt="Splunk GDI specification" src="https://img.shields.io/badge/GDI-1.3.0-blueviolet?style=for-the-badge">
+  <a href="https://github.com/signalfx/gdi-specification/releases/tag/v1.4.0">
+    <img alt="Splunk GDI specification" src="https://img.shields.io/badge/GDI-1.4.0-blueviolet?style=for-the-badge">
   </a>
   <a href="https://github.com/signalfx/splunk-otel-java/releases">
     <img alt="GitHub release (latest SemVer)" src="https://img.shields.io/github/v/release/signalfx/splunk-otel-java?include_prereleases&style=for-the-badge">
@@ -75,11 +75,6 @@ see [Migrate from the SignalFx Java Agent](https://docs.splunk.com/Observability
 
 <!-- Comments, spacing, empty and new lines in the section below are intentional, please do not modify them! -->
 <!--DEV_DOCS_WARNING-->
-<!--DEV_DOCS_WARNING_START-->
-The following documentation refers to the in-development version of `splunk-otel-java`. Docs for the latest version ([v1.18.0](https://github.com/signalfx/splunk-otel-java/releases/latest)) can be found [here](https://github.com/signalfx/splunk-otel-java/blob/v1.18.0/README.md).
-
----
-<!--DEV_DOCS_WARNING_END-->
 
 ## Requirements
 
@@ -162,11 +157,11 @@ To extend the instrumentation with the OpenTelemetry Instrumentation for Java,
 you have to use a compatible API version.
 
 <!-- IMPORTANT: do not change comments or break those lines below -->
-The Splunk Distribution of OpenTelemetry Java version <!--SPLUNK_VERSION-->1.18.0<!--SPLUNK_VERSION--> is compatible
+The Splunk Distribution of OpenTelemetry Java version <!--SPLUNK_VERSION-->1.19.0<!--SPLUNK_VERSION--> is compatible
 with:
 
-* OpenTelemetry API version <!--OTEL_VERSION-->1.18.0<!--OTEL_VERSION-->
-* OpenTelemetry Instrumentation for Java version <!--OTEL_INSTRUMENTATION_VERSION-->1.18.0<!--OTEL_INSTRUMENTATION_VERSION-->
+* OpenTelemetry API version <!--OTEL_VERSION-->1.21.0<!--OTEL_VERSION-->
+* OpenTelemetry Instrumentation for Java version <!--OTEL_INSTRUMENTATION_VERSION-->1.21.0<!--OTEL_INSTRUMENTATION_VERSION-->
 * Micrometer version 1.10.2
 
 ## Snapshot builds

--- a/buildSrc/src/main/kotlin/splunk.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.java-conventions.gradle.kts
@@ -15,7 +15,7 @@ repositories {
 
 val otelVersion = "1.21.0"
 val otelAlphaVersion = "1.21.0-alpha"
-val otelContribAlphaVersion = "1.20.1-alpha"
+val otelContribAlphaVersion = "1.21.0-alpha"
 val otelInstrumentationVersion = "1.21.0"
 val otelInstrumentationAlphaVersion = "1.21.0-alpha"
 val micrometerVersion = "1.10.2"
@@ -29,21 +29,21 @@ extensions.configure<DependencyManagementExtension>("dependencyManagement") {
     dependency("org.assertj:assertj-core:3.23.1")
     dependency("org.awaitility:awaitility:4.2.0")
     dependency("io.jaegertracing:jaeger-client:1.8.1")
-    dependency("com.signalfx.public:signalfx-java:1.0.26")
+    dependency("com.signalfx.public:signalfx-java:1.0.27")
 
     dependencySet("com.github.docker-java:3.2.11") {
       entry("docker-java-core")
       entry("docker-java-transport-httpclient5")
     }
-    dependencySet("org.mockito:4.7.0") {
+    dependencySet("org.mockito:4.9.0") {
       entry("mockito-core")
       entry("mockito-junit-jupiter")
     }
-    dependencySet("org.slf4j:1.7.36") {
+    dependencySet("org.slf4j:2.0.6") {
       entry("slf4j-api")
       entry("slf4j-simple")
     }
-    dependencySet("com.google.auto.value:1.9") {
+    dependencySet("com.google.auto.value:1.10.1") {
       entry("auto-value")
       entry("auto-value-annotations")
     }
@@ -83,14 +83,14 @@ extensions.configure<DependencyManagementExtension>("dependencyManagement") {
 
   imports {
     mavenBom("com.fasterxml.jackson:jackson-bom:2.14.1")
-    mavenBom("com.google.protobuf:protobuf-bom:3.21.9")
+    mavenBom("com.google.protobuf:protobuf-bom:3.21.12")
     mavenBom("com.squareup.okhttp3:okhttp-bom:4.10.0")
-    mavenBom("io.grpc:grpc-bom:1.49.0")
+    mavenBom("io.grpc:grpc-bom:1.51.0")
     mavenBom("io.micrometer:micrometer-bom:$micrometerVersion")
     mavenBom("io.opentelemetry:opentelemetry-bom-alpha:$otelAlphaVersion")
     mavenBom("io.opentelemetry:opentelemetry-bom:$otelVersion")
-    mavenBom("org.junit:junit-bom:5.9.0")
-    mavenBom("org.testcontainers:testcontainers-bom:1.17.3")
+    mavenBom("org.junit:junit-bom:5.9.1")
+    mavenBom("org.testcontainers:testcontainers-bom:1.17.6")
   }
 }
 
@@ -102,7 +102,7 @@ dependencies {
   add("testImplementation", "org.junit.jupiter:junit-jupiter-api")
   add("testImplementation", "org.junit.jupiter:junit-jupiter-params")
   add("testRuntimeOnly", "org.junit.jupiter:junit-jupiter-engine")
-  add("testRuntimeOnly", "org.slf4j:slf4j-api:2.0.3")
+  add("testRuntimeOnly", "org.slf4j:slf4j-api:2.0.6")
 }
 
 tasks.withType<Test>().configureEach {

--- a/deployments/cloudfoundry/buildpack/README.md
+++ b/deployments/cloudfoundry/buildpack/README.md
@@ -40,7 +40,7 @@ If you want to use a specific version of the Java agent in your application, you
 environment variable before application deployment, either using `cf set-env` or the `manifest.yml` file:
 
 ```sh
-$ cf set-env SPLUNK_OTEL_JAVA_VERSION 1.18.0
+$ cf set-env SPLUNK_OTEL_JAVA_VERSION 1.19.0
 ```
 
 By default, the [latest](https://github.com/signalfx/splunk-otel-java/releases/latest) available agent version is used.


### PR DESCRIPTION
I also updated the GDI spec version to 1.4.0 -- there weren't any changed that affected the javaagent anyway.