### PR TITLE
update otel dep and fix profiler logs dep name

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   `java-platform`
 }
 
-val otelVersion = "1.26.0"
+val otelVersion = "1.27.0"
 val otelAlphaVersion = otelVersion.replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
 val otelInstrumentationVersion = "1.27.0-SNAPSHOT"
 val otelInstrumentationAlphaVersion =  otelInstrumentationVersion.replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")

--- a/profiler/build.gradle.kts
+++ b/profiler/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
   // required to access InstrumentationHolder
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-bootstrap")
   implementation("io.opentelemetry:opentelemetry-sdk-logs")
-  implementation("io.opentelemetry:opentelemetry-exporter-otlp-logs")
+  implementation("io.opentelemetry:opentelemetry-exporter-otlp")
   implementation("com.google.protobuf:protobuf-java:$protobufVersion")
   implementation("org.openjdk.jmc:flightrecorder:8.3.1")
 


### PR DESCRIPTION
Supersedes #1316 and fixes the problem with the profiler module using the old exporter dep name.