### PR TITLE
Add python buildpack

### DIFF
--- a/deployments/cloudfoundry/buildpack/README.md
+++ b/deployments/cloudfoundry/buildpack/README.md
@@ -27,7 +27,8 @@ $ cf set-env my-app OTEL_RESOURCE_ATTRIBUTES "service.name=<application name>"
 # ...
 
 # java_buildpack is the main buildpack for JVM apps, it needs to be the final one
-$ cf push my-app -b splunk_otel_java_buildpack -b https://github.com/cloudfoundry/java-buildpack
+# python is required for the supply script
+$ cf push my-app -b python_buildpack -b splunk_otel_java_buildpack -b https://github.com/cloudfoundry/java-buildpack
 ```
 
 ## Configuration


### PR DESCRIPTION
Based on this comment:
https://github.com/cloudfoundry/cflinuxfs4-release/issues/2#issuecomment-1487651634

It's believed that this needs to be provided, otherwise the `supply` script (python) may not work. This is untested, but we had a report of cflinuxfs4 failing due to missing python.