### PR TITLE
Re-add profiling.data.format

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/ProfilingSemanticAttributes.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/ProfilingSemanticAttributes.java
@@ -36,6 +36,8 @@ public class ProfilingSemanticAttributes {
   public static final AttributeKey<Long> SOURCE_EVENT_TIME = longKey("source.event.time");
 
   public static final AttributeKey<String> DATA_TYPE = stringKey("profiling.data.type");
+  public static final AttributeKey<String> DATA_FORMAT = stringKey("profiling.data.format");
+  public static final String PPROF_GZIP_BASE64 = "pprof-gzip-base64";
   public static final AttributeKey<Long> FRAME_COUNT = longKey("profiling.data.total.frame.count");
 
   public static final AttributeKey<Long> THREAD_ID = longKey("thread.id");

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporter.java
@@ -16,8 +16,10 @@
 
 package com.splunk.opentelemetry.profiler.exporter;
 
+import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.DATA_FORMAT;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.DATA_TYPE;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.FRAME_COUNT;
+import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.PPROF_GZIP_BASE64;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.PROFILING_SOURCE;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SOURCE_TYPE;
 import static java.util.logging.Level.FINE;
@@ -42,6 +44,7 @@ public class PprofLogDataExporter {
         Attributes.builder()
             .put(SOURCE_TYPE, PROFILING_SOURCE)
             .put(DATA_TYPE, dataType.value())
+            .put(DATA_FORMAT, PPROF_GZIP_BASE64)
             .build();
   }
 

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/ProfilerSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/ProfilerSmokeTest.java
@@ -18,7 +18,9 @@ package com.splunk.opentelemetry;
 
 import static com.splunk.opentelemetry.LogsInspector.getStringAttr;
 import static com.splunk.opentelemetry.LogsInspector.hasThreadName;
+import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.DATA_FORMAT;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.FRAME_COUNT;
+import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.PPROF_GZIP_BASE64;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SOURCE_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -136,7 +138,8 @@ public abstract class ProfilerSmokeTest {
     LogsInspector logs = telemetryRetriever.waitForLogs();
 
     assertThat(logs.getLogStream())
-        .allMatch(log -> "otel.profiling".equals(getStringAttr(log, SOURCE_TYPE)));
+        .allMatch(log -> "otel.profiling".equals(getStringAttr(log, SOURCE_TYPE)))
+        .allMatch(log -> PPROF_GZIP_BASE64.equals(getStringAttr(log, DATA_FORMAT)));
 
     assertThat(logs.getLogStream())
         .allMatch(log -> LogsInspector.getLongAttr(log, FRAME_COUNT) > 0);


### PR DESCRIPTION
GDI spec mandates the use of this attribute, so let's add it back in even though there is currently only one value.