### PR TITLE
Fix agent startup with security manager

### DIFF
--- a/bootstrap/src/main/java/com/splunk/opentelemetry/javaagent/SplunkAgent.java
+++ b/bootstrap/src/main/java/com/splunk/opentelemetry/javaagent/SplunkAgent.java
@@ -25,31 +25,6 @@ public class SplunkAgent {
   }
 
   public static void agentmain(final String agentArgs, final Instrumentation inst) {
-    addCustomLoggingConfiguration();
-
     OpenTelemetryAgent.agentmain(agentArgs, inst);
-  }
-
-  private static final String METRICS_RETRY_LOGGER_PROPERTY =
-      "io.opentelemetry.javaagent.slf4j.simpleLogger.log.com.signalfx.shaded.apache.http.impl.execchain.RetryExec";
-
-  private static void addCustomLoggingConfiguration() {
-    // metrics exporter sometimes logs "Broken pipe (Write failed)" at INFO; usually in
-    // docker-based environments
-    // most likely docker resets long-running connections and the exporter has to retry, and it
-    // always succeeds after retrying and metrics are exported correctly
-    // limit default logging level to WARN unless debug mode is on or the user has overridden it
-    String metricsRetryLoggerLevel = System.getProperty(METRICS_RETRY_LOGGER_PROPERTY);
-    if (metricsRetryLoggerLevel == null && !isDebugMode()) {
-      System.setProperty(METRICS_RETRY_LOGGER_PROPERTY, "WARN");
-    }
-  }
-
-  private static boolean isDebugMode() {
-    String value = System.getProperty("otel.javaagent.debug");
-    if (value == null) {
-      value = System.getenv("OTEL_JAVAAGENT_DEBUG");
-    }
-    return Boolean.parseBoolean(value);
   }
 }

--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
   compileOnly("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api")
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api")
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling")
+  compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-internal-logging-simple")
 
   annotationProcessor("com.google.auto.service:auto-service")
   compileOnly("com.google.auto.service:auto-service")

--- a/custom/src/main/java/com/splunk/opentelemetry/logging/SplunkSlf4jLoggingCustomizer.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/logging/SplunkSlf4jLoggingCustomizer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.opentelemetry.logging;
 
 import com.google.auto.service.AutoService;

--- a/custom/src/main/java/com/splunk/opentelemetry/logging/SplunkSlf4jLoggingCustomizer.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/logging/SplunkSlf4jLoggingCustomizer.java
@@ -1,0 +1,55 @@
+package com.splunk.opentelemetry.logging;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.javaagent.logging.simple.Slf4jSimpleLoggingCustomizer;
+import io.opentelemetry.javaagent.tooling.LoggingCustomizer;
+
+@AutoService(LoggingCustomizer.class)
+public class SplunkSlf4jLoggingCustomizer implements LoggingCustomizer {
+  private final Slf4jSimpleLoggingCustomizer delegate = new Slf4jSimpleLoggingCustomizer();
+
+  @Override
+  public String name() {
+    return delegate.name();
+  }
+
+  @Override
+  public void init() {
+    addCustomLoggingConfiguration();
+
+    delegate.init();
+  }
+
+  @Override
+  public void onStartupSuccess() {
+    delegate.onStartupSuccess();
+  }
+
+  @Override
+  public void onStartupFailure(Throwable throwable) {
+    delegate.onStartupFailure(throwable);
+  }
+
+  private static final String METRICS_RETRY_LOGGER_PROPERTY =
+      "io.opentelemetry.javaagent.slf4j.simpleLogger.log.com.signalfx.shaded.apache.http.impl.execchain.RetryExec";
+
+  private static void addCustomLoggingConfiguration() {
+    // metrics exporter sometimes logs "Broken pipe (Write failed)" at INFO; usually in
+    // docker-based environments
+    // most likely docker resets long-running connections and the exporter has to retry, and it
+    // always succeeds after retrying and metrics are exported correctly
+    // limit default logging level to WARN unless debug mode is on or the user has overridden it
+    String metricsRetryLoggerLevel = System.getProperty(METRICS_RETRY_LOGGER_PROPERTY);
+    if (metricsRetryLoggerLevel == null && !isDebugMode()) {
+      System.setProperty(METRICS_RETRY_LOGGER_PROPERTY, "WARN");
+    }
+  }
+
+  private static boolean isDebugMode() {
+    String value = System.getProperty("otel.javaagent.debug");
+    if (value == null) {
+      value = System.getenv("OTEL_JAVAAGENT_DEBUG");
+    }
+    return Boolean.parseBoolean(value);
+  }
+}

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
     api("io.opentelemetry.javaagent:opentelemetry-javaagent-bootstrap:$otelInstrumentationAlphaVersion")
     api("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api:$otelInstrumentationAlphaVersion")
     api("io.opentelemetry.javaagent:opentelemetry-javaagent-instrumentation-api:$otelInstrumentationAlphaVersion")
