### PR TITLE
Truncate process.command_args

### DIFF
--- a/custom/src/main/java/com/splunk/opentelemetry/TruncateCommandLineWhenMetricsEnabled.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/TruncateCommandLineWhenMetricsEnabled.java
@@ -95,7 +95,7 @@ public class TruncateCommandLineWhenMetricsEnabled implements AutoConfigurationC
       // double quotes, elements are separated with a comma
       int maxLength = MAX_LENGTH - 4;
       List<String> result = new ArrayList<>();
-      int size = 0;
+      int totalLength = 0;
       for (Iterator<String> i = list.iterator(); i.hasNext(); ) {
         String s = i.next();
         int length = s.length();
@@ -103,12 +103,12 @@ public class TruncateCommandLineWhenMetricsEnabled implements AutoConfigurationC
           // we assume that list elements are joined with ","
           length += 3;
         }
-        if (size + length <= maxLength) {
+        if (totalLength + length <= maxLength) {
           result.add(s);
         } else {
           // if there is room for less than 3 chars we'll need to truncate the previous element
-          if (maxLength - size >= 3) {
-            s = s.substring(0, Math.min(s.length(), maxLength - size - 3)) + "...";
+          if (maxLength - totalLength >= 3) {
+            s = s.substring(0, Math.min(s.length(), maxLength - totalLength - 3)) + "...";
           } else {
             s = result.remove(result.size() - 1);
             // we just truncate the last 3 chars, this can make the end result slightly shorter
@@ -118,7 +118,7 @@ public class TruncateCommandLineWhenMetricsEnabled implements AutoConfigurationC
           result.add(s);
           return result;
         }
-        size += length;
+        totalLength += length;
       }
 
       return null;

--- a/custom/src/main/java/com/splunk/opentelemetry/TruncateCommandLineWhenMetricsEnabled.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/TruncateCommandLineWhenMetricsEnabled.java
@@ -91,8 +91,9 @@ public class TruncateCommandLineWhenMetricsEnabled implements AutoConfigurationC
     }
 
     private static List<String> truncate(List<String> list) {
-      // when List is translated to String it is surrounded in [], each element is surrounded in
-      // double quotes, elements are separated with a comma
+      // Ensure that String representation of the List does not exceed max allowed length. List is
+      // translated to String as a JSON array (it is surrounded in [], each element is surrounded in
+      // double quotes, elements are separated with a comma).
       int maxLength = MAX_LENGTH - 4;
       List<String> result = new ArrayList<>();
       int totalLength = 0;


### PR DESCRIPTION
Similarly to `process.command_line` we need to limit the size of `process.command_args`