### PR TITLE
Enable console exporter for traces in smoke tests

### DIFF
--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/AbstractTestContainerManager.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/AbstractTestContainerManager.java
@@ -48,6 +48,7 @@ public abstract class AbstractTestContainerManager implements TestContainerManag
     // This does not affect tests in any way but serves to verify that agent can actually load this
     // sampler
     environment.put("OTEL_TRACES_SAMPLER", "internal_root_off");
+    environment.put("OTEL_TRACES_EXPORTER", "otlp,console");
 
     return environment;
   }


### PR DESCRIPTION
resolves https://github.com/signalfx/splunk-otel-java/issues/2211
hopefully with this we'll know whether the span was exported from the agent at all next time we have a similar failure