### PR TITLE
Profiling instrumentation source

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/InstrumentationSource.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/InstrumentationSource.java
@@ -1,0 +1,6 @@
+package com.splunk.opentelemetry.profiler;
+
+public enum InstrumentationSource {
+  CONTINUOUS,
+  SNAPSHOT
+}

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/InstrumentationSource.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/InstrumentationSource.java
@@ -1,6 +1,18 @@
 package com.splunk.opentelemetry.profiler;
 
+import java.util.Locale;
+
 public enum InstrumentationSource {
   CONTINUOUS,
-  SNAPSHOT
+  SNAPSHOT;
+
+  private final String value;
+
+  InstrumentationSource() {
+    this.value = name().toLowerCase(Locale.ROOT);
+  }
+
+  public String value() {
+    return value;
+  }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/InstrumentationSource.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/InstrumentationSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.opentelemetry.profiler;
 
 import java.util.Locale;

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/ProfilingSemanticAttributes.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/ProfilingSemanticAttributes.java
@@ -39,6 +39,8 @@ public class ProfilingSemanticAttributes {
   public static final AttributeKey<String> DATA_FORMAT = stringKey("profiling.data.format");
   public static final String PPROF_GZIP_BASE64 = "pprof-gzip-base64";
   public static final AttributeKey<Long> FRAME_COUNT = longKey("profiling.data.total.frame.count");
+  public static final AttributeKey<String> INSTRUMENTATION_SOURCE =
+      stringKey("profiling.instrumentation.source");
 
   public static final AttributeKey<Long> THREAD_ID = longKey("thread.id");
   public static final AttributeKey<String> THREAD_NAME = stringKey("thread.name");

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/allocation/exporter/PprofAllocationEventExporter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/allocation/exporter/PprofAllocationEventExporter.java
@@ -52,7 +52,8 @@ public class PprofAllocationEventExporter implements AllocationEventExporter {
     this.eventReader = builder.eventReader;
     this.stackDepth = builder.stackDepth;
     this.pprofLogDataExporter =
-        new PprofLogDataExporter(builder.otelLogger, ProfilingDataType.ALLOCATION, InstrumentationSource.CONTINUOUS);
+        new PprofLogDataExporter(
+            builder.otelLogger, ProfilingDataType.ALLOCATION, InstrumentationSource.CONTINUOUS);
   }
 
   @Override

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/allocation/exporter/PprofAllocationEventExporter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/allocation/exporter/PprofAllocationEventExporter.java
@@ -29,6 +29,7 @@ import com.google.perftools.profiles.ProfileProto;
 import com.google.perftools.profiles.ProfileProto.Profile;
 import com.google.perftools.profiles.ProfileProto.Sample;
 import com.splunk.opentelemetry.profiler.EventReader;
+import com.splunk.opentelemetry.profiler.InstrumentationSource;
 import com.splunk.opentelemetry.profiler.ProfilingDataType;
 import com.splunk.opentelemetry.profiler.allocation.sampler.AllocationEventSampler;
 import com.splunk.opentelemetry.profiler.exporter.PprofLogDataExporter;
@@ -51,7 +52,7 @@ public class PprofAllocationEventExporter implements AllocationEventExporter {
     this.eventReader = builder.eventReader;
     this.stackDepth = builder.stackDepth;
     this.pprofLogDataExporter =
-        new PprofLogDataExporter(builder.otelLogger, ProfilingDataType.ALLOCATION);
+        new PprofLogDataExporter(builder.otelLogger, ProfilingDataType.ALLOCATION, InstrumentationSource.CONTINUOUS);
   }
 
   @Override

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/PprofCpuEventExporter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/PprofCpuEventExporter.java
@@ -27,6 +27,7 @@ import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.THRE
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.TRACE_ID;
 
 import com.google.perftools.profiles.ProfileProto.Sample;
+import com.splunk.opentelemetry.profiler.InstrumentationSource;
 import com.splunk.opentelemetry.profiler.ProfilingDataType;
 import com.splunk.opentelemetry.profiler.context.StackToSpanLinkage;
 import com.splunk.opentelemetry.profiler.events.EventPeriods;
@@ -46,7 +47,7 @@ public class PprofCpuEventExporter implements CpuEventExporter {
   private PprofCpuEventExporter(Builder builder) {
     this.eventPeriods = builder.eventPeriods;
     this.stackDepth = builder.stackDepth;
-    this.pprofLogDataExporter = new PprofLogDataExporter(builder.otelLogger, ProfilingDataType.CPU);
+    this.pprofLogDataExporter = new PprofLogDataExporter(builder.otelLogger, ProfilingDataType.CPU, InstrumentationSource.CONTINUOUS);
   }
 
   @Override

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/PprofCpuEventExporter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/PprofCpuEventExporter.java
@@ -47,7 +47,9 @@ public class PprofCpuEventExporter implements CpuEventExporter {
   private PprofCpuEventExporter(Builder builder) {
     this.eventPeriods = builder.eventPeriods;
     this.stackDepth = builder.stackDepth;
-    this.pprofLogDataExporter = new PprofLogDataExporter(builder.otelLogger, ProfilingDataType.CPU, InstrumentationSource.CONTINUOUS);
+    this.pprofLogDataExporter =
+        new PprofLogDataExporter(
+            builder.otelLogger, ProfilingDataType.CPU, InstrumentationSource.CONTINUOUS);
   }
 
   @Override

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporter.java
@@ -24,6 +24,7 @@ import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.PROF
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SOURCE_TYPE;
 import static java.util.logging.Level.FINE;
 
+import com.splunk.opentelemetry.profiler.InstrumentationSource;
 import com.splunk.opentelemetry.profiler.ProfilingDataType;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.logs.Logger;
@@ -38,6 +39,10 @@ public class PprofLogDataExporter {
   private final Attributes commonAttributes;
 
   public PprofLogDataExporter(Logger otelLogger, ProfilingDataType dataType) {
+    this(otelLogger, dataType, InstrumentationSource.CONTINUOUS);
+  }
+
+  public PprofLogDataExporter(Logger otelLogger, ProfilingDataType dataType, InstrumentationSource instrumentationSource) {
     this.otelLogger = otelLogger;
     this.dataType = dataType;
     this.commonAttributes =
@@ -45,6 +50,7 @@ public class PprofLogDataExporter {
             .put(SOURCE_TYPE, PROFILING_SOURCE)
             .put(DATA_TYPE, dataType.value())
             .put(DATA_FORMAT, PPROF_GZIP_BASE64)
+            .put("profiling.instrumentation.source", instrumentationSource.toString())
             .build();
   }
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporter.java
@@ -50,7 +50,7 @@ public class PprofLogDataExporter {
             .put(SOURCE_TYPE, PROFILING_SOURCE)
             .put(DATA_TYPE, dataType.value())
             .put(DATA_FORMAT, PPROF_GZIP_BASE64)
-            .put("profiling.instrumentation.source", instrumentationSource.toString())
+            .put("profiling.instrumentation.source", instrumentationSource.value())
             .build();
   }
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporter.java
@@ -19,6 +19,7 @@ package com.splunk.opentelemetry.profiler.exporter;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.DATA_FORMAT;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.DATA_TYPE;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.FRAME_COUNT;
+import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.INSTRUMENTATION_SOURCE;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.PPROF_GZIP_BASE64;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.PROFILING_SOURCE;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SOURCE_TYPE;
@@ -47,7 +48,7 @@ public class PprofLogDataExporter {
             .put(SOURCE_TYPE, PROFILING_SOURCE)
             .put(DATA_TYPE, dataType.value())
             .put(DATA_FORMAT, PPROF_GZIP_BASE64)
-            .put("profiling.instrumentation.source", instrumentationSource.value())
+            .put(INSTRUMENTATION_SOURCE, instrumentationSource.value())
             .build();
   }
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporter.java
@@ -38,7 +38,8 @@ public class PprofLogDataExporter {
   private final ProfilingDataType dataType;
   private final Attributes commonAttributes;
 
-  public PprofLogDataExporter(Logger otelLogger, ProfilingDataType dataType, InstrumentationSource instrumentationSource) {
+  public PprofLogDataExporter(
+      Logger otelLogger, ProfilingDataType dataType, InstrumentationSource instrumentationSource) {
     this.otelLogger = otelLogger;
     this.dataType = dataType;
     this.commonAttributes =

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporter.java
@@ -38,10 +38,6 @@ public class PprofLogDataExporter {
   private final ProfilingDataType dataType;
   private final Attributes commonAttributes;
 
-  public PprofLogDataExporter(Logger otelLogger, ProfilingDataType dataType) {
-    this(otelLogger, dataType, InstrumentationSource.CONTINUOUS);
-  }
-
   public PprofLogDataExporter(Logger otelLogger, ProfilingDataType dataType, InstrumentationSource instrumentationSource) {
     this.otelLogger = otelLogger;
     this.dataType = dataType;

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/InstrumentationSourceTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/InstrumentationSourceTest.java
@@ -1,0 +1,17 @@
+package com.splunk.opentelemetry.profiler;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class InstrumentationSourceTest {
+  @ParameterizedTest
+  @EnumSource(InstrumentationSource.class)
+  void valueIsLowerCaseOfEnumName(InstrumentationSource source) {
+    var value = source.value();
+    assertEquals(source.name().toLowerCase(Locale.ROOT), value);
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/InstrumentationSourceTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/InstrumentationSourceTest.java
@@ -1,11 +1,26 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.opentelemetry.profiler;
 
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Locale;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class InstrumentationSourceTest {
   @ParameterizedTest

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/exporter/InMemoryOtelLogger.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/exporter/InMemoryOtelLogger.java
@@ -1,11 +1,17 @@
 /*
- * 2024 Copyright (C) AppDynamics, Inc., and its affiliates
- * All Rights Reserved
- */
-
-/*
- * Copyright The OpenTelemetry Authors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.splunk.opentelemetry.profiler.exporter;

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/exporter/InMemoryOtelLogger.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/exporter/InMemoryOtelLogger.java
@@ -1,0 +1,220 @@
+/*
+ * 2024 Copyright (C) AppDynamics, Inc., and its affiliates
+ * All Rights Reserved
+ */
+
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.splunk.opentelemetry.profiler.exporter;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.logs.LogRecordBuilder;
+import io.opentelemetry.api.logs.Logger;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.logs.data.Body;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
+import io.opentelemetry.sdk.resources.Resource;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * In memory implementation of the OpenTelemetry {@link Logger} interface that allows for direct
+ * access to the collected logs. Intended for testing use only.
+ */
+class InMemoryOtelLogger implements Logger, AfterEachCallback {
+  private final List<LogRecordData> records = new ArrayList<>();
+
+  @Override
+  public LogRecordBuilder logRecordBuilder() {
+    return new Builder(this);
+  }
+
+  @Override
+  public void afterEach(ExtensionContext extensionContext) {
+    records.clear();
+  }
+
+  List<LogRecordData> records() {
+    return Collections.unmodifiableList(records);
+  }
+
+  static class Builder implements LogRecordBuilder {
+    private final InMemoryOtelLogger logger;
+    private long timestampEpochNanos;
+    private long observedTimestampEpochNanos;
+    private Context context = Context.current();
+    private Severity severity = Severity.UNDEFINED_SEVERITY_NUMBER;
+    private String severityText = "";
+    private String body = "";
+    private final AttributesBuilder attributes = Attributes.builder();
+
+    private Builder(InMemoryOtelLogger logger) {
+      this.logger = logger;
+    }
+
+    @Override
+    public LogRecordBuilder setTimestamp(Instant instant) {
+      return setTimestamp(instant.toEpochMilli(), TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public LogRecordBuilder setTimestamp(long timestamp, TimeUnit unit) {
+      this.timestampEpochNanos = unit.toNanos(timestamp);
+      return this;
+    }
+
+    @Override
+    public LogRecordBuilder setObservedTimestamp(Instant instant) {
+      return setObservedTimestamp(instant.toEpochMilli(), TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public LogRecordBuilder setObservedTimestamp(long timestamp, TimeUnit unit) {
+      this.observedTimestampEpochNanos = unit.toNanos(timestamp);
+      return this;
+    }
+
+    @Override
+    public LogRecordBuilder setContext(Context context) {
+      this.context = Objects.requireNonNull(context);
+      return this;
+    }
+
+    @Override
+    public LogRecordBuilder setSeverity(Severity severity) {
+      this.severity = Objects.requireNonNull(severity);
+      return this;
+    }
+
+    @Override
+    public LogRecordBuilder setSeverityText(String severityText) {
+      this.severityText = Objects.requireNonNull(severityText);
+      return this;
+    }
+
+    @Override
+    public LogRecordBuilder setBody(String body) {
+      this.body = Objects.requireNonNull(body);
+      return this;
+    }
+
+    @Override
+    public <T> LogRecordBuilder setAttribute(AttributeKey<T> key, T value) {
+      attributes.put(Objects.requireNonNull(key), Objects.requireNonNull(value));
+      return this;
+    }
+
+    @Override
+    public void emit() {
+      logger.records.add(
+          new LogRecord(
+              null,
+              null,
+              timestampEpochNanos,
+              observedTimestampEpochNanos,
+              Span.fromContext(context).getSpanContext(),
+              severity,
+              severityText,
+              Body.string(body),
+              attributes.build()));
+    }
+  }
+
+  static class LogRecord implements LogRecordData {
+    private final Resource resource;
+    private final InstrumentationScopeInfo instrumentationScopeInfo;
+    private final long timestampEpochNanos;
+    private final long observedTimestampEpochNanos;
+    private final SpanContext spanContext;
+    private final Severity severity;
+    private final String severityText;
+    private final Body body;
+    private final Attributes attributes;
+
+    LogRecord(
+        Resource resource,
+        InstrumentationScopeInfo instrumentationScopeInfo,
+        long timestampEpochNanos,
+        long observedTimestampEpochNanos,
+        SpanContext spanContext,
+        Severity severity,
+        String severityText,
+        Body body,
+        Attributes attributes) {
+      this.resource = resource;
+      this.instrumentationScopeInfo = instrumentationScopeInfo;
+      this.timestampEpochNanos = timestampEpochNanos;
+      this.observedTimestampEpochNanos = observedTimestampEpochNanos;
+      this.spanContext = spanContext;
+      this.severity = severity;
+      this.severityText = severityText;
+      this.body = body;
+      this.attributes = attributes;
+    }
+
+    @Override
+    public Resource getResource() {
+      return resource;
+    }
+
+    @Override
+    public InstrumentationScopeInfo getInstrumentationScopeInfo() {
+      return instrumentationScopeInfo;
+    }
+
+    @Override
+    public long getTimestampEpochNanos() {
+      return timestampEpochNanos;
+    }
+
+    @Override
+    public long getObservedTimestampEpochNanos() {
+      return observedTimestampEpochNanos;
+    }
+
+    @Override
+    public SpanContext getSpanContext() {
+      return spanContext;
+    }
+
+    @Override
+    public Severity getSeverity() {
+      return severity;
+    }
+
+    @Override
+    public String getSeverityText() {
+      return severityText;
+    }
+
+    @Override
+    public Body getBody() {
+      return body;
+    }
+
+    @Override
+    public Attributes getAttributes() {
+      return attributes;
+    }
+
+    @Override
+    public int getTotalAttributeCount() {
+      return attributes.size();
+    }
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporterTest.java
@@ -68,6 +68,6 @@ class PprofLogDataExporterTest {
     exporter.export(logMessage.getBytes(StandardCharsets.UTF_8), 1);
 
     var attributes = logger.records().getFirst().getAttributes();
-    assertEquals(source.toString(), attributes.get(stringKey("profiling.instrumentation.source")));
+    assertEquals(source.value(), attributes.get(stringKey("profiling.instrumentation.source")));
   }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.splunk.opentelemetry.profiler.exporter;
 
 import static io.opentelemetry.api.common.AttributeKey.longKey;
@@ -21,7 +37,8 @@ class PprofLogDataExporterTest {
   void emitDataToOpenTelemetryLogger() {
     var logMessage = "this is a test log message, the contents are not important.";
 
-    var exporter = new PprofLogDataExporter(logger, ProfilingDataType.CPU, InstrumentationSource.CONTINUOUS);
+    var exporter =
+        new PprofLogDataExporter(logger, ProfilingDataType.CPU, InstrumentationSource.CONTINUOUS);
     exporter.export(logMessage.getBytes(StandardCharsets.UTF_8), 1);
 
     assertEquals(Value.of(logMessage), logger.records().getFirst().getBodyValue());
@@ -31,7 +48,8 @@ class PprofLogDataExporterTest {
   void includeSplunkSourceTypeAttributeInLogMessage() {
     var logMessage = "this is a test log message, the contents are not important.";
 
-    var exporter = new PprofLogDataExporter(logger, ProfilingDataType.CPU, InstrumentationSource.CONTINUOUS);
+    var exporter =
+        new PprofLogDataExporter(logger, ProfilingDataType.CPU, InstrumentationSource.CONTINUOUS);
     exporter.export(logMessage.getBytes(StandardCharsets.UTF_8), 1);
 
     var attributes = logger.records().getFirst().getAttributes();
@@ -42,7 +60,8 @@ class PprofLogDataExporterTest {
   void includeProfilingDataFormatAttributeInLogMessage() {
     var logMessage = "this is a test log message, the contents are not important.";
 
-    var exporter = new PprofLogDataExporter(logger, ProfilingDataType.CPU, InstrumentationSource.CONTINUOUS);
+    var exporter =
+        new PprofLogDataExporter(logger, ProfilingDataType.CPU, InstrumentationSource.CONTINUOUS);
     exporter.export(logMessage.getBytes(StandardCharsets.UTF_8), 1);
 
     var attributes = logger.records().getFirst().getAttributes();
@@ -74,11 +93,12 @@ class PprofLogDataExporterTest {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = { 1, 50, 100, 10_000 })
+  @ValueSource(ints = {1, 50, 100, 10_000})
   void includeFrameCountAttributeInLogMessage(int frameCount) {
     var logMessage = "this is a test log message, the contents are not important.";
 
-    var exporter = new PprofLogDataExporter(logger, ProfilingDataType.CPU, InstrumentationSource.CONTINUOUS);
+    var exporter =
+        new PprofLogDataExporter(logger, ProfilingDataType.CPU, InstrumentationSource.CONTINUOUS);
     exporter.export(logMessage.getBytes(StandardCharsets.UTF_8), frameCount);
 
     var attributes = logger.records().getFirst().getAttributes();

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporterTest.java
@@ -45,6 +45,18 @@ class PprofLogDataExporterTest {
   }
 
   @Test
+  void expectedNumberOfLogMessageAttributesAreIncluded() {
+    var logMessage = "this is a test log message, the contents are not important.";
+
+    var exporter =
+        new PprofLogDataExporter(logger, ProfilingDataType.CPU, InstrumentationSource.CONTINUOUS);
+    exporter.export(logMessage.getBytes(StandardCharsets.UTF_8), 1);
+
+    var attributes = logger.records().get(0).getAttributes();
+    assertEquals(5, attributes.size());
+  }
+
+  @Test
   void includeSplunkSourceTypeAttributeInLogMessage() {
     var logMessage = "this is a test log message, the contents are not important.";
 

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporterTest.java
@@ -1,0 +1,73 @@
+package com.splunk.opentelemetry.profiler.exporter;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.splunk.opentelemetry.profiler.InstrumentationSource;
+import com.splunk.opentelemetry.profiler.ProfilingDataType;
+import io.opentelemetry.api.common.Value;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class PprofLogDataExporterTest {
+  @RegisterExtension public final InMemoryOtelLogger logger = new InMemoryOtelLogger();
+
+  @Test
+  void emitDataToOpenTelemetryLogger() {
+    var logMessage = "this is a test log message, the contents are not important.";
+
+    var exporter = new PprofLogDataExporter(logger, ProfilingDataType.CPU, InstrumentationSource.CONTINUOUS);
+    exporter.export(logMessage.getBytes(StandardCharsets.UTF_8), 1);
+
+    assertEquals(Value.of(logMessage), logger.records().getFirst().getBodyValue());
+  }
+
+  @Test
+  void includeSplunkSourceTypeAttributeInLogMessage() {
+    var logMessage = "this is a test log message, the contents are not important.";
+
+    var exporter = new PprofLogDataExporter(logger, ProfilingDataType.CPU, InstrumentationSource.CONTINUOUS);
+    exporter.export(logMessage.getBytes(StandardCharsets.UTF_8), 1);
+
+    var attributes = logger.records().getFirst().getAttributes();
+    assertEquals("otel.profiling", attributes.get(stringKey("com.splunk.sourcetype")));
+  }
+
+  @Test
+  void includeProfilingDataFormatAttributeInLogMessage() {
+    var logMessage = "this is a test log message, the contents are not important.";
+
+    var exporter = new PprofLogDataExporter(logger, ProfilingDataType.CPU, InstrumentationSource.CONTINUOUS);
+    exporter.export(logMessage.getBytes(StandardCharsets.UTF_8), 1);
+
+    var attributes = logger.records().getFirst().getAttributes();
+    assertEquals("pprof-gzip-base64", attributes.get(stringKey("profiling.data.format")));
+  }
+
+  @ParameterizedTest
+  @EnumSource(ProfilingDataType.class)
+  void includeProfilingDataTypeAttributeInLogMessage(ProfilingDataType dataType) {
+    var logMessage = "this is a test log message, the contents are not important.";
+
+    var exporter = new PprofLogDataExporter(logger, dataType, InstrumentationSource.CONTINUOUS);
+    exporter.export(logMessage.getBytes(StandardCharsets.UTF_8), 1);
+
+    var attributes = logger.records().getFirst().getAttributes();
+    assertEquals(dataType.value(), attributes.get(stringKey("profiling.data.type")));
+  }
+
+  @ParameterizedTest
+  @EnumSource(InstrumentationSource.class)
+  void includeProfilingInstrumentationSourceAttributeInLogMessage(InstrumentationSource source) {
+    var logMessage = "this is a test log message, the contents are not important.";
+
+    var exporter = new PprofLogDataExporter(logger, ProfilingDataType.CPU, source);
+    exporter.export(logMessage.getBytes(StandardCharsets.UTF_8), 1);
+
+    var attributes = logger.records().getFirst().getAttributes();
+    assertEquals(source.toString(), attributes.get(stringKey("profiling.instrumentation.source")));
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporterTest.java
@@ -24,6 +24,7 @@ import com.splunk.opentelemetry.profiler.InstrumentationSource;
 import com.splunk.opentelemetry.profiler.ProfilingDataType;
 import io.opentelemetry.api.common.Value;
 import java.nio.charset.StandardCharsets;
+import net.bytebuddy.utility.RandomString;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -35,7 +36,7 @@ class PprofLogDataExporterTest {
 
   @Test
   void emitDataToOpenTelemetryLogger() {
-    var logMessage = "this is a test log message, the contents are not important.";
+    var logMessage = RandomString.make();
 
     var exporter =
         new PprofLogDataExporter(logger, ProfilingDataType.CPU, InstrumentationSource.CONTINUOUS);
@@ -46,7 +47,7 @@ class PprofLogDataExporterTest {
 
   @Test
   void expectedNumberOfLogMessageAttributesAreIncluded() {
-    var logMessage = "this is a test log message, the contents are not important.";
+    var logMessage = RandomString.make();
 
     var exporter =
         new PprofLogDataExporter(logger, ProfilingDataType.CPU, InstrumentationSource.CONTINUOUS);
@@ -58,7 +59,7 @@ class PprofLogDataExporterTest {
 
   @Test
   void includeSplunkSourceTypeAttributeInLogMessage() {
-    var logMessage = "this is a test log message, the contents are not important.";
+    var logMessage = RandomString.make();
 
     var exporter =
         new PprofLogDataExporter(logger, ProfilingDataType.CPU, InstrumentationSource.CONTINUOUS);
@@ -70,7 +71,7 @@ class PprofLogDataExporterTest {
 
   @Test
   void includeProfilingDataFormatAttributeInLogMessage() {
-    var logMessage = "this is a test log message, the contents are not important.";
+    var logMessage = RandomString.make();
 
     var exporter =
         new PprofLogDataExporter(logger, ProfilingDataType.CPU, InstrumentationSource.CONTINUOUS);
@@ -83,7 +84,7 @@ class PprofLogDataExporterTest {
   @ParameterizedTest
   @EnumSource(ProfilingDataType.class)
   void includeProfilingDataTypeAttributeInLogMessage(ProfilingDataType dataType) {
-    var logMessage = "this is a test log message, the contents are not important.";
+    var logMessage = RandomString.make();
 
     var exporter = new PprofLogDataExporter(logger, dataType, InstrumentationSource.CONTINUOUS);
     exporter.export(logMessage.getBytes(StandardCharsets.UTF_8), 1);
@@ -95,7 +96,7 @@ class PprofLogDataExporterTest {
   @ParameterizedTest
   @EnumSource(InstrumentationSource.class)
   void includeProfilingInstrumentationSourceAttributeInLogMessage(InstrumentationSource source) {
-    var logMessage = "this is a test log message, the contents are not important.";
+    var logMessage = RandomString.make();
 
     var exporter = new PprofLogDataExporter(logger, ProfilingDataType.CPU, source);
     exporter.export(logMessage.getBytes(StandardCharsets.UTF_8), 1);
@@ -107,7 +108,7 @@ class PprofLogDataExporterTest {
   @ParameterizedTest
   @ValueSource(ints = {1, 50, 100, 10_000})
   void includeFrameCountAttributeInLogMessage(int frameCount) {
-    var logMessage = "this is a test log message, the contents are not important.";
+    var logMessage = RandomString.make();
 
     var exporter =
         new PprofLogDataExporter(logger, ProfilingDataType.CPU, InstrumentationSource.CONTINUOUS);

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/exporter/PprofLogDataExporterTest.java
@@ -41,7 +41,7 @@ class PprofLogDataExporterTest {
         new PprofLogDataExporter(logger, ProfilingDataType.CPU, InstrumentationSource.CONTINUOUS);
     exporter.export(logMessage.getBytes(StandardCharsets.UTF_8), 1);
 
-    assertEquals(Value.of(logMessage), logger.records().getFirst().getBodyValue());
+    assertEquals(Value.of(logMessage), logger.records().get(0).getBodyValue());
   }
 
   @Test
@@ -52,7 +52,7 @@ class PprofLogDataExporterTest {
         new PprofLogDataExporter(logger, ProfilingDataType.CPU, InstrumentationSource.CONTINUOUS);
     exporter.export(logMessage.getBytes(StandardCharsets.UTF_8), 1);
 
-    var attributes = logger.records().getFirst().getAttributes();
+    var attributes = logger.records().get(0).getAttributes();
     assertEquals("otel.profiling", attributes.get(stringKey("com.splunk.sourcetype")));
   }
 
@@ -64,7 +64,7 @@ class PprofLogDataExporterTest {
         new PprofLogDataExporter(logger, ProfilingDataType.CPU, InstrumentationSource.CONTINUOUS);
     exporter.export(logMessage.getBytes(StandardCharsets.UTF_8), 1);
 
-    var attributes = logger.records().getFirst().getAttributes();
+    var attributes = logger.records().get(0).getAttributes();
     assertEquals("pprof-gzip-base64", attributes.get(stringKey("profiling.data.format")));
   }
 
@@ -76,7 +76,7 @@ class PprofLogDataExporterTest {
     var exporter = new PprofLogDataExporter(logger, dataType, InstrumentationSource.CONTINUOUS);
     exporter.export(logMessage.getBytes(StandardCharsets.UTF_8), 1);
 
-    var attributes = logger.records().getFirst().getAttributes();
+    var attributes = logger.records().get(0).getAttributes();
     assertEquals(dataType.value(), attributes.get(stringKey("profiling.data.type")));
   }
 
@@ -88,7 +88,7 @@ class PprofLogDataExporterTest {
     var exporter = new PprofLogDataExporter(logger, ProfilingDataType.CPU, source);
     exporter.export(logMessage.getBytes(StandardCharsets.UTF_8), 1);
 
-    var attributes = logger.records().getFirst().getAttributes();
+    var attributes = logger.records().get(0).getAttributes();
     assertEquals(source.value(), attributes.get(stringKey("profiling.instrumentation.source")));
   }
 
@@ -101,7 +101,7 @@ class PprofLogDataExporterTest {
         new PprofLogDataExporter(logger, ProfilingDataType.CPU, InstrumentationSource.CONTINUOUS);
     exporter.export(logMessage.getBytes(StandardCharsets.UTF_8), frameCount);
 
-    var attributes = logger.records().getFirst().getAttributes();
+    var attributes = logger.records().get(0).getAttributes();
     assertEquals(frameCount, attributes.get(longKey("profiling.data.total.frame.count")));
   }
 }


### PR DESCRIPTION
Adding an instrumentation source attribute to exported profiling logs. This new attribute will be utilized by the profiling log ingestion pipeline to differentiate between the existing continuous callstacks and the upcoming trace snapshot callstacks.