### PR TITLE
Prepare 1.30.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ## Unreleased
 
+## v1.30.3 - 2024-02-27
+
 - Remove dependency on python for CloudFoundry `supply` script 
 
 ## v1.30.2 - 2024-02-15

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ To extend the instrumentation with the OpenTelemetry Instrumentation for Java,
 you have to use a compatible API version.
 
 <!-- IMPORTANT: do not change comments or break those lines below -->
-The Splunk Distribution of OpenTelemetry Java version <!--SPLUNK_VERSION-->1.30.2<!--SPLUNK_VERSION--> is compatible
+The Splunk Distribution of OpenTelemetry Java version <!--SPLUNK_VERSION-->1.30.3<!--SPLUNK_VERSION--> is compatible
 with:
 
 * OpenTelemetry API version <!--OTEL_VERSION-->1.34.1<!--OTEL_VERSION-->

--- a/deployments/cloudfoundry/buildpack/README.md
+++ b/deployments/cloudfoundry/buildpack/README.md
@@ -40,7 +40,7 @@ If you want to use a specific version of the Java agent in your application, you
 environment variable before application deployment, either using `cf set-env` or the `manifest.yml` file:
 
 ```sh
-$ cf set-env SPLUNK_OTEL_JAVA_VERSION 1.30.2
+$ cf set-env SPLUNK_OTEL_JAVA_VERSION 1.30.3
 ```
 
 By default, the [latest](https://github.com/signalfx/splunk-otel-java/releases/latest) available agent version is used.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,5 +1,5 @@
 // do NOT update that variable manually - it is managed by the pre/post release scripts
-val distroVersion = "1.30.2"
+val distroVersion = "1.30.3"
 
 allprojects {
   version = distroVersion


### PR DESCRIPTION
Patch release that includes the updated non-python cloudfoundry `supply` script.