### PR TITLE
Remove dependency on signalfx-metrics

### DIFF
--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -22,10 +22,6 @@ dependencies {
     // we replace signalfx-java with signalfx-metrics
     exclude("com.signalfx.public", "signalfx-java")
   }
-  implementation("com.signalfx.public:signalfx-metrics") {
-    // we use jcl-over-slf4j
-    exclude("commons-logging", "commons-logging")
-  }
   implementation("org.slf4j:jcl-over-slf4j")
 
   testImplementation("io.opentelemetry:opentelemetry-sdk")

--- a/custom/src/test/java/com/splunk/opentelemetry/TruncateCommandLineWhenMetricsEnabledTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/TruncateCommandLineWhenMetricsEnabledTest.java
@@ -33,7 +33,6 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Arrays;
 import java.util.function.BiFunction;
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -109,7 +108,7 @@ class TruncateCommandLineWhenMetricsEnabledTest {
     assertThat(resultCmd.length()).isEqualTo(255);
     assertThat(resultCmd.endsWith("...")).isTrue();
     var cmdArgs = result.getAttribute(PROCESS_COMMAND_ARGS);
-    String joinedArgs = StringUtils.joinWith(", ", cmdArgs.toArray());
+    String joinedArgs = String.join(", ", cmdArgs);
     assertThat(joinedArgs.length()).isLessThan(255);
     assertThat(joinedArgs.endsWith("...")).isTrue();
     assertThat(result.getAttribute(stringKey("foo"))).isEqualTo("barfly");
@@ -137,7 +136,7 @@ class TruncateCommandLineWhenMetricsEnabledTest {
     assertThat(resultCmd.length()).isEqualTo(255);
     assertThat(resultCmd.endsWith("...")).isTrue();
     var cmdArgs = result.getAttribute(PROCESS_COMMAND_ARGS);
-    String joinedArgs = StringUtils.joinWith(", ", cmdArgs.toArray());
+    String joinedArgs = String.join(", ", cmdArgs);
     assertThat(joinedArgs.length()).isLessThan(255);
     assertThat(joinedArgs.endsWith("...")).isTrue();
     assertThat(result.getAttribute(stringKey("foo"))).isEqualTo("barfly");


### PR DESCRIPTION
I didn't actually see any usages, so maybe this was a carryover from when `signalfx-java` was a monolith? Were we shading this or something? In any case, there seemed to be just the one transitive test dependency on StringUtils.