### PR TITLE
Verify class compatibility before attempting cast

### DIFF
--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/AllocatedMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/AllocatedMemoryMetrics.java
@@ -54,7 +54,7 @@ public class AllocatedMemoryMetrics {
 
   private static boolean mxBeanTypeIsCompatible() {
     try {
-      Class<?> mxBeanClass = Class.forName("com.sun.management.ThreadMXBean");
+      Class<?> mxBeanClass = Class.forName("com.sun.management.ThreadMXBean", false, AllocatedMemoryMetrics.class.getClassLoader());
       return mxBeanClass.isInstance(ManagementFactory.getThreadMXBean());
     } catch (Exception e) {
       return false;

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/AllocatedMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/AllocatedMemoryMetrics.java
@@ -54,7 +54,11 @@ public class AllocatedMemoryMetrics {
 
   private static boolean mxBeanTypeIsCompatible() {
     try {
-      Class<?> mxBeanClass = Class.forName("com.sun.management.ThreadMXBean", false, AllocatedMemoryMetrics.class.getClassLoader());
+      Class<?> mxBeanClass =
+          Class.forName(
+              "com.sun.management.ThreadMXBean",
+              false,
+              AllocatedMemoryMetrics.class.getClassLoader());
       return mxBeanClass.isInstance(ManagementFactory.getThreadMXBean());
     } catch (Exception e) {
       return false;

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/GcMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/GcMemoryMetrics.java
@@ -47,8 +47,8 @@ public class GcMemoryMetrics implements AutoCloseable {
     return deltaSum.get();
   }
 
-  public boolean isAvailable() {
-    return managementExtensionsPresent;
+  public boolean isUnavailable() {
+    return !managementExtensionsPresent;
   }
 
   public void registerListener() {

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/micrometer/MicrometerAllocatedMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/micrometer/MicrometerAllocatedMemoryMetrics.java
@@ -19,6 +19,7 @@ package com.splunk.opentelemetry.instrumentation.jvmmetrics.micrometer;
 import static com.splunk.opentelemetry.instrumentation.jvmmetrics.AllocatedMemoryMetrics.METRIC_NAME;
 
 import com.splunk.opentelemetry.instrumentation.jvmmetrics.AllocatedMemoryMetrics;
+import io.micrometer.common.lang.NonNull;
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.BaseUnits;
@@ -27,9 +28,9 @@ import io.micrometer.core.instrument.binder.MeterBinder;
 public class MicrometerAllocatedMemoryMetrics implements MeterBinder {
 
   @Override
-  public void bindTo(MeterRegistry registry) {
+  public void bindTo(@NonNull MeterRegistry registry) {
     AllocatedMemoryMetrics allocatedMemoryMetrics = new AllocatedMemoryMetrics();
-    if (!allocatedMemoryMetrics.isAvailable()) {
+    if (allocatedMemoryMetrics.isUnavailable()) {
       return;
     }
 

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/micrometer/MicrometerGcMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/micrometer/MicrometerGcMemoryMetrics.java
@@ -29,7 +29,7 @@ public class MicrometerGcMemoryMetrics implements MeterBinder, AutoCloseable {
 
   @Override
   public void bindTo(MeterRegistry registry) {
-    if (!gcMemoryMetrics.isAvailable()) {
+    if (gcMemoryMetrics.isUnavailable()) {
       return;
     }
 

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/otel/OtelAllocatedMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/otel/OtelAllocatedMemoryMetrics.java
@@ -29,7 +29,7 @@ public class OtelAllocatedMemoryMetrics {
 
   public void install() {
     AllocatedMemoryMetrics allocatedMemoryMetrics = new AllocatedMemoryMetrics();
-    if (!allocatedMemoryMetrics.isAvailable()) {
+    if (allocatedMemoryMetrics.isUnavailable()) {
       return;
     }
 

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/otel/OtelGcMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/otel/OtelGcMemoryMetrics.java
@@ -25,7 +25,7 @@ public class OtelGcMemoryMetrics {
 
   public void install() {
     GcMemoryMetrics gcMemoryMetrics = new GcMemoryMetrics();
-    if (!gcMemoryMetrics.isAvailable()) {
+    if (gcMemoryMetrics.isUnavailable()) {
       return;
     }
 


### PR DESCRIPTION
Rework #1427 due to goofy merge shenanigans.

There was a case in the field on an IBM J9 JVM, where an instance returned from `ManagementFactory.getThreadMXBean()` could not be cast safely to the `com.sun.management.ThreadMXBean`, even thought that class can be found on the classpath.

It looks like [other implementations](https://github.com/elastic/apm-agent-java/issues/505) have also encountered this, and so this fix is inspired by those [other workarounds](https://github.com/felixbarny/apm-agent-java/commit/bb7f7712ca7c4126aeb3d22709777ba7684ab14a).