### PR TITLE
Rework gradle deps

### DIFF
--- a/agent/build.gradle.kts
+++ b/agent/build.gradle.kts
@@ -29,9 +29,10 @@ val upstreamAgent: Configuration by configurations.creating {
   isCanBeConsumed = false
 }
 
-val otelInstrumentationVersion: String by extra
+val otelInstrumentationVersion: String by rootProject.extra
 
 dependencies {
+  add("upstreamAgent", platform(project(":dependencyManagement")))
   bootstrapLibs(project(":bootstrap"))
 
   javaagentLibs(project(":custom"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,14 @@ group = "com.splunk"
 subprojects {
   version = rootProject.version
 
-  apply(plugin = "splunk.java-conventions")
-  apply(plugin = "splunk.spotless-conventions")
+  if (this.name != "dependencyManagement") {
+    apply(plugin = "splunk.java-conventions")
+    apply(plugin = "splunk.spotless-conventions")
+    dependencies {
+      for(conf in configurations) {
+        add(conf.name, platform(project(":dependencyManagement")))
+      }
+    }
+  }
 }
 

--- a/buildSrc/src/main/kotlin/splunk.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.java-conventions.gradle.kts
@@ -1,96 +1,11 @@
-import io.spring.gradle.dependencymanagement.dsl.DependencyManagementExtension
-
 plugins {
   java
-
-  id("io.spring.dependency-management")
 }
 
 repositories {
   mavenCentral()
   maven {
     url = uri("https://oss.sonatype.org/content/repositories/snapshots")
-  }
-}
-
-val otelVersion = "1.22.0"
-val otelAlphaVersion = "1.22.0-alpha"
-val otelContribAlphaVersion = "1.21.0-alpha"
-val otelInstrumentationVersion = "1.22.0-SNAPSHOT"
-val otelInstrumentationAlphaVersion = "1.22.0-alpha-SNAPSHOT"
-val micrometerVersion = "1.10.3"
-
-// instrumentation version is used to compute Implementation-Version manifest attribute
-extra["otelInstrumentationVersion"] = otelInstrumentationVersion
-
-extensions.configure<DependencyManagementExtension>("dependencyManagement") {
-  dependencies {
-    dependency("com.google.auto.service:auto-service:1.0.1")
-    dependency("org.assertj:assertj-core:3.23.1")
-    dependency("org.awaitility:awaitility:4.2.0")
-    dependency("io.jaegertracing:jaeger-client:1.8.1")
-    dependency("com.signalfx.public:signalfx-java:1.0.27")
-
-    dependencySet("com.github.docker-java:3.2.11") {
-      entry("docker-java-core")
-      entry("docker-java-transport-httpclient5")
-    }
-    dependencySet("org.mockito:4.9.0") {
-      entry("mockito-core")
-      entry("mockito-junit-jupiter")
-    }
-    dependencySet("org.slf4j:2.0.6") {
-      entry("slf4j-api")
-      entry("slf4j-simple")
-    }
-    dependencySet("com.google.auto.value:1.10.1") {
-      entry("auto-value")
-      entry("auto-value-annotations")
-    }
-
-    // otel-java-instrumentation
-    dependency("io.opentelemetry.javaagent:opentelemetry-javaagent:$otelInstrumentationVersion")
-    dependency("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:$otelInstrumentationVersion")
-    dependency("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv:$otelInstrumentationAlphaVersion")
-    dependencySet("io.opentelemetry.javaagent:$otelInstrumentationAlphaVersion") {
-      entry("opentelemetry-agent-for-testing")
-      entry("opentelemetry-javaagent-bootstrap")
-      entry("opentelemetry-javaagent-extension-api")
-      entry("opentelemetry-javaagent-instrumentation-api")
-      entry("opentelemetry-javaagent-tooling")
-      entry("opentelemetry-muzzle")
-      entry("opentelemetry-testing-common")
-    }
-    dependencySet("io.opentelemetry.instrumentation:$otelInstrumentationAlphaVersion") {
-      entry("opentelemetry-netty-4.1")
-    }
-    dependencySet("io.opentelemetry.javaagent.instrumentation:$otelInstrumentationAlphaVersion") {
-      entry("opentelemetry-javaagent-netty-3.8")
-      entry("opentelemetry-javaagent-netty-4.0")
-      entry("opentelemetry-javaagent-netty-4.1")
-      entry("opentelemetry-javaagent-netty-4.1-common")
-      entry("opentelemetry-javaagent-servlet-2.2")
-      entry("opentelemetry-javaagent-servlet-3.0")
-      entry("opentelemetry-javaagent-servlet-common")
-    }
-    dependencySet("io.opentelemetry.contrib:$otelContribAlphaVersion") {
-      entry("opentelemetry-samplers")
-      entry("opentelemetry-resource-providers")
-    }
-
-    dependency("io.opentelemetry.proto:opentelemetry-proto:0.19.0-alpha")
-  }
-
-  imports {
-    mavenBom("com.fasterxml.jackson:jackson-bom:2.14.1")
-    mavenBom("com.google.protobuf:protobuf-bom:3.21.12")
-    mavenBom("com.squareup.okhttp3:okhttp-bom:4.10.0")
-    mavenBom("io.grpc:grpc-bom:1.51.0")
-    mavenBom("io.micrometer:micrometer-bom:$micrometerVersion")
-    mavenBom("io.opentelemetry:opentelemetry-bom-alpha:$otelAlphaVersion")
-    mavenBom("io.opentelemetry:opentelemetry-bom:$otelVersion")
-    mavenBom("org.junit:junit-bom:5.9.1")
-    mavenBom("org.testcontainers:testcontainers-bom:1.17.6")
   }
 }
 

--- a/buildSrc/src/main/kotlin/splunk.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.java-conventions.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
   add("testImplementation", "org.junit.jupiter:junit-jupiter-api")
   add("testImplementation", "org.junit.jupiter:junit-jupiter-params")
   add("testRuntimeOnly", "org.junit.jupiter:junit-jupiter-engine")
-  add("testRuntimeOnly", "org.slf4j:slf4j-api:2.0.6")
+  add("testRuntimeOnly", "org.slf4j:slf4j-api")
 }
 
 tasks.withType<Test>().configureEach {

--- a/buildSrc/src/main/kotlin/splunk.muzzle-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.muzzle-conventions.gradle.kts
@@ -9,6 +9,9 @@ plugins {
 }
 
 dependencies {
+  add("muzzleTooling", platform(project(":dependencyManagement")))
+  add("muzzleBootstrap", platform(project(":dependencyManagement")))
+  add("codegen", platform(project(":dependencyManagement")))
   // dependencies needed to make muzzle-check work
   add("muzzleTooling", "io.opentelemetry.javaagent:opentelemetry-javaagent-tooling")
   add("muzzleTooling", "ch.qos.logback:logback-classic:1.2.10")

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -1,0 +1,84 @@
+plugins {
+  `java-platform`
+}
+
+val otelVersion = "1.22.0"
+val otelAlphaVersion = "1.22.0-alpha"
+val otelInstrumentationVersion = "1.22.0-SNAPSHOT"
+val otelInstrumentationAlphaVersion = "1.22.0-alpha-SNAPSHOT"
+val otelContribAlphaVersion = "1.21.0-alpha"
+
+val micrometerVersion = "1.10.3"
+val micrometerOldVersion = "1.3.20"
+val dockerJavaVersion = "3.2.11"
+val mockitoVersion = "4.9.0"
+val slfVersion = "2.0.6"
+val autoValueVersion = "1.10.1";
+
+// instrumentation version is used to compute Implementation-Version manifest attribute
+rootProject.extra["otelInstrumentationVersion"] = otelInstrumentationVersion
+rootProject.extra["micrometerOldVersion"] = micrometerOldVersion
+
+javaPlatform {
+  // What a great hack!
+  allowDependencies()
+}
+
+dependencies {
+
+  // BOMs
+  api(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.14.1"))
+  api(enforcedPlatform("com.google.protobuf:protobuf-bom:3.21.12"))
+  api(enforcedPlatform("com.squareup.okhttp3:okhttp-bom:4.10.0"))
+  api(enforcedPlatform("io.grpc:grpc-bom:1.51.0"))
+  api(platform("io.micrometer:micrometer-bom:$micrometerVersion"))
+  api(enforcedPlatform("io.opentelemetry:opentelemetry-bom-alpha:$otelAlphaVersion"))
+  api(enforcedPlatform("io.opentelemetry:opentelemetry-bom:$otelVersion"))
+  api(enforcedPlatform("org.junit:junit-bom:5.9.1"))
+  api(enforcedPlatform("org.testcontainers:testcontainers-bom:1.17.6"))
+
+  constraints {
+    api("com.google.auto.service:auto-service:1.0.1")
+    api("io.jaegertracing:jaeger-client:1.8.1")
+    api("org.assertj:assertj-core:3.23.1")
+    api("org.awaitility:awaitility:4.2.0")
+    api("com.signalfx.public:signalfx-java:1.0.27")
+
+    api("com.github.docker-java:docker-java-core:$dockerJavaVersion")
+    api("com.github.docker-java:docker-java-transport-httpclient5:$dockerJavaVersion")
+
+    api("org.mockito:mockito-core:$mockitoVersion")
+    api("org.mockito:mockito-junit-jupiter:$mockitoVersion")
+    api("org.slf4j:slf4j-api:$slfVersion")
+    api("org.slf4j:slf4j-simple:$slfVersion")
+    api("com.google.auto.value:auto-value:$autoValueVersion")
+    api("com.google.auto.value:auto-value-annotations:$autoValueVersion")
+
+    // otel-java-instrumentation
+    api("io.opentelemetry.javaagent:opentelemetry-javaagent:$otelInstrumentationVersion")
+    api("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:$otelInstrumentationVersion")
+    api("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv:$otelInstrumentationAlphaVersion")
+
+    api("io.opentelemetry.javaagent:opentelemetry-agent-for-testing:$otelInstrumentationAlphaVersion")
+    api("io.opentelemetry.javaagent:opentelemetry-javaagent-bootstrap:$otelInstrumentationAlphaVersion")
+    api("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api:$otelInstrumentationAlphaVersion")
+    api("io.opentelemetry.javaagent:opentelemetry-javaagent-instrumentation-api:$otelInstrumentationAlphaVersion")
+    api("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling:$otelInstrumentationAlphaVersion")
+    api("io.opentelemetry.javaagent:opentelemetry-muzzle:$otelInstrumentationAlphaVersion")
+    api("io.opentelemetry.javaagent:opentelemetry-testing-common:$otelInstrumentationAlphaVersion")
+    api("io.opentelemetry.instrumentation:opentelemetry-netty-4.1:$otelInstrumentationAlphaVersion")
+    api("io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-netty-3.8:$otelInstrumentationAlphaVersion")
+    api("io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-netty-4.0:$otelInstrumentationAlphaVersion")
+    api("io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-netty-4.1:$otelInstrumentationAlphaVersion")
+    api("io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-netty-4.1-common:$otelInstrumentationAlphaVersion")
+    api("io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-servlet-2.2:$otelInstrumentationAlphaVersion")
+    api("io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-servlet-3.0:$otelInstrumentationAlphaVersion")
+    api("io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-servlet-common:$otelInstrumentationAlphaVersion")
+
+    api("io.opentelemetry.contrib:opentelemetry-samplers:$otelContribAlphaVersion")
+    api("io.opentelemetry.contrib:opentelemetry-resource-providers:$otelContribAlphaVersion")
+
+    api("io.opentelemetry.proto:opentelemetry-proto:0.19.0-alpha")
+  }
+
+}

--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -16,6 +16,10 @@ subprojects {
       options.release.set(8)
     }
   }
+  dependencies {
+    implementation(platform(project(":dependencyManagement")))
+  }
+
 }
 
 tasks {

--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -19,7 +19,6 @@ subprojects {
   dependencies {
     implementation(platform(project(":dependencyManagement")))
   }
-
 }
 
 tasks {

--- a/instrumentation/khttp/src/main/java/com/splunk/opentelemetry/instrumentation/khttp/KHttpSingletons.java
+++ b/instrumentation/khttp/src/main/java/com/splunk/opentelemetry/instrumentation/khttp/KHttpSingletons.java
@@ -45,8 +45,9 @@ public final class KHttpSingletons {
                 INSTRUMENTATION_NAME,
                 HttpSpanNameExtractor.create(httpAttributesGetter))
             .setSpanStatusExtractor(HttpSpanStatusExtractor.create(httpAttributesGetter))
-            .addAttributesExtractor(HttpClientAttributesExtractor.create(httpAttributesGetter))
-            .addAttributesExtractor(NetClientAttributesExtractor.create(netAttributesGetter))
+            .addAttributesExtractor(HttpClientAttributesExtractor.create(httpAttributesGetter, netAttributesGetter))
+            .addAttributesExtractor(NetClientAttributesExtractor.create(
+                netAttributesGetter))
             .addAttributesExtractor(
                 PeerServiceAttributesExtractor.create(
                     netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))

--- a/instrumentation/khttp/src/main/java/com/splunk/opentelemetry/instrumentation/khttp/KHttpSingletons.java
+++ b/instrumentation/khttp/src/main/java/com/splunk/opentelemetry/instrumentation/khttp/KHttpSingletons.java
@@ -45,9 +45,9 @@ public final class KHttpSingletons {
                 INSTRUMENTATION_NAME,
                 HttpSpanNameExtractor.create(httpAttributesGetter))
             .setSpanStatusExtractor(HttpSpanStatusExtractor.create(httpAttributesGetter))
-            .addAttributesExtractor(HttpClientAttributesExtractor.create(httpAttributesGetter, netAttributesGetter))
-            .addAttributesExtractor(NetClientAttributesExtractor.create(
-                netAttributesGetter))
+            .addAttributesExtractor(
+                HttpClientAttributesExtractor.create(httpAttributesGetter, netAttributesGetter))
+            .addAttributesExtractor(NetClientAttributesExtractor.create(netAttributesGetter))
             .addAttributesExtractor(
                 PeerServiceAttributesExtractor.create(
                     netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))

--- a/instrumentation/micrometer-1.3-shaded-for-instrumenting/build.gradle.kts
+++ b/instrumentation/micrometer-1.3-shaded-for-instrumenting/build.gradle.kts
@@ -2,8 +2,19 @@ plugins {
   id("com.github.johnrengelman.shadow")
 }
 
+val micrometerOldVersion: String by rootProject.extra
+
 dependencies {
-  implementation("io.micrometer:micrometer-core:1.3.16")
+  implementation("io.micrometer:micrometer-core")
+}
+
+configurations.all {
+  resolutionStrategy.eachDependency {
+    if (requested.group == "io.micrometer" && requested.name == "micrometer-core") {
+      useVersion(micrometerOldVersion)
+      because("We need the old version")
+    }
+  }
 }
 
 // we need to shade the micrometer API to be able to instrument it - it's similar to how OTel bridge works

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,7 @@ gradleEnterprise {
 }
 
 rootProject.name = "splunk-otel-java"
+include(":dependencyManagement")
 include(
     "agent",
     "bootstrap",


### PR DESCRIPTION
Remove the spring dependency management plugin in favor of the gradle built-in `java-platform` approach. 

[Ref1](https://docs.gradle.org/current/userguide/platforms.html) and [ref2](https://docs.gradle.org/current/userguide/java_platform_plugin.html).

The spring plugin was not terribly compatible with dependabot and we were missing critical updates as they were released. This borrows from the approach in upstream, which seems much happier with dependabot poking around.