### PR TITLE
Disable logs exporter for windows smoke tests

### DIFF
--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/windows/WindowsTestContainerManager.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/windows/WindowsTestContainerManager.java
@@ -218,6 +218,8 @@ public class WindowsTestContainerManager extends AbstractTestContainerManager {
     }
 
     List<String> environment = new ArrayList<>();
+    // hec backend is not started on windows
+    environment.add("OTEL_LOGS_EXPORTER=none");
 
     if (builder.useDefaultAgentConfiguration) {
       getAgentEnvironment(builder.jvmArgsEnvVarName, !builder.autodetectServiceName)


### PR DESCRIPTION
Hopefully gets rid of
> 05:52:22.276 [docker-java-stream-1326425793] ERROR c.s.o.h.w.WindowsTestContainerManager - STDERR: 2025-02-27T05:52:22.276Z	info	internal/retry_sender.go:126	Exporting failed. Will retry the request after interval.	{"kind": "exporter", "data_type": "logs", "name": "splunk_hec", "error": "Post \"http://hec-backend:1080/services/collector/event\": dial tcp: lookup hec-backend: no such host", "interval": "3.147414794s"}