### PR TITLE
Let opentelemetry instrumentation bom configure the semconv version

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -56,8 +56,5 @@ dependencies {
     api("io.opentelemetry.contrib:opentelemetry-samplers:$otelContribAlphaVersion")
     api("io.opentelemetry.contrib:opentelemetry-resource-providers:$otelContribAlphaVersion")
     api("io.opentelemetry.proto:opentelemetry-proto:1.3.2-alpha")
-    api("io.opentelemetry.semconv:opentelemetry-semconv:1.25.0-alpha")
-    api("io.opentelemetry.semconv:opentelemetry-semconv-incubating:1.25.0-alpha")
   }
-
 }


### PR DESCRIPTION
Currently because we set the semconv version we get renovate updates for it that we don't want (can't update semconv anyway before upstream updates). 