### PR TITLE
Fix smoke test collector conf

### DIFF
--- a/smoke-tests/src/test/resources/otel.yaml
+++ b/smoke-tests/src/test/resources/otel.yaml
@@ -9,7 +9,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
       http:
+        endpoint: 0.0.0.0:4318
   signalfx:
 
 processors:


### PR DESCRIPTION
Resolves https://github.com/signalfx/splunk-otel-java/issues/1922
Resolves https://github.com/signalfx/splunk-otel-java/issues/1924
by default collector now binds only to localhost