### PR TITLE
Add labels to help dependabot

### DIFF
--- a/Dockerfile-ghcr
+++ b/Dockerfile-ghcr
@@ -6,6 +6,9 @@
 #    busybox image because it contains the Linux command cp which must be available.
 FROM busybox
 
+LABEL org.opencontainers.image.source="https://github.com/signalfx/splunk-otel-java"
+LABEL org.opencontainers.image.description="Splunk Distribution of OpenTelemetry Java Instrumentation"
+
 ARG RELEASE_VER
 ENV RELEASE_VER=$RELEASE_VER
 


### PR DESCRIPTION
According to the [dependabot docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#docker), we might be able to get dependabot to PR into the helm chart repo after we publish.

To help facilitate this, let's add these required tags. 