### PR TITLE
Run ci build on patch release branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - v[0-9]+.[0-9]+.x
 
 jobs:
   # TODO: lycheeverse/lychee:latest on which this job depends is broken, temporarily turning it off


### PR DESCRIPTION
this is what upstream used before changing adding `release/` prefix to the release branch name