### PR TITLE
Spotless rules update

### DIFF
--- a/buildSrc/src/main/kotlin/splunk.spotless-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.spotless-conventions.gradle.kts
@@ -63,7 +63,7 @@ extensions.configure<SpotlessExtension>("spotless") {
       "*.sh",
       "src/**/*.properties",
     )
-    indentWithSpaces()
+    leadingTabsToSpaces()
     trimTrailingWhitespace()
     endWithNewline()
   }


### PR DESCRIPTION
`indentWithSpaces()` function was deprecated in spotless and is replaced with `leadingTabsToSpaces()`