### PR TITLE
fix: Check mxBean compatibility

### DIFF
--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/AllocatedMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/AllocatedMemoryMetrics.java
@@ -36,7 +36,7 @@ public class AllocatedMemoryMetrics {
   }
 
   private AllocationTracker createAllocationTracker() {
-    if (hasComSunThreadMXBean() && isThreadAllocatedMemoryEnabled() && mxBeanTypeIsCompatible()) {
+    if (hasComSunThreadMXBean() && mxBeanTypeIsCompatible() && isThreadAllocatedMemoryEnabled()) {
       return new AllocationTracker();
     }
     return null;


### PR DESCRIPTION
Check for mxBean compatibility ahead of checking whether Allocated Memory is enabled. This is related to #1435 .