### PR TITLE
Verify class compatibility before attempting cast

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
           java-version: 17
 
       - name: Cache Gradle Wrapper
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v3.3.2
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
@@ -66,7 +66,7 @@ jobs:
           java-version: 17
 
       - name: Cache Gradle Wrapper
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v3.3.2
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
@@ -91,7 +91,7 @@ jobs:
           java-version: 17
 
       - name: Cache Gradle Wrapper
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v3.3.2
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
@@ -129,7 +129,7 @@ jobs:
           java-version: 17
 
       - name: Cache Gradle Wrapper
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v3.3.2
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -18,7 +18,7 @@ jobs:
           java-version: 17
 
       - name: Cache Gradle Wrapper
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v3.3.2
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
@@ -41,7 +41,7 @@ jobs:
           java-version: 17
 
       - name: Cache Gradle Wrapper
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v3.3.2
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
@@ -66,7 +66,7 @@ jobs:
           java-version: 17
 
       - name: Cache Gradle Wrapper
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v3.3.2
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
@@ -104,7 +104,7 @@ jobs:
           java-version: 17
 
       - name: Cache Gradle Wrapper
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v3.3.2
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -40,7 +40,7 @@ jobs:
           java-version: 17
 
       - name: Cache Gradle Wrapper
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v3.3.2
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
@@ -63,7 +63,7 @@ jobs:
           java-version: 17
 
       - name: Cache Gradle Wrapper
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v3.3.2
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
@@ -88,7 +88,7 @@ jobs:
           java-version: 17
 
       - name: Cache Gradle Wrapper
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v3.3.2
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
@@ -127,7 +127,7 @@ jobs:
           java-version: 17
 
       - name: Cache Gradle Wrapper
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v3.3.2
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
@@ -172,7 +172,7 @@ jobs:
           java-version: 17
 
       - name: Cache Gradle Wrapper
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v3.3.2
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}

--- a/.github/workflows/publish-docker-image-ghcr.yml
+++ b/.github/workflows/publish-docker-image-ghcr.yml
@@ -42,7 +42,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: build and publish container
-        uses: docker/build-push-action@v4.1.1
+        uses: docker/build-push-action@v4.2.1
         with:
           push: true
           file: Dockerfile-ghcr

--- a/.github/workflows/publish-profiling-petclinic-base.yml
+++ b/.github/workflows/publish-profiling-petclinic-base.yml
@@ -21,7 +21,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: push to gh packages
-        uses: docker/build-push-action@v4.1.1
+        uses: docker/build-push-action@v4.2.1
         with:
           push: true
           file: smoke-tests/profiling-base-petclinic/linux/Dockerfile

--- a/custom/src/main/java/com/splunk/opentelemetry/TruncateCommandLineWhenMetricsEnabled.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/TruncateCommandLineWhenMetricsEnabled.java
@@ -27,6 +27,9 @@ import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvide
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 import java.util.function.BiFunction;
 import java.util.logging.Logger;
 
