### PR TITLE
After release, push a version update PR to the helm chart repo.

### DIFF
--- a/scripts/install-gh-deps.sh
+++ b/scripts/install-gh-deps.sh
@@ -6,5 +6,5 @@ set -e
 curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
 
-apt-get update
-apt-get -y install zip gh
+apt update
+apt install -y zip gh

--- a/scripts/propagate-version.sh
+++ b/scripts/propagate-version.sh
@@ -66,7 +66,7 @@ create_collector_helm_chart_pr() {
   local repo_url="https://srv-gh-o11y-gdi:${GITHUB_TOKEN}@github.com/${repo}.git"
   local update_version_branch="java-version-update-$release_tag"
   local message="[java-version-update] Update agent version to $release_tag"
-  local java_repo = "ghcr.io/signalfx/splunk-otel-java/splunk-otel-java"
+  local java_repo="ghcr.io/signalfx/splunk-otel-java/splunk-otel-java"
 
   echo ">>> Cloning the $repo repository ..."
   git clone "$repo_url" collector-chart-mirror

--- a/scripts/propagate-version.sh
+++ b/scripts/propagate-version.sh
@@ -61,6 +61,42 @@ create_post_release_pr() {
     --head "$post_release_branch"
 }
 
+create_collector_helm_chart_pr() {
+  local repo="signalfx/splunk-otel-collector-chart"
+  local repo_url="https://srv-gh-o11y-gdi:${GITHUB_TOKEN}@github.com/${repo}.git"
+  local update_version_branch="java-version-update-$release_tag"
+  local message="[java-version-update] Update agent version to $release_tag"
+  local java_repo = "ghcr.io/signalfx/splunk-otel-java/splunk-otel-java"
+
+  echo ">>> Cloning the $repo repository ..."
+  git clone "$repo_url" collector-chart-mirror
+
+  cd collector-chart-mirror
+  git checkout -b "$update_version_branch"
+
+  # This relies on the tag being on the line after the java repo
+  echo ">>> Updating versions inline: values.yaml"
+  VLINE=$(grep -n -A 1 $java_repo helm-charts/splunk-otel-collector/values.yaml | tail -1 | sed -e "s/-.*//")
+  sed -i "${VLINE}s/\"v.*\"/\"${release_tag}\"/" helm-charts/splunk-otel-collector/values.yaml
+
+  # Update the examples as well
+  echo ">>> Updating versions inline: deployment.yaml"
+  sed -i "s#${java_repo}:v.*#${java_repo}:${release_tag}#" \
+    examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/deployment.yaml
+
+  git commit -S -am "[automated] $message"
+  git push "$repo_url" "$update_version_branch"
+
+  echo ">>> Creating a PR in splunk-otel-collector-chart..."
+  gh pr create \
+    --repo "$repo" \
+    --title "$message" \
+    --body "$message" \
+    --label automated \
+    --base main \
+    --head "$update_version_branch"
+}
+
 create_collector_pr() {
   local repo="signalfx/splunk-otel-collector"
   local repo_url="https://srv-gh-o11y-gdi:${GITHUB_TOKEN}@github.com/${repo}.git"
@@ -91,3 +127,4 @@ import_gpg_secret_key "$GITHUB_BOT_GPG_KEY"
 setup_git
 create_post_release_pr
 create_collector_pr
+create_collector_helm_chart_pr


### PR DESCRIPTION
In order for the helm charts to get updated, we need to push a PR after each release.

I really wanted to use `yq` to do yaml editing instead of `sed`, but sadly both flavors I found and tried have outstanding issues around keeping existing comments and formatting. I didn't want a one-line version change to result in thousands of lines touched or important comments removed.