### PR TITLE
Remove commons lang

### DIFF
--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -26,8 +26,6 @@ dependencies {
   testImplementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api")
   testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api")
   testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling")
-  testImplementation("org.apache.commons:commons-lang3:3.14.0")
-
   testImplementation(project(":testing:common"))
 }
 

--- a/custom/src/test/java/com/splunk/opentelemetry/TruncateCommandLineWhenMetricsEnabledTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/TruncateCommandLineWhenMetricsEnabledTest.java
@@ -31,7 +31,6 @@ import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Arrays;
-import java.util.List;
 import java.util.function.BiFunction;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
@@ -91,7 +90,7 @@ class TruncateCommandLineWhenMetricsEnabledTest {
     assertThat(resultCmd.length()).isEqualTo(255);
     assertThat(resultCmd.endsWith("...")).isTrue();
     var cmdArgs = result.getAttribute(PROCESS_COMMAND_ARGS);
-    String joinedArgs = getJoinedArgs(cmdArgs);
+    String joinedArgs = String.join(", ", cmdArgs.toArray(new String[] {}));
     assertThat(joinedArgs.length()).isLessThan(255);
     assertThat(joinedArgs.endsWith("...")).isTrue();
     assertThat(result.getAttribute(stringKey("foo"))).isEqualTo("barfly");
@@ -117,7 +116,7 @@ class TruncateCommandLineWhenMetricsEnabledTest {
     assertThat(resultCmd.length()).isEqualTo(255);
     assertThat(resultCmd.endsWith("...")).isTrue();
     var cmdArgs = result.getAttribute(PROCESS_COMMAND_ARGS);
-    String joinedArgs = getJoinedArgs(cmdArgs);
+    String joinedArgs = String.join(", ", cmdArgs.toArray(new String[] {}));
     assertThat(joinedArgs.length()).isLessThan(255);
     assertThat(joinedArgs.endsWith("...")).isTrue();
     assertThat(result.getAttribute(stringKey("foo"))).isEqualTo("barfly");
@@ -133,17 +132,5 @@ class TruncateCommandLineWhenMetricsEnabledTest {
             cmdLine != null ? Arrays.asList(cmdLine.split(" ")) : null,
             stringKey("foo"),
             "barfly"));
-  }
-
-  @NotNull
-  private static String getJoinedArgs(List<String> cmdArgs) {
-    StringBuilder sb = new StringBuilder();
-    for (Object item : cmdArgs.toArray()) {
-      if (!sb.isEmpty()) {
-        sb.append(", ");
-      }
-      sb.append(item);
-    }
-    return sb.toString();
   }
 }

--- a/custom/src/test/java/com/splunk/opentelemetry/TruncateCommandLineWhenMetricsEnabledTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/TruncateCommandLineWhenMetricsEnabledTest.java
@@ -139,12 +139,11 @@ class TruncateCommandLineWhenMetricsEnabledTest {
   private static String getJoinedArgs(List<String> cmdArgs) {
     StringBuilder sb = new StringBuilder();
     for (Object item : cmdArgs.toArray()) {
-      if(!sb.isEmpty()) {
+      if (!sb.isEmpty()) {
         sb.append(", ");
       }
       sb.append(item);
     }
     return sb.toString();
   }
-
 }

--- a/custom/src/test/java/com/splunk/opentelemetry/TruncateCommandLineWhenMetricsEnabledTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/TruncateCommandLineWhenMetricsEnabledTest.java
@@ -31,8 +31,8 @@ import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.BiFunction;
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -91,7 +91,7 @@ class TruncateCommandLineWhenMetricsEnabledTest {
     assertThat(resultCmd.length()).isEqualTo(255);
     assertThat(resultCmd.endsWith("...")).isTrue();
     var cmdArgs = result.getAttribute(PROCESS_COMMAND_ARGS);
-    String joinedArgs = StringUtils.joinWith(", ", cmdArgs.toArray());
+    String joinedArgs = getJoinedArgs(cmdArgs);
     assertThat(joinedArgs.length()).isLessThan(255);
     assertThat(joinedArgs.endsWith("...")).isTrue();
     assertThat(result.getAttribute(stringKey("foo"))).isEqualTo("barfly");
@@ -117,7 +117,7 @@ class TruncateCommandLineWhenMetricsEnabledTest {
     assertThat(resultCmd.length()).isEqualTo(255);
     assertThat(resultCmd.endsWith("...")).isTrue();
     var cmdArgs = result.getAttribute(PROCESS_COMMAND_ARGS);
-    String joinedArgs = StringUtils.joinWith(", ", cmdArgs.toArray());
+    String joinedArgs = getJoinedArgs(cmdArgs);
     assertThat(joinedArgs.length()).isLessThan(255);
     assertThat(joinedArgs.endsWith("...")).isTrue();
     assertThat(result.getAttribute(stringKey("foo"))).isEqualTo("barfly");
@@ -134,4 +134,17 @@ class TruncateCommandLineWhenMetricsEnabledTest {
             stringKey("foo"),
             "barfly"));
   }
+
+  @NotNull
+  private static String getJoinedArgs(List<String> cmdArgs) {
+    StringBuilder sb = new StringBuilder();
+    for (Object item : cmdArgs.toArray()) {
+      if(!sb.isEmpty()) {
+        sb.append(", ");
+      }
+      sb.append(item);
+    }
+    return sb.toString();
+  }
+
 }


### PR DESCRIPTION
Looks like this dep was only used in 1 test and was just a silly string join that is easily accomplished in an alternative fashion.