### PR TITLE
Allow setting otlp protocol for profiler with otel.exporter.otlp.protocol

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
@@ -47,7 +47,8 @@ public class Configuration implements AutoConfigurationCustomizerProvider {
   public static final String CONFIG_KEY_RECORDING_DURATION = "splunk.profiler.recording.duration";
   public static final String CONFIG_KEY_KEEP_FILES = "splunk.profiler.keep-files";
   public static final String CONFIG_KEY_INGEST_URL = "splunk.profiler.logs-endpoint";
-  public static final String CONFIG_KEY_OTLP_PROTOCOL = "splunk.profiler.otlp.protocol";
+  public static final String CONFIG_KEY_PROFILER_OTLP_PROTOCOL = "splunk.profiler.otlp.protocol";
+  public static final String CONFIG_KEY_OTLP_PROTOCOL = "otel.exporter.otlp.protocol";
   public static final String CONFIG_KEY_OTEL_OTLP_URL = "otel.exporter.otlp.endpoint";
   public static final String CONFIG_KEY_MEMORY_ENABLED = PROFILER_MEMORY_ENABLED_PROPERTY;
   public static final String CONFIG_KEY_MEMORY_EVENT_RATE_LIMIT_ENABLED =
@@ -82,7 +83,6 @@ public class Configuration implements AutoConfigurationCustomizerProvider {
     config.put(CONFIG_KEY_MEMORY_ENABLED, String.valueOf(DEFAULT_MEMORY_ENABLED));
     config.put(CONFIG_KEY_MEMORY_EVENT_RATE, DEFAULT_MEMORY_EVENT_RATE);
     config.put(CONFIG_KEY_CALL_STACK_INTERVAL, DEFAULT_CALL_STACK_INTERVAL.toMillis() + "ms");
-    config.put(CONFIG_KEY_OTLP_PROTOCOL, "http/protobuf");
     return config;
   }
 
@@ -116,7 +116,9 @@ public class Configuration implements AutoConfigurationCustomizerProvider {
   }
 
   public static String getOtlpProtocol(ConfigProperties config) {
-    return config.getString(CONFIG_KEY_OTLP_PROTOCOL);
+    return config.getString(
+        CONFIG_KEY_PROFILER_OTLP_PROTOCOL,
+        config.getString(CONFIG_KEY_OTLP_PROTOCOL, "http/protobuf"));
   }
 
   public static boolean getMemoryEnabled(ConfigProperties config) {

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationTest.java
@@ -40,7 +40,7 @@ class ConfigurationTest {
     when(config.getString(Configuration.CONFIG_KEY_INGEST_URL, otelEndpoint))
         .thenReturn(logsEndpoint);
     String result = Configuration.getConfigUrl(config);
-    assertEquals(result, logsEndpoint);
+    assertEquals(logsEndpoint, result);
   }
 
   @Test
@@ -50,7 +50,7 @@ class ConfigurationTest {
     when(config.getString(Configuration.CONFIG_KEY_INGEST_URL, otelEndpoint))
         .thenReturn(otelEndpoint);
     String result = Configuration.getConfigUrl(config);
-    assertEquals(result, otelEndpoint);
+    assertEquals(otelEndpoint, result);
   }
 
   @Test
@@ -76,7 +76,7 @@ class ConfigurationTest {
   void getOtlpProtocolDefault() {
     String result =
         Configuration.getOtlpProtocol(DefaultConfigProperties.create(Collections.emptyMap()));
-    assertEquals(result, "http/protobuf");
+    assertEquals("http/protobuf", result);
   }
 
   @Test
@@ -85,7 +85,7 @@ class ConfigurationTest {
         Configuration.getOtlpProtocol(
             DefaultConfigProperties.create(
                 Collections.singletonMap("otel.exporter.otlp.protocol", "test")));
-    assertEquals(result, "test");
+    assertEquals("test", result);
   }
 
   @Test
@@ -94,6 +94,6 @@ class ConfigurationTest {
     map.put("otel.exporter.otlp.protocol", "test1");
     map.put("splunk.profiler.otlp.protocol", "test2");
     String result = Configuration.getOtlpProtocol(DefaultConfigProperties.create(map));
-    assertEquals(result, "test2");
+    assertEquals("test2", result);
   }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationTest.java
@@ -22,6 +22,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class ConfigurationTest {
@@ -66,5 +70,30 @@ class ConfigurationTest {
     when(config.getString(Configuration.CONFIG_KEY_INGEST_URL, null)).thenReturn(null);
     String result = Configuration.getConfigUrl(config);
     assertNull(result);
+  }
+
+  @Test
+  void getOtlpProtocolDefault() {
+    String result =
+        Configuration.getOtlpProtocol(DefaultConfigProperties.create(Collections.emptyMap()));
+    assertEquals(result, "http/protobuf");
+  }
+
+  @Test
+  void getOtlpProtocolOtelPropertySet() {
+    String result =
+        Configuration.getOtlpProtocol(
+            DefaultConfigProperties.create(
+                Collections.singletonMap("otel.exporter.otlp.protocol", "test")));
+    assertEquals(result, "test");
+  }
+
+  @Test
+  void getOtlpProtocol() {
+    Map<String, String> map = new HashMap<>();
+    map.put("otel.exporter.otlp.protocol", "test1");
+    map.put("splunk.profiler.otlp.protocol", "test2");
+    String result = Configuration.getOtlpProtocol(DefaultConfigProperties.create(map));
+    assertEquals(result, "test2");
   }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/LogExporterBuilderTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/LogExporterBuilderTest.java
@@ -75,7 +75,8 @@ class LogExporterBuilderTest {
     when(builder.addHeader(EXTRA_CONTENT_TYPE, STACKTRACES_HEADER_VALUE)).thenReturn(builder);
     when(builder.build()).thenReturn(expected);
 
-    when(config.getString(Configuration.CONFIG_KEY_OTLP_PROTOCOL)).thenReturn("grpc");
+    when(config.getString(Configuration.CONFIG_KEY_PROFILER_OTLP_PROTOCOL, null))
+        .thenReturn("grpc");
     when(config.getString(Configuration.CONFIG_KEY_OTEL_OTLP_URL, null))
         .thenReturn("http://shadowed.example.com:9122/");
     when(config.getString(Configuration.CONFIG_KEY_INGEST_URL, "http://shadowed.example.com:9122/"))
@@ -97,7 +98,8 @@ class LogExporterBuilderTest {
     when(builder.addHeader(EXTRA_CONTENT_TYPE, STACKTRACES_HEADER_VALUE)).thenReturn(builder);
     when(builder.build()).thenReturn(expected);
 
-    when(config.getString(Configuration.CONFIG_KEY_OTLP_PROTOCOL)).thenReturn("http/protobuf");
+    when(config.getString(Configuration.CONFIG_KEY_PROFILER_OTLP_PROTOCOL, null))
+        .thenReturn("http/protobuf");
     when(config.getString(Configuration.CONFIG_KEY_OTEL_OTLP_URL, null))
         .thenReturn("http://shadowed.example.com:9122/");
     when(config.getString(


### PR DESCRIPTION
Use `otel.exporter.otlp.protocol` when `splunk.profiler.otlp.protocol` is not set.