### PR TITLE
Update shading configuration

### DIFF
--- a/buildSrc/src/main/kotlin/splunk.shadow-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.shadow-conventions.gradle.kts
@@ -32,6 +32,6 @@ tasks.withType<ShadowJar>().configureEach {
   // relocate the OpenTelemetry extensions that are used by instrumentation modules
   // these extensions live in the AgentClassLoader, and are injected into the user"s class loader
   // by the instrumentation modules that use them
-  relocate("io.opentelemetry.extension.aws", "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.aws")
+  relocate("io.opentelemetry.contrib.awsxray", "io.opentelemetry.javaagent.shaded.io.opentelemetry.contrib.awsxray")
   relocate("io.opentelemetry.extension.kotlin", "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.kotlin")
 }


### PR DESCRIPTION
Update shading configuration to use the package where aws propagator currently is. As we get the aws propagator from upstream and don't include it ourself this change does not change anything, it only serves to align shading configuration with what the demo distro uses (there is pr with the same change in upstream).