### PR TITLE
[chore][deployments/cloudfoundry/buildpack] Fix example cf command

### DIFF
--- a/deployments/cloudfoundry/buildpack/README.md
+++ b/deployments/cloudfoundry/buildpack/README.md
@@ -16,7 +16,7 @@ If you would like to install the buildpack, clone this repo, change to this dire
 $ ./build.sh
 
 # installs the buildpack on CloudFoundry
-$ cf create-buildpack splunk_otel_java_buildpack splunk_otel_java_buildpack-linux.zip 99 --enable
+$ cf create-buildpack splunk_otel_java_buildpack splunk_otel_java_buildpack-linux.zip 99
 ```
 
 Now you can use the buildpack when running your apps:


### PR DESCRIPTION
When running the example command given, an error is returned. The command is successful without the `--enable` option. I assume it's been removed in a more recent version of `cf`.
```
$ cf create-buildpack splunk_otel_java_buildpack splunk_otel_java_buildpack-linux.zip 99 --enable
Incorrect Usage: unknown flag `enable'

NAME:
   create-buildpack - Create a buildpack

USAGE:
   cf create-buildpack BUILDPACK PATH POSITION [--disable]

TIP:
   Path should be a zip file, a url to a zip file, or a local directory. Position is a positive integer, sets priority, and is sorted from lowest to highest.

OPTIONS:
   --disable      Disable the buildpack from being used for staging

SEE ALSO:
   buildpacks, push
$ cf version
cf version 8.7.8+515cf4e.2024-02-08
```