### PR TITLE
Make environment vars consistent with upstream

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,8 +10,8 @@ nexusPublishing {
 
   repositories {
     sonatype {
-      username.set(System.getenv("SONATYPE_USERNAME"))
-      password.set(System.getenv("SONATYPE_PASSWORD"))
+      username.set(System.getenv("SONATYPE_USER"))
+      password.set(System.getenv("SONATYPE_KEY"))
     }
   }
 }


### PR DESCRIPTION
NOTE: This is for the 1.32.x breanch.

Seems like a good time to do this, given the change to sonatype token.