@@ -49,6 +52,8 @@ public class TruncateCommandLineWhenMetricsEnabled implements AutoConfigurationC
 
   @VisibleForTesting
   static class CommandLineTruncator implements BiFunction<Resource, ConfigProperties, Resource> {
+    private static final int MAX_LENGTH = 255;
+
     @Override
     public Resource apply(Resource existing, ConfigProperties config) {
       boolean metricsEnabled = config.getBoolean(METRICS_ENABLED_PROPERTY, false);
@@ -57,15 +62,67 @@ public class TruncateCommandLineWhenMetricsEnabled implements AutoConfigurationC
         return existing;
       }
 
-      String commandLine = existing.getAttribute(ResourceAttributes.PROCESS_COMMAND_LINE);
-      if (commandLine == null || commandLine.length() < 256) {
-        return existing;
+      Resource resource = existing;
+      if (resource.getAttribute(ResourceAttributes.PROCESS_COMMAND_ARGS) != null) {
+        List<String> newCommandArgs =
+            truncate(resource.getAttribute(ResourceAttributes.PROCESS_COMMAND_ARGS));
+        if (newCommandArgs != null) {
+          resource =
+              resource.merge(
+                  Resource.create(
+                      Attributes.of(ResourceAttributes.PROCESS_COMMAND_ARGS, newCommandArgs)));
+        }
       }
 
-      logger.warning("Metrics are enabled. Truncating process.command_line resource attribute.");
-      String newCommandLine = commandLine.substring(0, 250) + "[...]";
-      return existing.merge(
-          Resource.create(Attributes.of(ResourceAttributes.PROCESS_COMMAND_LINE, newCommandLine)));
+      String commandLine = resource.getAttribute(ResourceAttributes.PROCESS_COMMAND_LINE);
+      if (commandLine != null && commandLine.length() > MAX_LENGTH) {
+        String newCommandLine = commandLine.substring(0, MAX_LENGTH - 3) + "...";
+        resource =
+            resource.merge(
+                Resource.create(
+                    Attributes.of(ResourceAttributes.PROCESS_COMMAND_LINE, newCommandLine)));
+      }
+
+      if (existing != resource) {
+        logger.warning(
+            "Metrics are enabled. Truncating process.command_line and process.command_args resource attributes.");
+      }
+      return resource;
+    }
+
+    private static List<String> truncate(List<String> list) {
+      // Ensure that String representation of the List does not exceed max allowed length. List is
+      // translated to String as a JSON array (it is surrounded in [], each element is surrounded in
+      // double quotes, elements are separated with a comma).
+      int maxLength = MAX_LENGTH - 4;
+      List<String> result = new ArrayList<>();
+      int totalLength = 0;
+      for (Iterator<String> i = list.iterator(); i.hasNext(); ) {
+        String s = i.next();
+        int length = s.length();
+        if (i.hasNext()) {
+          // we assume that list elements are joined with ","
+          length += 3;
+        }
+        if (totalLength + length <= maxLength) {
+          result.add(s);
+        } else {
+          // if there is room for less than 3 chars we'll need to truncate the previous element
+          if (maxLength - totalLength >= 3) {
+            s = s.substring(0, Math.min(s.length(), maxLength - totalLength - 3)) + "...";
+          } else {
+            s = result.remove(result.size() - 1);
+            // we just truncate the last 3 chars, this can make the end result slightly shorter
+            // than the max length
+            s = s.substring(0, Math.max(0, s.length() - 3)) + "...";
+          }
+          result.add(s);
+          return result;
+        }
+        totalLength += length;
+      }
+
+      return null;
     }
   }
 }

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -13,7 +13,7 @@ val dockerJavaVersion = "3.3.3"
 val micrometerOldVersion = "1.3.20"
 val micrometerVersion = "1.11.3"
 val mockitoVersion = "5.5.0"
