### PR TITLE
Remove data format, standardize on only pprof.

### DIFF
--- a/profiler/README.md
+++ b/profiler/README.md
@@ -54,8 +54,6 @@ property or as environment variables (by making them uppercase and replacing dot
 | `splunk.profiler.memory.sampler.interval` | 1                                                      | set to `2` or larger to enable sampling every Nth allocation event where N is the value of this property                                                                                      |
 | `splunk.profiler.include.internal.stacks` | false                                                  | set to `true` to include stack traces of agent internal threads and stack traces with only JDK internal frames                                                                                |
 | `splunk.profiler.tracing.stacks.only`     | false                                                  | set to `true` to include only stack traces that are linked to a span context                                                                                                                  |
-| `splunk.profiler.cpu.data.format`         | `pprof-gzip-base64`                                    | DEPRECATED. Controls the format of CPU call stack data sent to the collector. Should be `pprof-gzip-base64` (`text` is deprecated and will be removed in the next release)                    |
-| `splunk.profiler.memory.data.format`      | `pprof-gzip-base64`                                    | DEPRECATED. Controls the format of memory allocation call site stack data sent to the collector. Should be `pprof-gzip-base64` (`text` is deprecated and will be removed in the next release) |
 
 If the `splunk.profiler.enabled` option is not enabled, all profiling features are disabled. For
 example, setting `splunk.profiler.memory.enabled` to `true` has no effect if

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
@@ -26,7 +26,6 @@ import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvide
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import java.time.Duration;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.logging.Logger;
 
@@ -148,41 +147,11 @@ public class Configuration implements AutoConfigurationCustomizerProvider {
     return config.getInt(CONFIG_KEY_STACK_DEPTH, DEFAULT_STACK_DEPTH);
   }
 
-  public static DataFormat getCpuDataFormat(ConfigProperties config) {
-    String value =
-        config.getString(CONFIG_KEY_CPU_DATA_FORMAT, DataFormat.PPROF_GZIP_BASE64.value());
-    return DataFormat.fromString(value);
-  }
-
-  public static DataFormat getAllocationDataFormat(ConfigProperties config) {
-    String value =
-        config.getString(CONFIG_KEY_MEMORY_DATA_FORMAT, DataFormat.PPROF_GZIP_BASE64.value());
-    return DataFormat.fromString(value);
-  }
-
   private static int getJavaVersion() {
     String javaSpecVersion = System.getProperty("java.specification.version");
     if ("1.8".equals(javaSpecVersion)) {
       return 8;
     }
     return Integer.parseInt(javaSpecVersion);
-  }
-
-  public enum DataFormat {
-    PPROF_GZIP_BASE64;
-
-    private final String value;
-
-    DataFormat() {
-      value = name().toLowerCase(Locale.ROOT).replace('_', '-');
-    }
-
-    public static DataFormat fromString(String value) {
-      return DataFormat.valueOf(value.toUpperCase(Locale.ROOT).replace('-', '_'));
-    }
-
-    public String value() {
-      return value;
-    }
   }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrActivator.java
@@ -26,7 +26,6 @@ import static com.splunk.opentelemetry.profiler.util.Runnables.logUncaught;
 import static java.util.logging.Level.WARNING;
 
 import com.google.auto.service.AutoService;
-import com.splunk.opentelemetry.profiler.Configuration.DataFormat;
 import com.splunk.opentelemetry.profiler.allocation.exporter.AllocationEventExporter;
 import com.splunk.opentelemetry.profiler.allocation.exporter.PprofAllocationEventExporter;
 import com.splunk.opentelemetry.profiler.context.SpanContextualizer;
@@ -140,11 +139,9 @@ public class JfrActivator implements AgentListener {
     EventPeriods periods = new EventPeriods(jfrSettings::get);
     LogRecordExporter logsExporter = LogExporterBuilder.fromConfig(config);
 
-    DataFormat cpuDataFormat = Configuration.getCpuDataFormat(config);
     CpuEventExporter cpuEventExporter =
         PprofCpuEventExporter.builder()
             .otelLogger(buildOtelLogger(SimpleLogRecordProcessor.create(logsExporter), resource))
-            .dataFormat(cpuDataFormat)
             .eventPeriods(periods)
             .stackDepth(stackDepth)
             .build();
@@ -154,12 +151,10 @@ public class JfrActivator implements AgentListener {
         buildThreadDumpProcessor(
             eventReader, spanContextualizer, cpuEventExporter, stackTraceFilter, config);
 
-    DataFormat allocationDataFormat = Configuration.getAllocationDataFormat(config);
     AllocationEventExporter allocationEventExporter =
         PprofAllocationEventExporter.builder()
             .eventReader(eventReader)
             .otelLogger(buildOtelLogger(SimpleLogRecordProcessor.create(logsExporter), resource))
-            .dataFormat(allocationDataFormat)
             .stackDepth(stackDepth)
             .build();
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/ProfilingSemanticAttributes.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/ProfilingSemanticAttributes.java
@@ -36,7 +36,6 @@ public class ProfilingSemanticAttributes {
   public static final AttributeKey<Long> SOURCE_EVENT_TIME = longKey("source.event.time");
 
   public static final AttributeKey<String> DATA_TYPE = stringKey("profiling.data.type");
-  public static final AttributeKey<String> DATA_FORMAT = stringKey("profiling.data.format");
   public static final AttributeKey<Long> FRAME_COUNT = longKey("profiling.data.total.frame.count");
 
   public static final AttributeKey<Long> THREAD_ID = longKey("thread.id");

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/allocation/exporter/PprofAllocationEventExporter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/allocation/exporter/PprofAllocationEventExporter.java
@@ -29,7 +29,6 @@ import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.TRAC
 import com.google.perftools.profiles.ProfileProto;
 import com.google.perftools.profiles.ProfileProto.Profile;
 import com.google.perftools.profiles.ProfileProto.Sample;
-import com.splunk.opentelemetry.profiler.Configuration.DataFormat;
 import com.splunk.opentelemetry.profiler.EventReader;
 import com.splunk.opentelemetry.profiler.ProfilingDataType;
 import com.splunk.opentelemetry.profiler.allocation.sampler.AllocationEventSampler;
@@ -45,18 +44,15 @@ import org.openjdk.jmc.common.item.IItem;
 
 public class PprofAllocationEventExporter implements AllocationEventExporter {
   private final EventReader eventReader;
-  private final DataFormat dataFormat;
   private final PprofLogDataExporter pprofLogDataExporter;
   private final int stackDepth;
   private Pprof pprof = createPprof();
 
   private PprofAllocationEventExporter(Builder builder) {
     this.eventReader = builder.eventReader;
-    this.dataFormat = builder.dataFormat;
     this.stackDepth = builder.stackDepth;
     this.pprofLogDataExporter =
-        new PprofLogDataExporter(
-            builder.otelLogger, ProfilingDataType.ALLOCATION, builder.dataFormat);
+        new PprofLogDataExporter(builder.otelLogger, ProfilingDataType.ALLOCATION);
   }
 
   @Override
@@ -154,7 +150,7 @@ public class PprofAllocationEventExporter implements AllocationEventExporter {
   }
 
   private byte[] serializePprof() {
-    byte[] result = pprof.serialize(dataFormat);
+    byte[] result = pprof.serialize();
     pprof = createPprof();
     return result;
   }
@@ -177,7 +173,6 @@ public class PprofAllocationEventExporter implements AllocationEventExporter {
   public static class Builder {
     private EventReader eventReader;
     private Logger otelLogger;
-    private DataFormat dataFormat;
     private int stackDepth;
 
     public PprofAllocationEventExporter build() {
@@ -191,11 +186,6 @@ public class PprofAllocationEventExporter implements AllocationEventExporter {
 
     public Builder otelLogger(Logger otelLogger) {
       this.otelLogger = otelLogger;
-      return this;
-    }
-
-    public Builder dataFormat(DataFormat dataFormat) {
-      this.dataFormat = dataFormat;
       return this;
     }
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/PprofCpuEventExporter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/PprofCpuEventExporter.java
@@ -28,7 +28,6 @@ import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.THRE
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.TRACE_ID;
 
 import com.google.perftools.profiles.ProfileProto.Sample;
-import com.splunk.opentelemetry.profiler.Configuration.DataFormat;
 import com.splunk.opentelemetry.profiler.ProfilingDataType;
 import com.splunk.opentelemetry.profiler.context.StackToSpanLinkage;
 import com.splunk.opentelemetry.profiler.events.EventPeriods;
@@ -40,18 +39,15 @@ import java.time.Duration;
 import java.time.Instant;
 
 public class PprofCpuEventExporter implements CpuEventExporter {
-  private final DataFormat dataFormat;
   private final EventPeriods eventPeriods;
   private final int stackDepth;
   private final PprofLogDataExporter pprofLogDataExporter;
   private Pprof pprof = createPprof();
 
   private PprofCpuEventExporter(Builder builder) {
-    this.dataFormat = builder.dataFormat;
     this.eventPeriods = builder.eventPeriods;
     this.stackDepth = builder.stackDepth;
-    this.pprofLogDataExporter =
-        new PprofLogDataExporter(builder.otelLogger, ProfilingDataType.CPU, builder.dataFormat);
+    this.pprofLogDataExporter = new PprofLogDataExporter(builder.otelLogger, ProfilingDataType.CPU);
   }
 
   @Override
@@ -106,7 +102,7 @@ public class PprofCpuEventExporter implements CpuEventExporter {
   }
 
   private byte[] serializePprof() {
-    byte[] result = pprof.serialize(dataFormat);
+    byte[] result = pprof.serialize();
     pprof = createPprof();
     return result;
   }
@@ -128,7 +124,6 @@ public class PprofCpuEventExporter implements CpuEventExporter {
 
   public static class Builder {
     private Logger otelLogger;
-    private DataFormat dataFormat;
     private EventPeriods eventPeriods;
     private int stackDepth;
 
@@ -138,11 +133,6 @@ public class PprofCpuEventExporter implements CpuEventExporter {
 
     public Builder otelLogger(Logger otelLogger) {
       this.otelLogger = otelLogger;
-      return this;
-    }
-
-    public Builder dataFormat(DataFormat dataFormat) {
-      this.dataFormat = dataFormat;
       return this;
     }
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporter.java
@@ -16,14 +16,12 @@
 
 package com.splunk.opentelemetry.profiler.exporter;
 
-import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.DATA_FORMAT;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.DATA_TYPE;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.FRAME_COUNT;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.PROFILING_SOURCE;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SOURCE_TYPE;
 import static java.util.logging.Level.FINE;
 
-import com.splunk.opentelemetry.profiler.Configuration.DataFormat;
 import com.splunk.opentelemetry.profiler.ProfilingDataType;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.logs.Logger;
@@ -35,19 +33,15 @@ public class PprofLogDataExporter {
 
   private final Logger otelLogger;
   private final ProfilingDataType dataType;
-  private final DataFormat dataFormat;
   private final Attributes commonAttributes;
 
-  public PprofLogDataExporter(
-      Logger otelLogger, ProfilingDataType dataType, DataFormat dataFormat) {
+  public PprofLogDataExporter(Logger otelLogger, ProfilingDataType dataType) {
     this.otelLogger = otelLogger;
     this.dataType = dataType;
-    this.dataFormat = dataFormat;
     this.commonAttributes =
         Attributes.builder()
             .put(SOURCE_TYPE, PROFILING_SOURCE)
             .put(DATA_TYPE, dataType.value())
-            .put(DATA_FORMAT, dataFormat.value())
             .build();
   }
 
@@ -55,8 +49,8 @@ public class PprofLogDataExporter {
     if (logger.isLoggable(FINE)) {
       logger.log(
           FINE,
-          "Exporting {0} data as {1}, size {2}.",
-          new Object[] {dataType.value(), dataFormat.value(), bytes.length});
+          "Exporting {0} data as pprof, size {2}.",
+          new Object[] {dataType.value(), bytes.length});
     }
 
     String body = new String(bytes, StandardCharsets.ISO_8859_1);

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/pprof/Pprof.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/pprof/Pprof.java
@@ -16,9 +16,13 @@
 
 package com.splunk.opentelemetry.profiler.pprof;
 
-import static com.google.perftools.profiles.ProfileProto.*;
+import static com.google.perftools.profiles.ProfileProto.Function;
+import static com.google.perftools.profiles.ProfileProto.Label;
+import static com.google.perftools.profiles.ProfileProto.Line;
+import static com.google.perftools.profiles.ProfileProto.Location;
+import static com.google.perftools.profiles.ProfileProto.Profile;
+import static com.google.perftools.profiles.ProfileProto.Sample;
 
-import com.splunk.opentelemetry.profiler.Configuration;
 import io.opentelemetry.api.common.AttributeKey;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -94,11 +98,7 @@ public class Pprof {
     return frameCount;
   }
 
-  public byte[] serialize(Configuration.DataFormat dataFormat) {
-    if (dataFormat != Configuration.DataFormat.PPROF_GZIP_BASE64) {
-      throw new IllegalArgumentException("Unsupported data format " + dataFormat);
-    }
-
+  public byte[] serialize() {
     Profile profile = profileBuilder.build();
     try {
       ByteArrayOutputStream byteStream = new ByteArrayOutputStream();

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationTest.java
@@ -102,16 +102,4 @@ class ConfigurationTest {
     boolean result = Configuration.getTLABEnabled(config);
     assertFalse(result);
   }
-
-  @Test
-  void testValue() {
-    assertEquals("pprof-gzip-base64", Configuration.DataFormat.PPROF_GZIP_BASE64.value());
-  }
-
-  @Test
-  void testFromString() {
-    assertEquals(
-        Configuration.DataFormat.PPROF_GZIP_BASE64,
-        Configuration.DataFormat.fromString("pprof-gzip-base64"));
-  }
 }

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/ProfilerAllocationSanityTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/ProfilerAllocationSanityTest.java
@@ -16,13 +16,11 @@
 
 package com.splunk.opentelemetry;
 
-import static com.splunk.opentelemetry.profiler.Configuration.DataFormat.PPROF_GZIP_BASE64;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.splunk.opentelemetry.helper.TestImage;
-import com.splunk.opentelemetry.profiler.Configuration;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.proto.trace.v1.Span;
@@ -36,17 +34,8 @@ import org.testcontainers.utility.MountableFile;
 abstract class ProfilerAllocationSanityTest extends SmokeTest {
 
   private GenericContainer<?> app;
-  private final Configuration.DataFormat dataFormat;
 
-  ProfilerAllocationSanityTest(Configuration.DataFormat dataFormat) {
-    this.dataFormat = dataFormat;
-  }
-
-  public static class TestPprof extends ProfilerAllocationSanityTest {
-    TestPprof() {
-      super(PPROF_GZIP_BASE64);
-    }
-  }
+  public static class TestPprof extends ProfilerAllocationSanityTest {}
 
   @AfterEach
   void stopApp() {
@@ -81,7 +70,6 @@ abstract class ProfilerAllocationSanityTest extends SmokeTest {
                 "OTEL_INSTRUMENTATION_METHODS_INCLUDE", "TlabSanityTestApp[instrumentedMethod]")
             .withEnv("SPLUNK_PROFILER_ENABLED", "true")
             .withEnv("SPLUNK_PROFILER_TLAB_ENABLED", "true")
-            .withEnv("SPLUNK_PROFILER_MEMORY_DATA_FORMAT", dataFormat.value())
             .withEnv("SPLUNK_PROFILER_CALL_STACK_INTERVAL", "1000")
             .withEnv("SPLUNK_PROFILER_LOGS_ENDPOINT", "http://collector:4317")
             .withEnv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4317")

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/ProfilerSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/ProfilerSmokeTest.java
@@ -18,7 +18,6 @@ package com.splunk.opentelemetry;
 
 import static com.splunk.opentelemetry.LogsInspector.getStringAttr;
 import static com.splunk.opentelemetry.LogsInspector.hasThreadName;
-import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.DATA_FORMAT;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.FRAME_COUNT;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SOURCE_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,7 +30,6 @@ import com.splunk.opentelemetry.helper.TargetWaitStrategy;
 import com.splunk.opentelemetry.helper.TestContainerManager;
 import com.splunk.opentelemetry.helper.TestImage;
 import com.splunk.opentelemetry.helper.windows.WindowsTestContainerManager;
-import com.splunk.opentelemetry.profiler.Configuration;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -66,30 +64,28 @@ public abstract class ProfilerSmokeTest {
   private TestContainerManager containerManager;
   private TelemetryRetriever telemetryRetriever;
   private final String jdkVersion;
-  private final String dataFormat;
 
-  ProfilerSmokeTest(String jdkVersion, String dataFormat) {
+  ProfilerSmokeTest(String jdkVersion) {
     this.jdkVersion = jdkVersion;
-    this.dataFormat = dataFormat;
   }
 
   public static class TestJdk8 extends ProfilerSmokeTest {
     TestJdk8() {
-      super("8", Configuration.DataFormat.PPROF_GZIP_BASE64.value());
+      super("8");
     }
   }
 
   @Ignore
   public static class TestJdk11 extends ProfilerSmokeTest {
     TestJdk11() {
-      super("11", Configuration.DataFormat.PPROF_GZIP_BASE64.value());
+      super("11");
     }
   }
 
   @Ignore
   public static class TestJdk17 extends ProfilerSmokeTest {
     TestJdk17() {
-      super("17", Configuration.DataFormat.PPROF_GZIP_BASE64.value());
+      super("17");
     }
   }
 
@@ -140,13 +136,10 @@ public abstract class ProfilerSmokeTest {
     LogsInspector logs = telemetryRetriever.waitForLogs();
 
     assertThat(logs.getLogStream())
-        .allMatch(log -> "otel.profiling".equals(getStringAttr(log, SOURCE_TYPE)))
-        .allMatch(log -> dataFormat.equals(getStringAttr(log, DATA_FORMAT)));
+        .allMatch(log -> "otel.profiling".equals(getStringAttr(log, SOURCE_TYPE)));
 
-    if (dataFormat.equals(Configuration.DataFormat.PPROF_GZIP_BASE64.value())) {
-      assertThat(logs.getLogStream())
-          .allMatch(log -> LogsInspector.getLongAttr(log, FRAME_COUNT) > 0);
-    }
+    assertThat(logs.getLogStream())
+        .allMatch(log -> LogsInspector.getLongAttr(log, FRAME_COUNT) > 0);
 
     assertThat(logs.getCpuSamples())
         .isNotEmpty()
@@ -282,8 +275,6 @@ public abstract class ProfilerSmokeTest {
                 "-Dotel.javaagent.debug=true",
                 "-Dsplunk.profiler.enabled=true",
                 "-Dsplunk.profiler.tlab.enabled=true",
-                "-Dsplunk.profiler.cpu.data.format=" + dataFormat,
-                "-Dsplunk.profiler.memory.data.format=" + dataFormat,
                 "-Dsplunk.profiler.directory=/app/jfr",
                 "-Dsplunk.profiler.keep-files=true",
                 "-Dsplunk.profiler.call.stack.interval=1001",

--- a/testing/jmh-benchmarks/src/jmh/java/com/splunk/opentelemetry/profiler/ThreadDumpProcessorBenchmark.java
+++ b/testing/jmh-benchmarks/src/jmh/java/com/splunk/opentelemetry/profiler/ThreadDumpProcessorBenchmark.java
@@ -62,7 +62,7 @@ public class ThreadDumpProcessorBenchmark {
   }
 
   private static ThreadDumpProcessor buildNewThreadDumpProcessor() {
-    SpanContextualizer contextualizer = new SpanContextualizer();
+    SpanContextualizer contextualizer = new SpanContextualizer(new EventReader());
     CpuEventExporter cpuEventExporter = x -> {};
     return ThreadDumpProcessor.builder()
         .cpuEventExporter(cpuEventExporter)
@@ -72,17 +72,18 @@ public class ThreadDumpProcessorBenchmark {
 
   private static com.splunk.opentelemetry.profiler.old.ThreadDumpProcessor
       buildOldThreadDumpProcessor() {
-    SpanContextualizer contextualizer = new SpanContextualizer();
+    SpanContextualizer contextualizer = new SpanContextualizer(new EventReader());
     Consumer<StackToSpanLinkage> processor = x -> {};
     Predicate<String> filter = new AgentInternalsFilter();
     return new com.splunk.opentelemetry.profiler.old.ThreadDumpProcessor(
         contextualizer, processor, filter);
   }
 
-  @Benchmark
-  public void newThreadDumpProcessor(RecordingFileState state) {
-    state.newThreadDumpProcessor.accept(state.nextEvent());
-  }
+  // TODO: Not sure what to do with this or if we want to continue maintaining it
+  //  @Benchmark
+  //  public void newThreadDumpProcessor(RecordingFileState state) {
+  //    state.newThreadDumpProcessor.accept(state.nextEvent());
+  //  }
 
   @Benchmark
   public void oldThreadDumpProcessor(RecordingFileState state) {


### PR DESCRIPTION
The enum only had one value remaining, so it makes sense to just remove it.

The profiling README also still had reference to the config items for choosing data format, so those are also now removed.