### PR TITLE
Create symlink to agent jar in ghcr container

### DIFF
--- a/Dockerfile-ghcr
+++ b/Dockerfile-ghcr
@@ -1,7 +1,10 @@
-FROM scratch
+FROM busybox
 
 ARG RELEASE_VER
 ENV RELEASE_VER=$RELEASE_VER
+ADD https://github.com/signalfx/splunk-otel-java/releases/download/${RELEASE_VER}/splunk-otel-javaagent.jar /stage/
+RUN chmod 644 /stage/splunk-otel-javaagent.jar
+RUN ln -s splunk-otel-javaagent.jar /stage/javaagent.jar
 
-ADD https://github.com/signalfx/splunk-otel-java/releases/download/${RELEASE_VER}/splunk-otel-javaagent.jar /
-
+FROM scratch
+COPY --from=0 /stage/ /


### PR DESCRIPTION
In better keeping with the [upstream k8s operator](https://github.com/open-telemetry/opentelemetry-operator/blob/65c2bec1aeeff08c42ca2d31892af0ff06fa4c65/autoinstrumentation/java/Dockerfile#L2), we create a symlink in the root of the container whose name is `javaagent.jar` which matches the expectation.