+    api("io.opentelemetry.javaagent:opentelemetry-javaagent-internal-logging-simple:$otelInstrumentationAlphaVersion")
     api("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling:$otelInstrumentationAlphaVersion")
     api("io.opentelemetry.javaagent:opentelemetry-muzzle:$otelInstrumentationAlphaVersion")
     api("io.opentelemetry.javaagent:opentelemetry-testing-common:$otelInstrumentationAlphaVersion")

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/SecurityManagerSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/SecurityManagerSmokeTest.java
@@ -38,16 +38,18 @@ public class SecurityManagerSmokeTest extends SmokeTest {
 
   @Override
   protected Map<String, String> getExtraEnv() {
-    return Map.of("OTEL_JAVAAGENT_EXPERIMENTAL_SECURITY_MANAGER_SUPPORT_ENABLED", "true",
+    return Map.of(
+        "OTEL_JAVAAGENT_EXPERIMENTAL_SECURITY_MANAGER_SUPPORT_ENABLED",
+        "true",
         // AbstractTestContainerManager sets sampler to "internal_root_off" which isn't suitable for
         // this test, overwrite it
-        "OTEL_TRACES_SAMPLER", "always_on");
+        "OTEL_TRACES_SAMPLER",
+        "always_on");
   }
 
   @Override
   protected TargetWaitStrategy getWaitStrategy() {
-    return new TargetWaitStrategy.Log(
-        Duration.ofMinutes(1), ".*opentelemetry-javaagent.*");
+    return new TargetWaitStrategy.Log(Duration.ofMinutes(1), ".*opentelemetry-javaagent.*");
   }
 
   @ParameterizedTest(name = "{index} => SecurityManager SmokeTest On JDK{0}.")

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/SecurityManagerSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/SecurityManagerSmokeTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry;
+
+import static com.splunk.opentelemetry.helper.TestImage.linuxImage;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.splunk.opentelemetry.helper.TargetWaitStrategy;
+import com.splunk.opentelemetry.helper.TestImage;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class SecurityManagerSmokeTest extends SmokeTest {
+
+  private TestImage getTargetImage(int jdk) {
+    return linuxImage(
+        "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-security-manager:jdk"
+            + jdk
+            + "-20230323.4502979551");
+  }
+
+  @Override
+  protected Map<String, String> getExtraEnv() {
+    return Map.of("OTEL_JAVAAGENT_EXPERIMENTAL_SECURITY_MANAGER_SUPPORT_ENABLED", "true",
+        // AbstractTestContainerManager sets sampler to "internal_root_off" which isn't suitable for
+        // this test, overwrite it
+        "OTEL_TRACES_SAMPLER", "always_on");
+  }
+
+  @Override
+  protected TargetWaitStrategy getWaitStrategy() {
+    return new TargetWaitStrategy.Log(
+        Duration.ofMinutes(1), ".*opentelemetry-javaagent.*");
+  }
+
+  @ParameterizedTest(name = "{index} => SecurityManager SmokeTest On JDK{0}.")
+  @ValueSource(ints = {8, 11, 17, 19})
+  void securityManagerSmokeTestOnJDK(int jdk) throws IOException, InterruptedException {
+    startTargetOrSkipTest(getTargetImage(jdk));
+
+    assertEquals(1, waitForTraces().countSpansByName("test"));
+
+    stopTarget();
+  }
+}


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7983 adds an experimental option to improve compatibility with security manager to upstream agent. This pr adds a test for running our agent with enabled security manger and moves calls to methods that require privileges, such as `System.setProperty` and `System.getenv`, to a later point where agent code has the required privileges.