### PR TITLE
Add workflow to publish to GHCR

### DIFF
--- a/.github/workflows/publish-docker-image-ghcr.yml
+++ b/.github/workflows/publish-docker-image-ghcr.yml
@@ -29,7 +29,7 @@ jobs:
         uses: docker/build-push-action@v4.0.0
         with:
           push: true
-          file: Dockerfile
+          file: Dockerfile-ghcr
           build-args: |
             RELEASE_VER=${{ env.GITHUB_REF_NAME }}
           tags: |

--- a/.github/workflows/publish-docker-image-ghcr.yml
+++ b/.github/workflows/publish-docker-image-ghcr.yml
@@ -1,0 +1,40 @@
+name: publish splunk-otel-java docker image to ghcr
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3.3.0
+
+      - uses: docker/setup-buildx-action@v2
+
+      - name: Put GITHUB_REF_NAME into env
+        run: echo GITHUB_REF_NAME=${GITHUB_REF_NAME} >> $GITHUB_ENV
+
+      - name: Set the major version number
+        run: echo MAJOR_VERSION=${GITHUB_REF_NAME} | sed -e 's/\..*//' >> $GITHUB_ENV
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: build and publish container
+        uses: docker/build-push-action@v4.0.0
+        with:
+          push: true
+          file: Dockerfile
+          build-args: |
+            RELEASE_VER=${{ env.GITHUB_REF_NAME }}
+          tags: |
+            ghcr.io/signalfx/splunk-otel-java/splunk-otel-java:latest
+            ghcr.io/signalfx/splunk-otel-java/splunk-otel-java:${{ env.MAJOR_VERSION }}
+            ghcr.io/signalfx/splunk-otel-java/splunk-otel-java:${{ env.GITHUB_REF_NAME }}
+
+

--- a/Dockerfile-ghcr
+++ b/Dockerfile-ghcr
@@ -1,0 +1,7 @@
+FROM scratch
+
+ARG RELEASE_VER
+ENV RELEASE_VER=$RELEASE_VER
+
+ADD https://github.com/signalfx/splunk-otel-java/releases/download/${RELEASE_VER}/splunk-otel-javaagent.jar /
+


### PR DESCRIPTION
This is related to #647.
We want to be publishing a more minimal docker layer that only contains our released agent jars. Also, we are switching from quay.io for open source images, so this sets up a GHA workflow that triggers on release creation and builds/publishes to GHCR.

There is a [sample repo here](https://github.com/breedx-splk/ghcr-publish-exp) that I used in development. You can look at the actions there and see the packages that result.