### PR TITLE
Revert "Bump com.bmuschko.docker-remote-api from 9.0.1 to 9.1.0 (#1043)"

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,6 @@
 pluginManagement {
   plugins {
-    id("com.bmuschko.docker-remote-api") version "9.1.0"
+    id("com.bmuschko.docker-remote-api") version "9.0.1"
     id("com.github.johnrengelman.shadow") version "7.1.2"
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
     id("nebula.release") version "17.1.0"


### PR DESCRIPTION
This reverts commit 36cba588128b46239c38cf921ab6d79e40483b0a.

Looks like there's an issue with the newer version:

```
Exception in thread "docker-java-stream--1183027921" java.lang.UnsatisfiedLinkError: 'java.lang.String com.bmuschko.gradle.docker.shaded.com.sun.jna.Native.getNativeVersion()'
```