### PR TITLE
Exclude compile only dependencies from fossa analysis

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,10 @@
+version: 3
+
+experimental:
+  gradle:
+    # other configurations will be excluded, we don't wish to analyze compile only and test dependencies
+    configurations-only:
+      - runtimeClasspath
+      - runtime
+      - runtimeOnly
+      - runtimeOnlyDependenciesMetadata


### PR DESCRIPTION
See VULN-9916 for discussion, the list of configurations was also provided in that ticket. The intent is to exclude dependencies that are not bundled in the agent jar from the analysis.