### PR TITLE
Test for log correlation from HEC exporter as well

### DIFF
--- a/smoke-tests/build.gradle.kts
+++ b/smoke-tests/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
   testImplementation("ch.qos.logback:logback-classic:1.4.11")
   testImplementation("com.github.docker-java:docker-java-core")
   testImplementation("com.github.docker-java:docker-java-transport-httpclient5")
+  testImplementation("org.mock-server:mockserver-client-java:5.15.0")
 }
 
 tasks {

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/HecTelemetryInspector.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/HecTelemetryInspector.java
@@ -21,7 +21,7 @@ import java.util.function.Predicate;
 
 class HecTelemetryInspector {
   private static final String EVENT_KEY = "event";
-  private static final String FIELDS_KEY = "event";
+  private static final String FIELDS_KEY = "fields";
 
   static Predicate<JsonNode> hasEventName(String eventName) {
     return it -> {

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/HecTelemetryInspector.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/HecTelemetryInspector.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.function.Predicate;
+
+class HecTelemetryInspector {
+  private static final String EVENT_KEY = "event";
+  private static final String FIELDS_KEY = "event";
+
+  static Predicate<JsonNode> hasEventName(String eventName) {
+    return it -> {
+      JsonNode node = it.findValue(EVENT_KEY);
+      return node != null && node.isTextual() && eventName.equals(node.textValue());
+    };
+  }
+
+  static Predicate<JsonNode> hasTextFieldValue(String fieldName, String fieldValue) {
+    return it -> {
+      JsonNode node = it.findPath(FIELDS_KEY).findPath(fieldName);
+      return !node.isMissingNode() && node.isTextual() && fieldValue.equals(node.textValue());
+    };
+  }
+}

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/HecTelemetryRetriever.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/HecTelemetryRetriever.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.model.ClearType;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+
+class HecTelemetryRetriever {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final JsonFactory JSON_FACTORY = new JsonFactory(OBJECT_MAPPER);
+  private static final String HEC_PATH = "/services/collector/event";
+
+  private final MockServerClient client;
+
+  HecTelemetryRetriever(int backendPort) {
+    this.client = new MockServerClient("localhost", backendPort);
+  }
+
+  void initializeEndpoints() {
+    client
+        .when(HttpRequest.request(HEC_PATH))
+        .respond(HttpResponse.response("").withStatusCode(200));
+  }
+
+  void clearTelemetry() {
+    client.clear(HttpRequest.request(), ClearType.LOG);
+  }
+
+  List<JsonNode> waitForEntries() throws IOException, InterruptedException {
+    int previousSize = 0;
+    long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
+    HttpRequest[] requests = new HttpRequest[0];
+
+    while (System.currentTimeMillis() < deadline) {
+      requests = client.retrieveRecordedRequests(HttpRequest.request(HEC_PATH));
+
+      if (requests.length > 0 && requests.length == previousSize) {
+        break;
+      }
+      previousSize = requests.length;
+      System.out.printf("Current HEC entry count %d%n", previousSize);
+      TimeUnit.MILLISECONDS.sleep(500);
+    }
+
+    return extractJsonEntries(requests);
+  }
+
+  private List<JsonNode> extractJsonEntries(HttpRequest[] requests) throws IOException {
+    List<JsonNode> entryNodes = new ArrayList<>();
+
+    for (HttpRequest request : requests) {
+      // HEC format just concatenates multiple JSON bodies after one another without using a JSON
+      // array, that's why we
+      // use readValuesAs. Also use getBodyAsRawBytes instead of getBodyAsString - MockServerClient
+      // parses the content
+      // and reformats if content type is JSON, keeping only the JSON body.
+      try (JsonParser parser = JSON_FACTORY.createParser(request.getBodyAsRawBytes())) {
+        Iterator<JsonNode> entries = parser.readValuesAs(JsonNode.class);
+
+        while (entries.hasNext()) {
+          entryNodes.add(entries.next());
+        }
+      }
+    }
+
+    return entryNodes;
+  }
+}

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/HecTelemetryRetriever.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/HecTelemetryRetriever.java
@@ -75,10 +75,9 @@ class HecTelemetryRetriever {
 
     for (HttpRequest request : requests) {
       // HEC format just concatenates multiple JSON bodies after one another without using a JSON
-      // array, that's why we
-      // use readValuesAs. Also use getBodyAsRawBytes instead of getBodyAsString - MockServerClient
-      // parses the content
-      // and reformats if content type is JSON, keeping only the JSON body.
+      // array, that's why we use readValuesAs. Also use getBodyAsRawBytes instead of
+      // getBodyAsString - MockServerClient parses the content and reformats if content type is
+      // JSON, keeping only the JSON body.
       try (JsonParser parser = JSON_FACTORY.createParser(request.getBodyAsRawBytes())) {
         Iterator<JsonNode> entries = parser.readValuesAs(JsonNode.class);
 

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/OtlpLogsSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/OtlpLogsSmokeTest.java
@@ -25,9 +25,7 @@ import static com.splunk.opentelemetry.helper.TestImage.linuxImage;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import okhttp3.Request;
@@ -78,9 +76,7 @@ public class OtlpLogsSmokeTest extends SmokeTest {
             hasTraceId(traceId).and(hasSpanId(spanId)).and(hasStringBody("HTTP request received")));
 
     if (isHecEnabled()) {
-      List<JsonNode> hecEntries = waitForHecEntries();
-
-      assertThat(hecEntries)
+      assertThat(waitForHecEntries())
           .anyMatch(
               hasEventName("HTTP request received")
                   .and(hasTextFieldValue("span_id", spanId))

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/SmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/SmokeTest.java
@@ -146,6 +146,7 @@ public abstract class SmokeTest {
 
     if (hecTelemetryRetriever != null) {
       hecTelemetryRetriever.clearTelemetry();
+      hecTelemetryRetriever = null;
     }
   }
 
@@ -166,11 +167,11 @@ public abstract class SmokeTest {
   }
 
   protected List<JsonNode> waitForHecEntries() throws IOException, InterruptedException {
-    if (hecTelemetryRetriever != null) {
-      return hecTelemetryRetriever.waitForEntries();
-    } else {
+    if (hecTelemetryRetriever == null) {
       return Collections.emptyList();
     }
+
+    return hecTelemetryRetriever.waitForEntries();
   }
 
   protected boolean isHecEnabled() {

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/AbstractTestContainerManager.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/AbstractTestContainerManager.java
@@ -21,9 +21,11 @@ import java.util.Map;
 
 public abstract class AbstractTestContainerManager implements TestContainerManager {
   protected static final int BACKEND_PORT = 8080;
+  protected static final int HEC_BACKEND_PORT = 1080;
   protected static final int COLLECTOR_PORT = 4317;
 
   protected static final String BACKEND_ALIAS = "backend";
+  protected static final String HEC_BACKEND_ALIAS = "hec-backend";
   protected static final String COLLECTOR_ALIAS = "collector";
   protected static final String COLLECTOR_CONFIG_RESOURCE = "/otel.yaml";
 

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/TestContainerManager.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/TestContainerManager.java
@@ -35,6 +35,8 @@ public interface TestContainerManager {
 
   int getBackendMappedPort();
 
+  int getHecBackendMappedPort();
+
   int getTargetMappedPort(int originalPort);
 
   void startTarget(TargetContainerBuilder builder);

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/windows/WindowsTestContainerManager.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/windows/WindowsTestContainerManager.java
@@ -200,6 +200,11 @@ public class WindowsTestContainerManager extends AbstractTestContainerManager {
   }
 
   @Override
+  public int getHecBackendMappedPort() {
+    return 0;
+  }
+
+  @Override
   public int getTargetMappedPort(int originalPort) {
     return extractMappedPort(target, originalPort);
   }

--- a/smoke-tests/src/test/resources/otel.yaml
+++ b/smoke-tests/src/test/resources/otel.yaml
@@ -27,6 +27,14 @@ exporters:
     endpoint: backend:8080
     tls:
       insecure: true
+  splunk_hec:
+    token: "00000000-0000-0000-0000-000000000000"
+    endpoint: http://hec-backend:1080/services/collector/event
+    sourcetype: "test"
+    max_connections: 20
+    timeout: 10s
+    tls:
+      insecure_skip_verify: true
 
 service:
   pipelines:
@@ -41,6 +49,6 @@ service:
     logs:
       receivers: [ otlp ]
       processors: [ batch ]
-      exporters: [ logging/logging_info, otlp ]
+      exporters: [ logging/logging_info, otlp, splunk_hec ]
 
   extensions: [ health_check, pprof, zpages ]


### PR DESCRIPTION
Added HEC exporter configuration and a MockServer fake backend as part of the normal smoke test setup - although only logs are exported there at the moment. This enables reusing the same container setup and even the same test for checking HEC exporter output.

Could not find a MockServer image for Windows at the moment, so the HEC part of the test is disabled on Windows for now.