### PR TITLE
Prepare for 2.4.0-alpha release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,21 @@ The format is based on
 the [Splunk GDI specification](https://github.com/signalfx/gdi-specification/blob/v1.0.0/specification/repository.md),
 and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## v2.4.0 - 2024-04-29
+
+- OpenTelemetry Java SDK has been updated to version 1.38.0.
+- OpenTelemetry Instrumentation for Java has been updated to version 2.4.0.
+
+### ⚠️⚠️ Breaking changes ⚠️⚠️
+
+Please note that this release drops the `-alpha` suffix and marks `v2.4.0` as the 
+latest release version. There are many breaking changes in the 2.x line compared 
+to 1.x. Before switching, users are strongly encouraged to read the release notes for 
+[`v2.0.0-alpha`](https://github.com/signalfx/splunk-otel-java/releases/tag/v2.0.0-alpha) 
+through `v2.3.0-alpha` before upgrading.
+
+- Thread pool metrics for Liberty, Tomcat, and WebLogic have been removed. 
+  [#1848](https://github.com/signalfx/splunk-otel-java/pull/1848)
 
 ## v1.32.0 - 2024-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,12 @@ The format is based on
 the [Splunk GDI specification](https://github.com/signalfx/gdi-specification/blob/v1.0.0/specification/repository.md),
 and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v2.4.0 - 2024-04-29
+## v2.4.0-alpha - 2024-04-30
 
 - OpenTelemetry Java SDK has been updated to version 1.38.0.
 - OpenTelemetry Instrumentation for Java has been updated to version 2.4.0.
 
-### ⚠️⚠️ Breaking changes ⚠️⚠️
-
-Please note that this release drops the `-alpha` suffix and marks `v2.4.0` as the 
-latest release version. There are many breaking changes in the 2.x line compared 
-to 1.x. Before switching, users are strongly encouraged to read the release notes for 
-[`v2.0.0-alpha`](https://github.com/signalfx/splunk-otel-java/releases/tag/v2.0.0-alpha) 
-through `v2.3.0-alpha` before upgrading.
+Note: 2.4.0-alpha release is considered experimental, Splunk recommends using 1.x version of the agent.
 
 - Thread pool metrics for Liberty, Tomcat, and WebLogic have been removed. 
   [#1848](https://github.com/signalfx/splunk-otel-java/pull/1848)

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ To extend the instrumentation with the OpenTelemetry Instrumentation for Java,
 you have to use a compatible API version.
 
 <!-- IMPORTANT: do not change comments or break those lines below -->
-The Splunk Distribution of OpenTelemetry Java version <!--SPLUNK_VERSION-->2.4.0<!--SPLUNK_VERSION--> is compatible
+The Splunk Distribution of OpenTelemetry Java version <!--SPLUNK_VERSION-->2.4.0-alpha<!--SPLUNK_VERSION--> is compatible
 with:
 
 * OpenTelemetry API version <!--OTEL_VERSION-->1.38.0<!--OTEL_VERSION-->

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 
 <p align="center">
   <img alt="Stable" src="https://img.shields.io/badge/status-stable-informational?style=for-the-badge">
-  <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.3.0">
-    <img alt="OpenTelemetry Instrumentation for Java Version" src="https://img.shields.io/badge/otel-2.3.0-blueviolet?style=for-the-badge">
+  <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.4.0">
+    <img alt="OpenTelemetry Instrumentation for Java Version" src="https://img.shields.io/badge/otel-2.4.0-blueviolet?style=for-the-badge">
   </a>
   <a href="https://github.com/signalfx/gdi-specification/releases/tag/v1.6.0">
     <img alt="Splunk GDI specification" src="https://img.shields.io/badge/GDI-1.6.0-blueviolet?style=for-the-badge">
@@ -73,11 +73,6 @@ see [Migrate from the SignalFx Java Agent](https://quickdraw.splunk.com/redirect
 
 <!-- Comments, spacing, empty and new lines in the section below are intentional, please do not modify them! -->
 <!--DEV_DOCS_WARNING-->
-<!--DEV_DOCS_WARNING_START-->
-The following documentation refers to the in-development version of `splunk-otel-java`. Docs for the latest version ([v2.3.0-alpha](https://github.com/signalfx/splunk-otel-java/releases/latest)) can be found [here](https://github.com/signalfx/splunk-otel-java/blob/v2.3.0-alpha/README.md).
-
----
-<!--DEV_DOCS_WARNING_END-->
 
 ## Requirements
 
@@ -109,11 +104,11 @@ To extend the instrumentation with the OpenTelemetry Instrumentation for Java,
 you have to use a compatible API version.
 
 <!-- IMPORTANT: do not change comments or break those lines below -->
-The Splunk Distribution of OpenTelemetry Java version <!--SPLUNK_VERSION-->2.3.0-alpha<!--SPLUNK_VERSION--> is compatible
+The Splunk Distribution of OpenTelemetry Java version <!--SPLUNK_VERSION-->2.4.0<!--SPLUNK_VERSION--> is compatible
 with:
 
-* OpenTelemetry API version <!--OTEL_VERSION-->1.37.0<!--OTEL_VERSION-->
-* OpenTelemetry Instrumentation for Java version <!--OTEL_INSTRUMENTATION_VERSION-->2.3.0<!--OTEL_INSTRUMENTATION_VERSION-->
+* OpenTelemetry API version <!--OTEL_VERSION-->1.38.0<!--OTEL_VERSION-->
+* OpenTelemetry Instrumentation for Java version <!--OTEL_INSTRUMENTATION_VERSION-->2.4.0<!--OTEL_INSTRUMENTATION_VERSION-->
 
 ## Snapshot builds
 

--- a/deployments/cloudfoundry/buildpack/README.md
+++ b/deployments/cloudfoundry/buildpack/README.md
@@ -40,7 +40,7 @@ If you want to use a specific version of the Java agent in your application, you
 environment variable before application deployment, either using `cf set-env` or the `manifest.yml` file:
 
 ```sh
-$ cf set-env SPLUNK_OTEL_JAVA_VERSION 2.3.0-alpha
+$ cf set-env SPLUNK_OTEL_JAVA_VERSION 2.4.0
 ```
 
 By default, the [latest](https://github.com/signalfx/splunk-otel-java/releases/latest) available agent version is used.

--- a/deployments/cloudfoundry/buildpack/README.md
+++ b/deployments/cloudfoundry/buildpack/README.md
@@ -40,7 +40,7 @@ If you want to use a specific version of the Java agent in your application, you
 environment variable before application deployment, either using `cf set-env` or the `manifest.yml` file:
 
 ```sh
-$ cf set-env SPLUNK_OTEL_JAVA_VERSION 2.4.0
+$ cf set-env SPLUNK_OTEL_JAVA_VERSION 2.4.0-alpha
 ```
 
 By default, the [latest](https://github.com/signalfx/splunk-otel-java/releases/latest) available agent version is used.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,5 +1,5 @@
 // do NOT update that variable manually - it is managed by the pre/post release scripts
-val distroVersion = "2.4.0-alpha-SNAPSHOT"
+val distroVersion = "2.4.0"
 
 allprojects {
   version = distroVersion

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,5 +1,5 @@
 // do NOT update that variable manually - it is managed by the pre/post release scripts
-val distroVersion = "2.4.0"
+val distroVersion = "2.4.0-alpha"
 
 allprojects {
   version = distroVersion


### PR DESCRIPTION
~~Please hold on the release until we are certain we can proceed. Thanks.~~ 

We will release `2.4.0-alpha` and drop alpha with 2.5.0. This PR has been updated to reflect that.