-val protobufVersion = "3.24.2"
+val protobufVersion = "3.24.3"
 val slf4jVersion = "2.0.9"
 
 // instrumentation version is used to compute Implementation-Version manifest attribute

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
   api(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.15.2"))
   api(enforcedPlatform("com.google.protobuf:protobuf-bom:$protobufVersion"))
   api(enforcedPlatform("com.squareup.okhttp3:okhttp-bom:4.11.0"))
-  api(enforcedPlatform("io.grpc:grpc-bom:1.57.2"))
+  api(enforcedPlatform("io.grpc:grpc-bom:1.58.0"))
   api(platform("io.micrometer:micrometer-bom:$micrometerVersion"))
   api(enforcedPlatform("io.opentelemetry:opentelemetry-bom-alpha:$otelAlphaVersion"))
   api(enforcedPlatform("io.opentelemetry:opentelemetry-bom:$otelVersion"))

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/AllocatedMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/AllocatedMemoryMetrics.java
@@ -54,7 +54,7 @@ public class AllocatedMemoryMetrics {
 
   private static boolean mxBeanTypeIsCompatible() {
     try {
-      Class<?> mxBeanClass = Class.forName("com.sun.management.ThreadMXBean");
+      Class<?> mxBeanClass = Class.forName("com.sun.management.ThreadMXBean", false, AllocatedMemoryMetrics.class.getClassLoader());
       return mxBeanClass.isInstance(ManagementFactory.getThreadMXBean());
     } catch (Exception e) {
       return false;

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/AllocatedMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/AllocatedMemoryMetrics.java
@@ -54,7 +54,11 @@ public class AllocatedMemoryMetrics {
 
   private static boolean mxBeanTypeIsCompatible() {
     try {
-      Class<?> mxBeanClass = Class.forName("com.sun.management.ThreadMXBean", false, AllocatedMemoryMetrics.class.getClassLoader());
+      Class<?> mxBeanClass =
+          Class.forName(
+              "com.sun.management.ThreadMXBean",
+              false,
+              AllocatedMemoryMetrics.class.getClassLoader());
       return mxBeanClass.isInstance(ManagementFactory.getThreadMXBean());
     } catch (Exception e) {
       return false;

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/GcMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/GcMemoryMetrics.java
@@ -47,8 +47,8 @@ public class GcMemoryMetrics implements AutoCloseable {
     return deltaSum.get();
   }
 
-  public boolean isAvailable() {
-    return managementExtensionsPresent;
+  public boolean isUnavailable() {
+    return !managementExtensionsPresent;
   }
 
   public void registerListener() {

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/micrometer/MicrometerAllocatedMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/micrometer/MicrometerAllocatedMemoryMetrics.java
@@ -19,6 +19,7 @@ package com.splunk.opentelemetry.instrumentation.jvmmetrics.micrometer;
 import static com.splunk.opentelemetry.instrumentation.jvmmetrics.AllocatedMemoryMetrics.METRIC_NAME;
 
 import com.splunk.opentelemetry.instrumentation.jvmmetrics.AllocatedMemoryMetrics;
+import io.micrometer.common.lang.NonNull;
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.BaseUnits;
@@ -27,9 +28,9 @@ import io.micrometer.core.instrument.binder.MeterBinder;
 public class MicrometerAllocatedMemoryMetrics implements MeterBinder {
 
   @Override
-  public void bindTo(MeterRegistry registry) {
+  public void bindTo(@NonNull MeterRegistry registry) {
     AllocatedMemoryMetrics allocatedMemoryMetrics = new AllocatedMemoryMetrics();
-    if (!allocatedMemoryMetrics.isAvailable()) {
+    if (allocatedMemoryMetrics.isUnavailable()) {
       return;
     }
 

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/micrometer/MicrometerGcMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/micrometer/MicrometerGcMemoryMetrics.java
@@ -29,7 +29,7 @@ public class MicrometerGcMemoryMetrics implements MeterBinder, AutoCloseable {
 
   @Override
   public void bindTo(MeterRegistry registry) {
-    if (!gcMemoryMetrics.isAvailable()) {
+    if (gcMemoryMetrics.isUnavailable()) {
       return;
     }
 

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/otel/OtelAllocatedMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/otel/OtelAllocatedMemoryMetrics.java
@@ -29,7 +29,7 @@ public class OtelAllocatedMemoryMetrics {
 
   public void install() {
     AllocatedMemoryMetrics allocatedMemoryMetrics = new AllocatedMemoryMetrics();
-    if (!allocatedMemoryMetrics.isAvailable()) {
+    if (allocatedMemoryMetrics.isUnavailable()) {
       return;
     }
 

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/otel/OtelGcMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/otel/OtelGcMemoryMetrics.java
@@ -25,7 +25,7 @@ public class OtelGcMemoryMetrics {
 
   public void install() {
     GcMemoryMetrics gcMemoryMetrics = new GcMemoryMetrics();
-    if (!gcMemoryMetrics.isAvailable()) {
+    if (gcMemoryMetrics.isUnavailable()) {
       return;
     }
 

--- a/licenses/licenses.md
+++ b/licenses/licenses.md
@@ -1,7 +1,7 @@
 
 # splunk-otel-javaagent
 ## Dependency License Report
-_2023-09-05 08:53:31 EEST_
+_2023-09-08 22:02:49 EEST_
 ## Apache License, Version 2.0
 
 **1** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-core` **Version:** `2.15.2` 
@@ -253,7 +253,7 @@ _2023-09-05 08:53:31 EEST_
 
 ## The 3-Clause BSD License
 
-**50** **Group:** `com.google.protobuf` **Name:** `protobuf-java` **Version:** `3.24.2` 
+**50** **Group:** `com.google.protobuf` **Name:** `protobuf-java` **Version:** `3.24.3` 
 > - **Manifest Project URL**: [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
 > - **Manifest License**: The 3-Clause BSD License (Not Packaged)
 > - **POM License**: The 3-Clause BSD License - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)


### PR DESCRIPTION
There was a case in the field on an IBM J9 JVM, where an instance returned from `ManagementFactory.getThreadMXBean()` could not be cast safely to the `com.sun.management.ThreadMXBean`, even thought that class can be found on the classpath.

It looks like [other implementations](https://github.com/elastic/apm-agent-java/issues/505) have also encountered this, and so this fix is inspired by those [other workarounds](https://github.com/felixbarny/apm-agent-java/commit/bb7f7712ca7c4126aeb3d22709777ba7684ab14a).