### PR TITLE
Fix import after semconv update

### DIFF
--- a/custom/src/test/java/com/splunk/opentelemetry/TruncateCommandLineWhenMetricsEnabledTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/TruncateCommandLineWhenMetricsEnabledTest.java
@@ -18,8 +18,8 @@ package com.splunk.opentelemetry;
 
 import static com.splunk.opentelemetry.SplunkConfiguration.METRICS_FULL_COMMAND_LINE;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
-import static io.opentelemetry.semconv.ResourceAttributes.PROCESS_COMMAND_ARGS;
-import static io.opentelemetry.semconv.ResourceAttributes.PROCESS_COMMAND_LINE;
+import static io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes.PROCESS_COMMAND_ARGS;
+import static io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes.PROCESS_COMMAND_LINE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;

--- a/licenses/licenses.md
+++ b/licenses/licenses.md
@@ -1,7 +1,7 @@
 
 # splunk-otel-javaagent
 ## Dependency License Report
-_2025-01-23 10:02:28 EET_
+_2025-01-31 10:12:43 EET_
 ## Apache License, Version 2.0
 
 **1** **Group:** `com.squareup.okhttp3` **Name:** `okhttp` **Version:** `4.12.0` 
@@ -81,7 +81,7 @@ _2025-01-23 10:02:28 EET_
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java-instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**20** **Group:** `io.opentelemetry.semconv` **Name:** `opentelemetry-semconv` **Version:** `1.29.0-alpha` 
+**20** **Group:** `io.opentelemetry.semconv` **Name:** `opentelemetry-semconv` **Version:** `1.30.0-rc.1` 
 > - **POM Project URL**: [https://github.com/open-telemetry/semantic-conventions-java](https://github.com/open-telemetry/semantic-conventions-java)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 


### PR DESCRIPTION
Resolves https://github.com/signalfx/splunk-otel-java/issues/2177
`ResourceAttributes` class does not exist after semconv version was updated in the upstream