### PR TITLE
Don't enable thread pool metrics with profiler

### DIFF
--- a/custom/src/main/java/com/splunk/opentelemetry/SplunkConfiguration.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/SplunkConfiguration.java
@@ -66,12 +66,6 @@ public class SplunkConfiguration implements AutoConfigurationCustomizerProvider 
   Map<String, String> customize(ConfigProperties config) {
     Map<String, String> customized = new HashMap<>();
 
-    boolean memoryProfilerEnabled = config.getBoolean(PROFILER_MEMORY_ENABLED_PROPERTY, false);
-    // memory profiler implies metrics
-    if (memoryProfilerEnabled) {
-      customized.put(METRICS_ENABLED_PROPERTY, "true");
-    }
-
     String realm = config.getString(SPLUNK_REALM_PROPERTY, SPLUNK_REALM_NONE);
     if (!SPLUNK_REALM_NONE.equals(realm)) {
       addIfAbsent(

--- a/instrumentation/jvm-metrics/build.gradle.kts
+++ b/instrumentation/jvm-metrics/build.gradle.kts
@@ -8,6 +8,5 @@ dependencies {
 }
 
 tasks.withType<Test>().configureEach {
-  jvmArgs("-Dsplunk.metrics.enabled=true")
-  jvmArgs("-Dsplunk.metrics.experimental.enabled=true")
+  jvmArgs("-Dotel.instrumentation.jvm-metrics.splunk.enabled=true")
 }

--- a/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/JvmMetricsInstaller.java
+++ b/instrumentation/jvm-metrics/src/main/java/com/splunk/opentelemetry/instrumentation/jvmmetrics/JvmMetricsInstaller.java
@@ -16,7 +16,6 @@
 
 package com.splunk.opentelemetry.instrumentation.jvmmetrics;
 
-import static com.splunk.opentelemetry.SplunkConfiguration.METRICS_ENABLED_PROPERTY;
 import static com.splunk.opentelemetry.SplunkConfiguration.PROFILER_MEMORY_ENABLED_PROPERTY;
 import static io.opentelemetry.sdk.autoconfigure.AutoConfigureUtil.getConfig;
 
@@ -33,16 +32,12 @@ public class JvmMetricsInstaller implements AgentListener {
   @Override
   public void afterAgent(AutoConfiguredOpenTelemetrySdk autoConfiguredOpenTelemetrySdk) {
     ConfigProperties config = getConfig(autoConfiguredOpenTelemetrySdk);
-    boolean metricsEnabled = config.getBoolean(METRICS_ENABLED_PROPERTY, false);
+    boolean metricsEnabled = config.getBoolean(PROFILER_MEMORY_ENABLED_PROPERTY, false);
     if (!config.getBoolean("otel.instrumentation.jvm-metrics.splunk.enabled", metricsEnabled)) {
       return;
     }
 
-    // Following metrics are experimental, we'll enable them only when memory profiling is enabled
-    if (config.getBoolean(PROFILER_MEMORY_ENABLED_PROPERTY, false)
-        || config.getBoolean("splunk.metrics.experimental.enabled", false)) {
-      new OtelAllocatedMemoryMetrics().install();
-      new OtelGcMemoryMetrics().install();
-    }
+    new OtelAllocatedMemoryMetrics().install();
+    new OtelGcMemoryMetrics().install();
   }
 }

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/SpringBootSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/SpringBootSmokeTest.java
@@ -47,7 +47,7 @@ public class SpringBootSmokeTest extends AppServerTest {
         "smoke-test-app",
         "OTEL_INSTRUMENTATION_COMMON_EXPERIMENTAL_CONTROLLER_TELEMETRY_ENABLED",
         "true",
-        "SPLUNK_METRICS_EXPERIMENTAL_ENABLED",
+        "OTEL_INSTRUMENTATION_JVM_METRICS_SPLUNK_ENABLED",
         "true");
   }
 


### PR DESCRIPTION
As discussed with @akubik-splunk in preparation for the potential removal of the thread pool metrics I'm going to make memory profiling enable only the profiling metrics and leave the thread pool metrics disabled.