### PR TITLE
Update deprecated CF stack

### DIFF
--- a/deployments/cloudfoundry/buildpack/manifest.yml
+++ b/deployments/cloudfoundry/buildpack/manifest.yml
@@ -1,3 +1,3 @@
 ---
 language: splunk-otel-java
-stack: cflinuxfs3
+stack: cflinuxfs4

--- a/deployments/cloudfoundry/index.yml
+++ b/deployments/cloudfoundry/index.yml
@@ -17,3 +17,4 @@
 1.27.0: https://github.com/signalfx/splunk-otel-java/releases/download/v1.27.0/splunk-otel-javaagent.jar
 1.28.0: https://github.com/signalfx/splunk-otel-java/releases/download/v1.28.0/splunk-otel-javaagent.jar
 1.29.0: https://github.com/signalfx/splunk-otel-java/releases/download/v1.29.0/splunk-otel-javaagent.jar
+1.30.1: https://github.com/signalfx/splunk-otel-java/releases/download/v1.30.1/splunk-otel-javaagent.jar


### PR DESCRIPTION
cflinuxcf3 is deprecated. 

https://community.sap.com/t5/technology-blogs-by-sap/deprecation-of-cloud-foundry-stack-cflinuxfs3-and-migration-to-cflinuxfs4/ba-p/13549149