### PR TITLE
Test spanId in log correlation smoke test

### DIFF
--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/LogsInspector.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/LogsInspector.java
@@ -27,6 +27,7 @@ import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.TRAC
 import com.google.perftools.profiles.ProfileProto;
 import com.splunk.opentelemetry.profiler.ProfilingDataType;
 import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
 import io.opentelemetry.proto.common.v1.KeyValue;
@@ -112,6 +113,10 @@ public final class LogsInspector {
 
   public static Predicate<LogRecord> hasTraceId(String traceId) {
     return log -> traceId.equals(TraceId.fromBytes(log.getTraceId().toByteArray()));
+  }
+
+  public static Predicate<LogRecord> hasSpanId(String spanId) {
+    return log -> spanId.equals(SpanId.fromBytes(log.getSpanId().toByteArray()));
   }
 
   public static Predicate<LogRecord> hasStringBody(String body) {

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/OtlpLogsSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/OtlpLogsSmokeTest.java
@@ -23,13 +23,9 @@ import static com.splunk.opentelemetry.helper.TestImage.linuxImage;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.google.protobuf.ByteString;
-import io.opentelemetry.api.trace.SpanId;
-import io.opentelemetry.proto.trace.v1.Span;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -61,18 +57,11 @@ public class OtlpLogsSmokeTest extends SmokeTest {
     assertEquals(response.body().string(), "Hi!");
 
     TraceInspector traces = waitForTraces();
+
     Set<String> traceIds = traces.getTraceIds();
     assertThat(traceIds).hasSize(1);
 
-    Set<String> springSpanIds =
-        traces
-            .getSpanStream()
-            .filter(it -> it.getName().equals("WebController.greeting"))
-            .map(Span::getSpanId)
-            .map(ByteString::toByteArray)
-            .map(SpanId::fromBytes)
-            .collect(Collectors.toSet());
-
+    Set<String> springSpanIds = traces.getSpanIdsByName("WebController.greeting");
     assertThat(springSpanIds).hasSize(1);
 
     String traceId = traceIds.iterator().next();

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/TraceInspector.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/TraceInspector.java
@@ -17,6 +17,7 @@
 package com.splunk.opentelemetry;
 
 import com.google.protobuf.ByteString;
+import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
@@ -89,6 +90,15 @@ public class TraceInspector {
         .map(Span::getTraceId)
         .map(ByteString::toByteArray)
         .map(TraceId::fromBytes)
+        .collect(Collectors.toSet());
+  }
+
+  public Set<String> getSpanIdsByName(String spanName) {
+    return getSpanStream()
+        .filter(it -> it.getName().equals(spanName))
+        .map(Span::getSpanId)
+        .map(ByteString::toByteArray)
+        .map(SpanId::fromBytes)
         .collect(Collectors.toSet());
   }
 


### PR DESCRIPTION
Since we are already testing that `traceId` gets attached to autoinstrumented log entries, check for `spanId` as well.