### PR TITLE
Add TextMapPropagator to Inform Downstream Services About Trace Snapshot Selection.

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSdkCustomizer.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSdkCustomizer.java
@@ -58,10 +58,13 @@ public class SnapshotProfilingSdkCustomizer implements AutoConfigurationCustomiz
     };
   }
 
-  private BiFunction<TextMapPropagator, ConfigProperties, TextMapPropagator> addProfilingSignalPropagator(TraceRegistry registry) {
+  private BiFunction<TextMapPropagator, ConfigProperties, TextMapPropagator>
+      addProfilingSignalPropagator(TraceRegistry registry) {
     return (textMapPropagator, properties) -> {
-      if (snapshotProfilingEnabled(properties) && textMapPropagator instanceof W3CTraceContextPropagator) {
-        return TextMapPropagator.composite(textMapPropagator, new SnapshotProfilingSignalPropagator(registry));
+      if (snapshotProfilingEnabled(properties)
+          && textMapPropagator instanceof W3CTraceContextPropagator) {
+        return TextMapPropagator.composite(
+            textMapPropagator, new SnapshotProfilingSignalPropagator(registry));
       }
       return textMapPropagator;
     };

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSdkCustomizer.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSdkCustomizer.java
@@ -20,6 +20,8 @@ import static com.splunk.opentelemetry.profiler.Configuration.CONFIG_KEY_ENABLE_
 
 import com.google.auto.service.AutoService;
 import com.google.common.annotations.VisibleForTesting;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
@@ -41,8 +43,9 @@ public class SnapshotProfilingSdkCustomizer implements AutoConfigurationCustomiz
 
   @Override
   public void customize(AutoConfigurationCustomizer autoConfigurationCustomizer) {
-    autoConfigurationCustomizer.addTracerProviderCustomizer(
-        snapshotProfilingSpanProcessor(registry));
+    autoConfigurationCustomizer
+        .addTracerProviderCustomizer(snapshotProfilingSpanProcessor(registry))
+        .addPropagatorCustomizer(addProfilingSignalPropagator(registry));
   }
 
   private BiFunction<SdkTracerProviderBuilder, ConfigProperties, SdkTracerProviderBuilder>
@@ -52,6 +55,15 @@ public class SnapshotProfilingSdkCustomizer implements AutoConfigurationCustomiz
         return builder.addSpanProcessor(new SnapshotProfilingSpanProcessor(registry));
       }
       return builder;
+    };
+  }
+
+  private BiFunction<TextMapPropagator, ConfigProperties, TextMapPropagator> addProfilingSignalPropagator(TraceRegistry registry) {
+    return (textMapPropagator, properties) -> {
+      if (snapshotProfilingEnabled(properties) && textMapPropagator instanceof W3CTraceContextPropagator) {
+        return TextMapPropagator.composite(textMapPropagator, new SnapshotProfilingSignalPropagator(registry));
+      }
+      return textMapPropagator;
     };
   }
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSignalPropagator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSignalPropagator.java
@@ -1,11 +1,17 @@
 /*
- * 2024 Copyright (C) AppDynamics, Inc., and its affiliates
- * All Rights Reserved
- */
-
-/*
- * Copyright The OpenTelemetry Authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.splunk.opentelemetry.profiler.snapshot;

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSignalPropagator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSignalPropagator.java
@@ -20,7 +20,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 class SnapshotProfilingSignalPropagator implements TextMapPropagator {
-  private static final String PROFILING_SIGNAL = "splunk.trace.snapshot";
+  private static final String PROFILING_SIGNAL = "splunk.trace.snapshot.volume";
 
   private final TraceRegistry registry;
 
@@ -37,15 +37,15 @@ class SnapshotProfilingSignalPropagator implements TextMapPropagator {
   public <C> void inject(Context context, C carrier, TextMapSetter<C> setter) {
     SpanContext spanContext = Span.fromContext(context).getSpanContext();
     if (registry.isRegistered(spanContext)) {
-      setter.set(carrier, PROFILING_SIGNAL, Boolean.TRUE.toString());
+      setter.set(carrier, PROFILING_SIGNAL, Volume.HIGHEST.toString());
     }
   }
 
   @Override
   public <C> Context extract(Context context, C carrier, TextMapGetter<C> getter) {
-    boolean profile = Boolean.parseBoolean(getter.get(carrier, PROFILING_SIGNAL));
+    Volume volume = Volume.fromString(getter.get(carrier, PROFILING_SIGNAL));
     SpanContext spanContext = Span.fromContext(context).getSpanContext();
-    if (profile) {
+    if (volume == Volume.HIGHEST) {
       registry.register(spanContext);
     }
     return context;

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSignalPropagator.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSignalPropagator.java
@@ -1,0 +1,53 @@
+/*
+ * 2024 Copyright (C) AppDynamics, Inc., and its affiliates
+ * All Rights Reserved
+ */
+
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.splunk.opentelemetry.profiler.snapshot;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.context.propagation.TextMapSetter;
+import java.util.Collection;
+import java.util.Collections;
+
+class SnapshotProfilingSignalPropagator implements TextMapPropagator {
+  private static final String PROFILING_SIGNAL = "splunk.trace.snapshot";
+
+  private final TraceRegistry registry;
+
+  SnapshotProfilingSignalPropagator(TraceRegistry registry) {
+    this.registry = registry;
+  }
+
+  @Override
+  public Collection<String> fields() {
+    return Collections.singletonList(PROFILING_SIGNAL);
+  }
+
+  @Override
+  public <C> void inject(Context context, C carrier, TextMapSetter<C> setter) {
+    SpanContext spanContext = Span.fromContext(context).getSpanContext();
+    if (registry.isRegistered(spanContext)) {
+      setter.set(carrier, PROFILING_SIGNAL, Boolean.TRUE.toString());
+    }
+  }
+
+  @Override
+  public <C> Context extract(Context context, C carrier, TextMapGetter<C> getter) {
+    boolean profile = Boolean.parseBoolean(getter.get(carrier, PROFILING_SIGNAL));
+    SpanContext spanContext = Span.fromContext(context).getSpanContext();
+    if (profile) {
+      registry.register(spanContext);
+    }
+    return context;
+  }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/Volume.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/Volume.java
@@ -1,0 +1,23 @@
+package com.splunk.opentelemetry.profiler.snapshot;
+
+public enum Volume {
+  OFF,
+  HIGHEST;
+
+  static Volume fromString(String value) {
+    if (value == null) {
+      return OFF;
+    }
+
+    try {
+      return Volume.valueOf(value.toUpperCase());
+    } catch (IllegalArgumentException e) {
+      return OFF;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return name().toLowerCase();
+  }
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/Volume.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/Volume.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.opentelemetry.profiler.snapshot;
 
 public enum Volume {

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/DistributedProfilingSignalTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/DistributedProfilingSignalTest.java
@@ -62,7 +62,7 @@ class DistributedProfilingSignalTest {
           .build();
 
   @Test
-  void traceProfilingSignalPropagatesAcrossProcessBoundaries() {
+  void traceSnapshotVolumePropagatesAcrossProcessBoundaries() {
     var message = new Message();
 
     upstream.send(message);

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/DistributedProfilingSignalTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/DistributedProfilingSignalTest.java
@@ -1,11 +1,17 @@
 /*
- * 2024 Copyright (C) AppDynamics, Inc., and its affiliates
- * All Rights Reserved
- */
-
-/*
- * Copyright The OpenTelemetry Authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.splunk.opentelemetry.profiler.snapshot;
@@ -28,7 +34,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 class DistributedProfilingSignalTest {
   private final RecordingTraceRegistry downstreamRegistry = new RecordingTraceRegistry();
-  private final SnapshotProfilingSdkCustomizer downstreamCustomizer = new SnapshotProfilingSdkCustomizer(downstreamRegistry);
+  private final SnapshotProfilingSdkCustomizer downstreamCustomizer =
+      new SnapshotProfilingSdkCustomizer(downstreamRegistry);
 
   @RegisterExtension
   public final OpenTelemetrySdkExtension downstreamSdk =
@@ -45,7 +52,8 @@ class DistributedProfilingSignalTest {
           .build();
 
   private final RecordingTraceRegistry upstreamRegistry = new RecordingTraceRegistry();
-  private final SnapshotProfilingSdkCustomizer upstreamCustomizer = new SnapshotProfilingSdkCustomizer(upstreamRegistry);
+  private final SnapshotProfilingSdkCustomizer upstreamCustomizer =
+      new SnapshotProfilingSdkCustomizer(upstreamRegistry);
 
   @RegisterExtension
   public final OpenTelemetrySdkExtension upstreamSdk =
@@ -56,10 +64,7 @@ class DistributedProfilingSignalTest {
 
   @RegisterExtension
   public final Server upstream =
-      Server.builder(upstreamSdk)
-          .named("upstream")
-          .performing(ExitCall.to(downstream))
-          .build();
+      Server.builder(upstreamSdk).named("upstream").performing(ExitCall.to(downstream)).build();
 
   @Test
   void traceSnapshotVolumePropagatesAcrossProcessBoundaries() {

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/DistributedProfilingSignalTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/DistributedProfilingSignalTest.java
@@ -1,0 +1,110 @@
+/*
+ * 2024 Copyright (C) AppDynamics, Inc., and its affiliates
+ * All Rights Reserved
+ */
+
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.splunk.opentelemetry.profiler.snapshot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.splunk.opentelemetry.profiler.snapshot.simulation.ExitCall;
+import com.splunk.opentelemetry.profiler.snapshot.simulation.Message;
+import com.splunk.opentelemetry.profiler.snapshot.simulation.Server;
+import io.opentelemetry.api.trace.SpanContext;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.UnaryOperator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class DistributedProfilingSignalTest {
+  private final RecordingTraceRegistry downstreamRegistry = new RecordingTraceRegistry();
+  private final SnapshotProfilingSdkCustomizer downstreamCustomizer = new SnapshotProfilingSdkCustomizer(downstreamRegistry);
+
+  @RegisterExtension
+  public final OpenTelemetrySdkExtension downstreamSdk =
+      OpenTelemetrySdkExtension.builder()
+          .withProperty("splunk.snapshot.profiler.enabled", "true")
+          .with(downstreamCustomizer)
+          .build();
+
+  @RegisterExtension
+  public final Server downstream =
+      Server.builder(downstreamSdk)
+          .named("downstream")
+          .performing(delayOf(Duration.ofMillis(250)))
+          .build();
+
+  private final RecordingTraceRegistry upstreamRegistry = new RecordingTraceRegistry();
+  private final SnapshotProfilingSdkCustomizer upstreamCustomizer = new SnapshotProfilingSdkCustomizer(upstreamRegistry);
+
+  @RegisterExtension
+  public final OpenTelemetrySdkExtension upstreamSdk =
+      OpenTelemetrySdkExtension.builder()
+          .withProperty("splunk.snapshot.profiler.enabled", "true")
+          .with(upstreamCustomizer)
+          .build();
+
+  @RegisterExtension
+  public final Server upstream =
+      Server.builder(upstreamSdk)
+          .named("upstream")
+          .performing(ExitCall.to(downstream))
+          .build();
+
+  @Test
+  void traceProfilingSignalPropagatesAcrossProcessBoundaries() {
+    var message = new Message();
+
+    upstream.send(message);
+
+    await().atMost(Duration.ofSeconds(2)).until(() -> upstream.waitForResponse() != null);
+    assertThat(upstreamRegistry.registeredTraceIds()).isNotEmpty();
+    assertThat(downstreamRegistry.registeredTraceIds()).isNotEmpty();
+    assertEquals(upstreamRegistry.registeredTraceIds(), downstreamRegistry.registeredTraceIds());
+  }
+
+  private UnaryOperator<Message> delayOf(Duration duration) {
+    return message -> {
+      try {
+        Thread.sleep(duration.toMillis());
+        return message;
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    };
+  }
+
+  private static class RecordingTraceRegistry extends TraceRegistry {
+    private final Set<String> registeredTraceIds = new HashSet<>();
+
+    @Override
+    public void register(SpanContext spanContext) {
+      registeredTraceIds.add(spanContext.getTraceId());
+      super.register(spanContext);
+    }
+
+    @Override
+    public boolean isRegistered(SpanContext spanContext) {
+      return super.isRegistered(spanContext);
+    }
+
+    @Override
+    public void unregister(SpanContext spanContext) {
+      super.unregister(spanContext);
+    }
+
+    Set<String> registeredTraceIds() {
+      return Collections.unmodifiableSet(registeredTraceIds);
+    }
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/ObservableCarrier.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/ObservableCarrier.java
@@ -1,23 +1,28 @@
 /*
- * 2024 Copyright (C) AppDynamics, Inc., and its affiliates
- * All Rights Reserved
- */
-
-/*
- * Copyright The OpenTelemetry Authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.splunk.opentelemetry.profiler.snapshot;
 
 import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.context.propagation.TextMapSetter;
-import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Test-only "Carrier" that also implements of both the {@link TextMapGetter} and {@link

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/ObservableCarrier.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/ObservableCarrier.java
@@ -1,0 +1,72 @@
+/*
+ * 2024 Copyright (C) AppDynamics, Inc., and its affiliates
+ * All Rights Reserved
+ */
+
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.splunk.opentelemetry.profiler.snapshot;
+
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapSetter;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Test-only "Carrier" that also implements of both the {@link TextMapGetter} and {@link
+ * TextMapSetter} interfaces. Intended for use with {@link
+ * io.opentelemetry.context.propagation.TextMapPropagator} implementations.
+ *
+ * <p>Allows for getting and setting values either directly or indirectly through the OpenTelemetry
+ * {@link TextMapGetter} and {@link TextMapSetter} interfaces.
+ */
+class ObservableCarrier
+    implements TextMapSetter<ObservableCarrier>,
+        TextMapGetter<ObservableCarrier>,
+        AfterEachCallback {
+  private final Map<String, String> fields = new HashMap<>();
+
+  @Override
+  public Iterable<String> keys(ObservableCarrier carrier) {
+    return carrier.keys();
+  }
+
+  public Set<String> keys() {
+    return fields.keySet();
+  }
+
+  @Override
+  public String get(ObservableCarrier carrier, String key) {
+    if (carrier == null) {
+      return null;
+    }
+    return carrier.get(key);
+  }
+
+  public String get(String key) {
+    return fields.get(key);
+  }
+
+  @Override
+  public void set(ObservableCarrier carrier, String key, String value) {
+    if (carrier != null) {
+      carrier.set(key, value);
+    }
+  }
+
+  public void set(String key, String value) {
+    fields.put(key, value);
+  }
+
+  @Override
+  public void afterEach(ExtensionContext extensionContext) {
+    fields.clear();
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/OpenTelemetrySdkExtension.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/OpenTelemetrySdkExtension.java
@@ -48,7 +48,8 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolver;
 
-public class OpenTelemetrySdkExtension implements OpenTelemetry, AfterEachCallback, ParameterResolver {
+public class OpenTelemetrySdkExtension
+    implements OpenTelemetry, AfterEachCallback, ParameterResolver {
   public static Builder builder() {
     return new Builder();
   }
@@ -132,10 +133,11 @@ public class OpenTelemetrySdkExtension implements OpenTelemetry, AfterEachCallba
       TextMapPropagator propagator = customizePropagators(configProperties);
       ContextPropagators contextPropagators = ContextPropagators.create(propagator);
 
-      OpenTelemetrySdk sdk = OpenTelemetrySdk.builder()
-          .setTracerProvider(tracerProvider)
-          .setPropagators(contextPropagators)
-          .build();
+      OpenTelemetrySdk sdk =
+          OpenTelemetrySdk.builder()
+              .setTracerProvider(tracerProvider)
+              .setPropagators(contextPropagators)
+              .build();
       return new OpenTelemetrySdkExtension(sdk);
     }
 

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/OpenTelemetrySdkExtension.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/OpenTelemetrySdkExtension.java
@@ -16,7 +16,9 @@
 
 package com.splunk.opentelemetry.profiler.snapshot;
 
+import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
@@ -102,6 +104,8 @@ public class OpenTelemetrySdkExtension implements AfterEachCallback, ParameterRe
       ConfigProperties configProperties = customizeProperties();
       SdkTracerProvider tracerProvider = customizeTracerProvider(configProperties);
 
+      TextMapPropagator propagator = customizePropagators(configProperties);
+
       OpenTelemetrySdk sdk = OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build();
       return new OpenTelemetrySdkExtension(sdk);
     }
@@ -121,6 +125,18 @@ public class OpenTelemetrySdkExtension implements AfterEachCallback, ParameterRe
           customizer -> customizer.apply(builder, properties));
       return builder.build();
     }
+
+    private TextMapPropagator customizePropagators(ConfigProperties properties) {
+      var propagators = new ArrayList<TextMapPropagator>();
+      for (var propagator : configuredPropagators()) {
+        propagators.add(customizer.textMapPropagatorBifunction.apply(propagator, properties));
+      }
+      return TextMapPropagator.composite(propagators);
+    }
+
+    private List<TextMapPropagator> configuredPropagators() {
+      return List.of(W3CTraceContextPropagator.getInstance(), W3CBaggagePropagator.getInstance());
+    }
   }
 
   private static class SdkCustomizer implements AutoConfigurationCustomizer {
@@ -129,6 +145,8 @@ public class OpenTelemetrySdkExtension implements AfterEachCallback, ParameterRe
     private final List<
             BiFunction<SdkTracerProviderBuilder, ConfigProperties, SdkTracerProviderBuilder>>
         tracerProviderCustomizers = new ArrayList<>();
+    BiFunction<? super TextMapPropagator, ConfigProperties, ? extends TextMapPropagator>
+        textMapPropagatorBifunction = (a, unused) -> a;
 
     @Override
     public AutoConfigurationCustomizer addTracerProviderCustomizer(
@@ -142,6 +160,7 @@ public class OpenTelemetrySdkExtension implements AfterEachCallback, ParameterRe
     public AutoConfigurationCustomizer addPropagatorCustomizer(
         BiFunction<? super TextMapPropagator, ConfigProperties, ? extends TextMapPropagator>
             textMapPropagator) {
+      textMapPropagatorBifunction = Objects.requireNonNull(textMapPropagator);
       return this;
     }
 

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSignalPropagatorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSignalPropagatorTest.java
@@ -19,22 +19,22 @@ class SnapshotProfilingSignalPropagatorTest {
 
   @Test
   void propagatorReportsOnlyProfilingSignalField() {
-    assertEquals(List.of("splunk.trace.snapshot"), propagator.fields());
+    assertEquals(List.of("splunk.trace.snapshot.volume"), propagator.fields());
   }
 
   @Test
-  void attachProfilingSignalToCarrierWhenTraceIsRegisteredForProfiling(Tracer tracer) {
+  void attachTraceSnapshotVolumeToCarrierWhenTraceIsRegisteredForProfiling(Tracer tracer) {
     var span = tracer.spanBuilder("span").startSpan();
     var context = Context.current().with(span);
     registry.register(span.getSpanContext());
 
     propagator.inject(context, carrier, carrier);
 
-    assertEquals("true", carrier.get("splunk.trace.snapshot"));
+    assertEquals(Volume.HIGHEST.toString(), carrier.get("splunk.trace.snapshot.volume"));
   }
 
   @Test
-  void doNotAttachProfilingSignalToCarrierWhenTraceNotRegisteredForProfiling(Tracer tracer) {
+  void doNotAttachTraceSnapshotVolumeToCarrierWhenTraceNotRegisteredForProfiling(Tracer tracer) {
     var span = tracer.spanBuilder("span").startSpan();
     var context = Context.current().with(span);
 
@@ -44,8 +44,8 @@ class SnapshotProfilingSignalPropagatorTest {
   }
 
   @Test
-  void registerTraceForProfilingWhenProfilingSignalIsTrue(Tracer tracer) {
-    carrier.set("splunk.trace.snapshot", "true");
+  void registerTraceForProfilingWhenTraceSnapshotVolumeIsHighest(Tracer tracer) {
+    carrier.set("splunk.trace.snapshot.volume", Volume.HIGHEST.toString());
     var span = tracer.spanBuilder("span").startSpan();
     var context = Context.current().with(span);
 
@@ -56,7 +56,7 @@ class SnapshotProfilingSignalPropagatorTest {
 
   @Test
   void extractReturnsProvidedContextWhenRegisteringTraceForProfiling(Tracer tracer) {
-    carrier.set("splunk.trace.snapshot", "true");
+    carrier.set("splunk.trace.snapshot.volume", Volume.HIGHEST.toString());
     var span = tracer.spanBuilder("span").startSpan();
     var context = Context.current().with(span);
 
@@ -66,8 +66,8 @@ class SnapshotProfilingSignalPropagatorTest {
   }
 
   @Test
-  void doNotRegisterTraceForProfilingWhenProfilingSignalIsFalse(Tracer tracer) {
-    carrier.set("appdynamics-profiling", "false");
+  void doNotRegisterTraceForProfilingWhenTraceSnapshotVolumeIsOff(Tracer tracer) {
+    carrier.set("splunk.trace.snapshot.volume", Volume.OFF.toString());
     var span = tracer.spanBuilder("span").startSpan();
     var context = Context.current().with(span);
 
@@ -77,7 +77,7 @@ class SnapshotProfilingSignalPropagatorTest {
   }
 
   @Test
-  void doNotRegisterTraceForProfilingWhenProfilingSignalIsMissing(Tracer tracer) {
+  void doNotRegisterTraceForProfilingWhenTraceSnapshotVolumeIsMissing(Tracer tracer) {
     var span = tracer.spanBuilder("span").startSpan();
     var context = Context.current().with(span);
 

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSignalPropagatorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSignalPropagatorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.opentelemetry.profiler.snapshot;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -11,11 +27,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class SnapshotProfilingSignalPropagatorTest {
-  @RegisterExtension public final OpenTelemetrySdkExtension sdk = OpenTelemetrySdkExtension.builder().build();
+  @RegisterExtension
+  public final OpenTelemetrySdkExtension sdk = OpenTelemetrySdkExtension.builder().build();
+
   @RegisterExtension public final ObservableCarrier carrier = new ObservableCarrier();
 
   private final TraceRegistry registry = new TraceRegistry();
-  private final SnapshotProfilingSignalPropagator propagator = new SnapshotProfilingSignalPropagator(registry);
+  private final SnapshotProfilingSignalPropagator propagator =
+      new SnapshotProfilingSignalPropagator(registry);
 
   @Test
   void propagatorReportsOnlyProfilingSignalField() {

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSignalPropagatorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSignalPropagatorTest.java
@@ -1,0 +1,98 @@
+package com.splunk.opentelemetry.profiler.snapshot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class SnapshotProfilingSignalPropagatorTest {
+  @RegisterExtension public final OpenTelemetrySdkExtension sdk = OpenTelemetrySdkExtension.builder().build();
+  @RegisterExtension public final ObservableCarrier carrier = new ObservableCarrier();
+
+  private final TraceRegistry registry = new TraceRegistry();
+  private final SnapshotProfilingSignalPropagator propagator = new SnapshotProfilingSignalPropagator(registry);
+
+  @Test
+  void propagatorReportsOnlyProfilingSignalField() {
+    assertEquals(List.of("splunk.trace.snapshot"), propagator.fields());
+  }
+
+  @Test
+  void attachProfilingSignalToCarrierWhenTraceIsRegisteredForProfiling(Tracer tracer) {
+    var span = tracer.spanBuilder("span").startSpan();
+    var context = Context.current().with(span);
+    registry.register(span.getSpanContext());
+
+    propagator.inject(context, carrier, carrier);
+
+    assertEquals("true", carrier.get("splunk.trace.snapshot"));
+  }
+
+  @Test
+  void doNotAttachProfilingSignalToCarrierWhenTraceNotRegisteredForProfiling(Tracer tracer) {
+    var span = tracer.spanBuilder("span").startSpan();
+    var context = Context.current().with(span);
+
+    propagator.inject(context, carrier, carrier);
+
+    assertEquals(Collections.emptySet(), carrier.keys());
+  }
+
+  @Test
+  void registerTraceForProfilingWhenProfilingSignalIsTrue(Tracer tracer) {
+    carrier.set("splunk.trace.snapshot", "true");
+    var span = tracer.spanBuilder("span").startSpan();
+    var context = Context.current().with(span);
+
+    propagator.extract(context, carrier, carrier);
+
+    assertThat(registry.isRegistered(span.getSpanContext())).isTrue();
+  }
+
+  @Test
+  void extractReturnsProvidedContextWhenRegisteringTraceForProfiling(Tracer tracer) {
+    carrier.set("splunk.trace.snapshot", "true");
+    var span = tracer.spanBuilder("span").startSpan();
+    var context = Context.current().with(span);
+
+    var fromPropagator = propagator.extract(context, carrier, carrier);
+
+    assertEquals(context, fromPropagator);
+  }
+
+  @Test
+  void doNotRegisterTraceForProfilingWhenProfilingSignalIsFalse(Tracer tracer) {
+    carrier.set("appdynamics-profiling", "false");
+    var span = tracer.spanBuilder("span").startSpan();
+    var context = Context.current().with(span);
+
+    propagator.extract(context, carrier, carrier);
+
+    assertThat(registry.isRegistered(span.getSpanContext())).isFalse();
+  }
+
+  @Test
+  void doNotRegisterTraceForProfilingWhenProfilingSignalIsMissing(Tracer tracer) {
+    var span = tracer.spanBuilder("span").startSpan();
+    var context = Context.current().with(span);
+
+    propagator.extract(context, carrier, carrier);
+
+    assertThat(registry.isRegistered(span.getSpanContext())).isFalse();
+  }
+
+  @Test
+  void extractReturnsProvidedContextWhenNotRegisteringTraceForProfiling(Tracer tracer) {
+    var span = tracer.spanBuilder("span").startSpan();
+    var context = Context.current().with(span);
+
+    var fromPropagator = propagator.extract(context, carrier, carrier);
+
+    assertEquals(context, fromPropagator);
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/VolumeTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/VolumeTest.java
@@ -1,0 +1,45 @@
+package com.splunk.opentelemetry.profiler.snapshot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class VolumeTest {
+  @ParameterizedTest
+  @MethodSource("volumesAsStrings")
+  void toStringRepresentation(Volume volume, String asString) {
+    assertEquals(asString, volume.toString());
+  }
+
+  @ParameterizedTest
+  @MethodSource("volumesAsStrings")
+  void fromStringRepresentation(Volume volume, String asString) {
+    assertEquals(volume, Volume.fromString(asString));
+  }
+
+  private static Stream<Arguments> volumesAsStrings() {
+    return Stream.of(
+        Arguments.of(Volume.OFF, "off"),
+        Arguments.of(Volume.HIGHEST, "highest")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("notVolumes")
+  void fromStringReturnsOffWhenMatchNotFound(String value) {
+    var volume = Volume.fromString(value);
+    assertEquals(Volume.OFF, volume);
+  }
+
+  private static Stream<Arguments> notVolumes() {
+    return Stream.of(
+        Arguments.of("not-a-volume"),
+        Arguments.of((String)null)
+    );
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/VolumeTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/VolumeTest.java
@@ -1,13 +1,27 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.opentelemetry.profiler.snapshot;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 class VolumeTest {
   @ParameterizedTest
@@ -23,10 +37,7 @@ class VolumeTest {
   }
 
   private static Stream<Arguments> volumesAsStrings() {
-    return Stream.of(
-        Arguments.of(Volume.OFF, "off"),
-        Arguments.of(Volume.HIGHEST, "highest")
-    );
+    return Stream.of(Arguments.of(Volume.OFF, "off"), Arguments.of(Volume.HIGHEST, "highest"));
   }
 
   @ParameterizedTest
@@ -37,9 +48,6 @@ class VolumeTest {
   }
 
   private static Stream<Arguments> notVolumes() {
-    return Stream.of(
-        Arguments.of("not-a-volume"),
-        Arguments.of((String)null)
-    );
+    return Stream.of(Arguments.of("not-a-volume"), Arguments.of((String) null));
   }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/simulation/ExitCall.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/simulation/ExitCall.java
@@ -1,11 +1,17 @@
 /*
- * 2024 Copyright (C) AppDynamics, Inc., and its affiliates
- * All Rights Reserved
- */
-
-/*
- * Copyright The OpenTelemetry Authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.splunk.opentelemetry.profiler.snapshot.simulation;

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/simulation/ExitCall.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/simulation/ExitCall.java
@@ -1,0 +1,68 @@
+/*
+ * 2024 Copyright (C) AppDynamics, Inc., and its affiliates
+ * All Rights Reserved
+ */
+
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.splunk.opentelemetry.profiler.snapshot.simulation;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import java.util.function.UnaryOperator;
+
+public class ExitCall implements UnaryOperator<Message> {
+  public static Builder to(Server server) {
+    return new Builder(server);
+  }
+
+  private final OpenTelemetry otel;
+  private final Server server;
+
+  private ExitCall(Builder builder) {
+    this.otel = builder.otel;
+    this.server = builder.server;
+  }
+
+  @Override
+  public Message apply(Message input) {
+    var tracer = otel.getTracer(ExitCall.class.getName());
+    var span =
+        tracer
+            .spanBuilder("send")
+            .setSpanKind(SpanKind.CLIENT)
+            .setParent(Context.current())
+            .startSpan();
+
+    try (Scope ignored = span.makeCurrent()) {
+      otel.getPropagators().getTextMapPropagator().inject(Context.current(), input, Message::put);
+      server.send(input);
+      return server.waitForResponse();
+    } finally {
+      span.end();
+    }
+  }
+
+  public static class Builder {
+    private final Server server;
+    private OpenTelemetry otel;
+
+    private Builder(Server server) {
+      this.server = server;
+    }
+
+    public Builder with(OpenTelemetry otel) {
+      this.otel = otel;
+      return this;
+    }
+
+    public ExitCall build() {
+      return new ExitCall(this);
+    }
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/simulation/Message.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/simulation/Message.java
@@ -1,11 +1,17 @@
 /*
- * 2024 Copyright (C) AppDynamics, Inc., and its affiliates
- * All Rights Reserved
- */
-
-/*
- * Copyright The OpenTelemetry Authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.splunk.opentelemetry.profiler.snapshot.simulation;

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/simulation/Message.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/simulation/Message.java
@@ -1,0 +1,97 @@
+/*
+ * 2024 Copyright (C) AppDynamics, Inc., and its affiliates
+ * All Rights Reserved
+ */
+
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.splunk.opentelemetry.profiler.snapshot.simulation;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class Message implements Map<String, String> {
+  private final Map<String, String> map = new ConcurrentHashMap<>();
+
+  @Override
+  public int size() {
+    return map.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return map.isEmpty();
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    return map.containsKey(key);
+  }
+
+  @Override
+  public boolean containsValue(Object value) {
+    return map.containsValue(value);
+  }
+
+  @Override
+  public String get(Object key) {
+    return map.get(key);
+  }
+
+  @Override
+  public String put(String key, String value) {
+    return map.put(key, value);
+  }
+
+  @Override
+  public String remove(Object key) {
+    return map.remove(key);
+  }
+
+  @Override
+  public void putAll(Map<? extends String, ? extends String> otherMap) {
+    map.putAll(otherMap);
+  }
+
+  @Override
+  public void clear() {}
+
+  @Override
+  public Set<String> keySet() {
+    return map.keySet();
+  }
+
+  @Override
+  public Collection<String> values() {
+    return map.values();
+  }
+
+  @Override
+  public Set<Entry<String, String>> entrySet() {
+    return map.entrySet();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Message message = (Message) o;
+    return Objects.equals(map, message.map);
+  }
+
+  @Override
+  public int hashCode() {
+    return map.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return map.toString();
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/simulation/Server.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/simulation/Server.java
@@ -1,11 +1,17 @@
 /*
- * 2024 Copyright (C) AppDynamics, Inc., and its affiliates
- * All Rights Reserved
- */
-
-/*
- * Copyright The OpenTelemetry Authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.splunk.opentelemetry.profiler.snapshot.simulation;
@@ -15,15 +21,14 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.TextMapGetter;
-import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.BeforeEachCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
-
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.UnaryOperator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 public class Server extends Thread implements BeforeEachCallback, AfterEachCallback {
   private static final Logger logger = Logger.getLogger(Server.class.getName());
@@ -38,7 +43,6 @@ public class Server extends Thread implements BeforeEachCallback, AfterEachCallb
   private final OpenTelemetry otel;
   private final UnaryOperator<Message> operation;
   private boolean shutdown = false;
-
 
   private Server(Builder builder) {
     super(builder.name);

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/simulation/Server.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/simulation/Server.java
@@ -15,17 +15,18 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.TextMapGetter;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.function.UnaryOperator;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.UnaryOperator;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class Server extends Thread implements BeforeEachCallback, AfterEachCallback {
-  private static final Logger logger = LoggerFactory.getLogger(Server.class);
+  private static final Logger logger = Logger.getLogger(Server.class.getName());
 
   public static Builder builder(OpenTelemetry otel) {
     return new Builder(otel);
@@ -63,7 +64,7 @@ public class Server extends Thread implements BeforeEachCallback, AfterEachCallb
       try {
         accept(requests.take());
       } catch (InterruptedException e) {
-        logger.error("Interrupted while waiting for message", e);
+        logger.log(Level.WARNING, e.getMessage(), e);
       }
     }
   }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/simulation/Server.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/simulation/Server.java
@@ -1,0 +1,137 @@
+/*
+ * 2024 Copyright (C) AppDynamics, Inc., and its affiliates
+ * All Rights Reserved
+ */
+
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.splunk.opentelemetry.profiler.snapshot.simulation;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.UnaryOperator;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Server extends Thread implements BeforeEachCallback, AfterEachCallback {
+  private static final Logger logger = LoggerFactory.getLogger(Server.class);
+
+  public static Builder builder(OpenTelemetry otel) {
+    return new Builder(otel);
+  }
+
+  private final BlockingQueue<Message> requests = new LinkedBlockingQueue<>();
+  private final BlockingQueue<Message> responses = new LinkedBlockingQueue<>();
+
+  private final OpenTelemetry otel;
+  private final UnaryOperator<Message> operation;
+  private boolean shutdown = false;
+
+
+  private Server(Builder builder) {
+    super(builder.name);
+    this.otel = builder.otel;
+    this.operation = builder.operation;
+  }
+
+  public void send(Message message) {
+    requests.add(message);
+  }
+
+  public Message waitForResponse() {
+    try {
+      return responses.take();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void run() {
+    while (!shutdown && !Thread.currentThread().isInterrupted()) {
+      try {
+        accept(requests.take());
+      } catch (InterruptedException e) {
+        logger.error("Interrupted while waiting for message", e);
+      }
+    }
+  }
+
+  private void accept(Message message) {
+    var context =
+        otel.getPropagators()
+            .getTextMapPropagator()
+            .extract(Context.current(), message, new MessageGetter());
+
+    var tracer = otel.getTracer(Server.class.getName());
+    var span =
+        tracer.spanBuilder("process").setSpanKind(SpanKind.SERVER).setParent(context).startSpan();
+    try (Scope ignored = span.makeCurrent()) {
+      responses.add(operation.apply(message));
+    } finally {
+      span.end();
+    }
+  }
+
+  @Override
+  public void beforeEach(ExtensionContext extensionContext) {
+    start();
+  }
+
+  @Override
+  public void afterEach(ExtensionContext extensionContext) throws Exception {
+    shutdown = true;
+    join(1_000);
+  }
+
+  private static class MessageGetter implements TextMapGetter<Message> {
+    @Override
+    public Iterable<String> keys(Message message) {
+      return message.keySet();
+    }
+
+    @Override
+    public String get(Message message, String key) {
+      return message.get(key);
+    }
+  }
+
+  public static class Builder {
+    private final OpenTelemetry otel;
+    private String name;
+    private UnaryOperator<Message> operation = message -> message;
+
+    private Builder(OpenTelemetry otel) {
+      this.otel = otel;
+    }
+
+    public Builder named(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder performing(ExitCall.Builder builder) {
+      return performing(builder.with(otel).build());
+    }
+
+    public Builder performing(UnaryOperator<Message> operation) {
+      this.operation = operation;
+      return this;
+    }
+
+    public Server build() {
+      return new Server(this);
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a custom `TextMapPropagator` responsible for identifying when a trace has been selected for trace snapshotting and including a special header that downstream services can use to register the same trace for snapshotting.