### PR TITLE
Don't set metrics exporter to otlp for tests

### DIFF
--- a/buildSrc/src/main/kotlin/splunk.instrumentation-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.instrumentation-conventions.gradle.kts
@@ -55,8 +55,6 @@ tasks.withType<Test>().configureEach {
   // Reduce noise in assertion messages since we don't need to verify this in most tests. We check
   // in smoke tests instead.
   jvmArgs("-Dotel.javaagent.add-thread-details=false")
-  // needed for proper GlobalMeterProvider registration
-  jvmArgs("-Dotel.metrics.exporter=otlp")
   // suppress repeated logging of "No metric data to export - skipping export."
   // since PeriodicMetricReader is configured with a short interval
   jvmArgs("-Dio.opentelemetry.javaagent.slf4j.simpleLogger.log.io.opentelemetry.sdk.metrics.export.PeriodicMetricReader=INFO")


### PR DESCRIPTION
Testing extension already sets up exporter for tests adding the otlp exporter flag only adds stack traces with export failures to test output.