### PR TITLE
Rename metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -32,11 +32,11 @@ Besides OpenTelemetry JVM Metrics we include the following JVM metrics.
 
 These metrics are enabled only when memory profiler is enabled.
 
-| Metric name                            | Instrument   | Description                                                      |
-|----------------------------------------|--------------|------------------------------------------------------------------|
-| `process.runtime.jvm.memory.allocated` | [Counter][c] | Approximate sum of heap allocations.                             |
-| `runtime.jvm.gc.pause.count`           | [Counter][c] | Number of gc pauses.                                             |
-| `runtime.jvm.gc.pause.totalTime`       | [Counter][c] | Time spent in GC pause.                                          |
+| Metric name              | Instrument   | Description                                                              |
+|--------------------------|--------------|--------------------------------------------------------------------------|
+| `jvm.memory.allocated`   | [Counter][c] | Approximate sum of heap allocations.                                     |
+| `jvm.gc.pause.count`     | [Counter][c] | Number of gc pauses. This metric will be removed in a future release.    |
+| `jvm.gc.pause.totalTime` | [Counter][c] | Time spent in GC pause. This metric will be removed in a future release. |
 
 #### Thread metrics
 

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/AllocatedMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/AllocatedMemoryMetrics.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class AllocatedMemoryMetrics {
-  public static final String METRIC_NAME = "process.runtime.jvm.memory.allocated";
+  public static final String METRIC_NAME = "jvm.memory.allocated";
   private final AllocationTracker allocationTracker = createAllocationTracker();
 
   public boolean isUnavailable() {

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/JvmMetricsInstaller.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/JvmMetricsInstaller.java
@@ -48,7 +48,6 @@ public class JvmMetricsInstaller implements AgentListener {
     //     process.runtime.jvm.memory.limit{pool=<long lived pools>}
     //   runtime.jvm.gc.live.data.size is replaced by OTel
     //     process.runtime.jvm.memory.usage_after_last_gc{pool=<long lived pools>}
-    //     (temporarily restored to ease migration)
     //   runtime.jvm.gc.memory.allocated is replaced by memory profiling metric
     //     process.runtime.jvm.memory.allocated
     //   runtime.jvm.gc.memory.promoted is removed with no direct replacement

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/otel/OtelGcMemoryMetrics.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/otel/OtelGcMemoryMetrics.java
@@ -52,15 +52,16 @@ public class OtelGcMemoryMetrics {
     Meter meter = OtelMeterProvider.get();
     LongCounter gcPauseCounter =
         meter
-            .counterBuilder("runtime.jvm.gc.pause.count")
+            .counterBuilder("jvm.gc.pause.count")
             .setUnit("{gcs}")
-            .setDescription("Number of gc pauses.")
+            .setDescription("Number of gc pauses. This metric will be removed in a future release.")
             .build();
     LongCounter gcPauseTime =
         meter
-            .counterBuilder("runtime.jvm.gc.pause.totalTime")
+            .counterBuilder("jvm.gc.pause.totalTime")
             .setUnit("ms")
-            .setDescription("Time spent in GC pause.")
+            .setDescription(
+                "Time spent in GC pause. This metric will be removed in a future release.")
             .build();
 
     gcMemoryMetrics.registerListener(

--- a/instrumentation/jvm-metrics/src/test/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/OtelJvmMetricsTest.java
+++ b/instrumentation/jvm-metrics/src/test/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/OtelJvmMetricsTest.java
@@ -49,7 +49,7 @@ class OtelJvmMetricsTest {
     // allocated memory metrics
     assertOtelMetricPresent(AllocatedMemoryMetrics.METRIC_NAME);
     // Our custom GC metrics
-    assertOtelMetricPresent("runtime.jvm.gc.pause.count");
+    assertOtelMetricPresent("jvm.gc.pause.count");
   }
 
   private void assertOtelMetricPresent(String name) {

--- a/metadata-generator/src/main/java/com/splunk/opentelemetry/tools/MetadataGenerator.java
+++ b/metadata-generator/src/main/java/com/splunk/opentelemetry/tools/MetadataGenerator.java
@@ -3199,11 +3199,14 @@ public class MetadataGenerator {
                 "process.runtime.jvm.memory.allocated",
                 MetricInstrument.COUNTER,
                 "Approximate sum of heap allocations.")
-            .metric("runtime.jvm.gc.pause.count", MetricInstrument.COUNTER, "Number of gc pauses.")
             .metric(
-                "runtime.jvm.gc.pause.totalTime",
+                "jvm.gc.pause.count",
                 MetricInstrument.COUNTER,
-                "Time spent in GC pause.")
+                "Number of gc pauses. This metric will be removed in a future release.")
+            .metric(
+                "jvm.gc.pause.totalTime",
+                MetricInstrument.COUNTER,
+                "Time spent in GC pause. This metric will be removed in a future release.")
             .metric(
                 "runtime.jvm.threads.states",
                 MetricInstrument.GAUGE,

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/SpringBootSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/SpringBootSmokeTest.java
@@ -95,7 +95,7 @@ public class SpringBootSmokeTest extends AppServerTest {
   protected void assertMetrics(MetricsInspector metrics) {
     // verify that JVM metrics are exported
     assertTrue(metrics.hasMetricsNamed("jvm.class.loaded"));
-    assertTrue(metrics.hasMetricsNamed("process.runtime.jvm.memory.allocated"));
+    assertTrue(metrics.hasMetricsNamed("jvm.memory.allocated"));
     assertTrue(metrics.hasMetricsNamed("jvm.memory.used"));
     assertTrue(metrics.hasMetricsNamed("jvm.thread.count"));
   }


### PR DESCRIPTION
Micrometer and otel counters use different aggregation temporality. Rename the counters to so they wouldn't clash.