### PR TITLE
Skip publishing splunk-otel-javaagent-all.jar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM busybox 
 
-ADD dist/splunk-otel-javaagent-all.jar /
+ADD dist/splunk-otel-javaagent.jar /

--- a/agent/build.gradle.kts
+++ b/agent/build.gradle.kts
@@ -161,7 +161,6 @@ tasks {
         groupId = "com.splunk"
         version = project.version.toString()
 
-        artifact(shadowJar)
         artifact(mainShadowJar)
         artifact(t.named("sourcesJar"))
         artifact(t.named("javadocJar"))

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -47,8 +47,6 @@ build_project() {
   ./gradlew assemble publishToSonatype closeAndReleaseSonatypeStagingRepository --no-daemon --stacktrace
   mv "agent/build/libs/splunk-otel-javaagent-${release_version}.jar" dist/splunk-otel-javaagent.jar
   mv "agent/build/libs/splunk-otel-javaagent-${release_version}.jar.asc" dist/splunk-otel-javaagent.jar.asc
-  mv "agent/build/libs/splunk-otel-javaagent-${release_version}-all.jar" dist/splunk-otel-javaagent-all.jar
-  mv "agent/build/libs/splunk-otel-javaagent-${release_version}-all.jar.asc" dist/splunk-otel-javaagent-all.jar.asc
 
   echo ">>> Building the cloudfoundry buildpack ..."
   ./deployments/cloudfoundry/buildpack/build.sh


### PR DESCRIPTION
This cherry picks aaf480f27ae18d088bb18a21d016cb1f15293be3 from #1567 into the 1.32.x branch, so that the next release won't have the `-all` artifact, which is causing some confusion to some users.