### PR TITLE
Disable memory profiling for some versions of java 17 

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
@@ -67,6 +67,7 @@ public class Configuration implements AutoConfigurationCustomizerProvider {
       "splunk.profiler.include.internal.stacks";
   public static final String CONFIG_KEY_TRACING_STACKS_ONLY = "splunk.profiler.tracing.stacks.only";
   private static final String CONFIG_KEY_STACK_DEPTH = "splunk.profiler.max.stack.depth";
+  private static final String RISKY_JFR_OPT_IN = "risky.jfr.optin";
 
   @Override
   public void customize(AutoConfigurationCustomizer autoConfiguration) {
@@ -143,6 +144,10 @@ public class Configuration implements AutoConfigurationCustomizerProvider {
 
   public static int getStackDepth(ConfigProperties config) {
     return config.getInt(CONFIG_KEY_STACK_DEPTH, DEFAULT_STACK_DEPTH);
+  }
+
+  public static boolean getRiskyJfrOptIn(ConfigProperties config) {
+    return config.getBoolean(RISKY_JFR_OPT_IN, false);
   }
 
   private static int getJavaVersion() {

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrSettingsOverridesTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrSettingsOverridesTest.java
@@ -18,7 +18,9 @@ package com.splunk.opentelemetry.profiler;
 
 import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_CALL_STACK_INTERVAL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -47,5 +49,22 @@ class JfrSettingsOverridesTest {
     assertEquals("163 ms", result.get("jdk.ThreadDump#period"));
     assertEquals("true", result.get("jdk.ObjectAllocationInNewTLAB#enabled"));
     assertEquals("true", result.get("jdk.ObjectAllocationOutsideTLAB#enabled"));
+  }
+
+  @Test
+  void avoidanceSoup(){
+      assertFalse(JfrSettingsOverrides.isVulnerableToJdk8309862("8.0.382"));
+      assertFalse(JfrSettingsOverrides.isVulnerableToJdk8309862("11.0.1"));
+      assertTrue(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.1"));
+      assertTrue(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.2"));
+      assertTrue(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.3"));
+      assertTrue(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.4"));
+      assertTrue(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.5"));
+      assertTrue(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.6"));
+      assertTrue(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.7"));
+      assertTrue(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.8"));
+      assertFalse(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.9"));
+      assertFalse(JfrSettingsOverrides.isVulnerableToJdk8309862("21.0.0"));
+      assertFalse(JfrSettingsOverrides.isVulnerableToJdk8309862("21.0.1"));
   }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrSettingsOverridesTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/JfrSettingsOverridesTest.java
@@ -52,19 +52,19 @@ class JfrSettingsOverridesTest {
   }
 
   @Test
-  void avoidanceSoup(){
-      assertFalse(JfrSettingsOverrides.isVulnerableToJdk8309862("8.0.382"));
-      assertFalse(JfrSettingsOverrides.isVulnerableToJdk8309862("11.0.1"));
-      assertTrue(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.1"));
-      assertTrue(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.2"));
-      assertTrue(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.3"));
-      assertTrue(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.4"));
-      assertTrue(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.5"));
-      assertTrue(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.6"));
-      assertTrue(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.7"));
-      assertTrue(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.8"));
-      assertFalse(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.9"));
-      assertFalse(JfrSettingsOverrides.isVulnerableToJdk8309862("21.0.0"));
-      assertFalse(JfrSettingsOverrides.isVulnerableToJdk8309862("21.0.1"));
+  void avoidanceSoup() {
+    assertFalse(JfrSettingsOverrides.isVulnerableToJdk8309862("8.0.382"));
+    assertFalse(JfrSettingsOverrides.isVulnerableToJdk8309862("11.0.1"));
+    assertTrue(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.1"));
+    assertTrue(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.2"));
+    assertTrue(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.3"));
+    assertTrue(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.4"));
+    assertTrue(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.5"));
+    assertTrue(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.6"));
+    assertTrue(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.7"));
+    assertTrue(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.8"));
+    assertFalse(JfrSettingsOverrides.isVulnerableToJdk8309862("17.0.9"));
+    assertFalse(JfrSettingsOverrides.isVulnerableToJdk8309862("21.0.0"));
+    assertFalse(JfrSettingsOverrides.isVulnerableToJdk8309862("21.0.1"));
   }
 }


### PR DESCRIPTION
Safeguard against https://bugs.openjdk.org/browse/JDK-8309862.

Can be bypassed with `-Drisky.jfr.optin=true`.