### PR TITLE
Use type of expression result to decide span attribute type

### DIFF
--- a/bootstrap/src/main/java/com/splunk/opentelemetry/javaagent/bootstrap/nocode/NocodeEvaluation.java
+++ b/bootstrap/src/main/java/com/splunk/opentelemetry/javaagent/bootstrap/nocode/NocodeEvaluation.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class NocodeEvaluation {
 
   public interface Evaluator {
-    String evaluate(String expression, Object thiz, Object[] params);
+    Object evaluate(String expression, Object thiz, Object[] params);
   }
 
   private static final AtomicReference<Evaluator> globalEvaluator = new AtomicReference<>();
@@ -30,7 +30,7 @@ public class NocodeEvaluation {
     globalEvaluator.set(evaluator);
   }
 
-  public static String evaluate(String expression, Object thiz, Object[] params) {
+  public static Object evaluate(String expression, Object thiz, Object[] params) {
     Evaluator e = globalEvaluator.get();
     return e == null ? null : e.evaluate(expression, thiz, params);
   }

--- a/instrumentation/nocode/src/main/java/com/splunk/opentelemetry/instrumentation/nocode/JexlEvaluator.java
+++ b/instrumentation/nocode/src/main/java/com/splunk/opentelemetry/instrumentation/nocode/JexlEvaluator.java
@@ -53,7 +53,7 @@ public class JexlEvaluator implements NocodeEvaluation.Evaluator {
   }
 
   @Override
-  public String evaluate(String expression, Object thiz, Object[] params) {
+  public Object evaluate(String expression, Object thiz, Object[] params) {
     JexlContext context = new MapContext();
     context.set("this", thiz);
     for (int i = 0; i < params.length; i++) {
@@ -61,8 +61,7 @@ public class JexlEvaluator implements NocodeEvaluation.Evaluator {
     }
     try {
       // could cache the Expression in the Rule if desired
-      Object result = jexl.createExpression(expression).evaluate(context);
-      return result == null ? null : result.toString();
+      return jexl.createExpression(expression).evaluate(context);
     } catch (Throwable t) {
       logger.warning("Can't evaluate {" + expression + "}: " + t);
       return null;

--- a/instrumentation/nocode/src/main/java/com/splunk/opentelemetry/instrumentation/nocode/NocodeAttributesExtractor.java
+++ b/instrumentation/nocode/src/main/java/com/splunk/opentelemetry/instrumentation/nocode/NocodeAttributesExtractor.java
@@ -41,9 +41,15 @@ public final class NocodeAttributesExtractor
     Map<String, String> attributes = mi.getRuleAttributes();
     for (String key : attributes.keySet()) {
       String expression = attributes.get(key);
-      String value = NocodeEvaluation.evaluate(expression, mi.getThiz(), mi.getParameters());
-      if (value != null) {
-        attributesBuilder.put(key, value);
+      Object value = NocodeEvaluation.evaluate(expression, mi.getThiz(), mi.getParameters());
+      if (value instanceof Long || value instanceof Integer) {
+        attributesBuilder.put(key, ((Number) value).longValue());
+      } else if (value instanceof Float || value instanceof Double) {
+        attributesBuilder.put(key, ((Number) value).doubleValue());
+      } else if (value instanceof Boolean) {
+        attributesBuilder.put(key, (Boolean) value);
+      } else if (value != null) {
+        attributesBuilder.put(key, value.toString());
       }
     }
   }

--- a/instrumentation/nocode/src/main/java/com/splunk/opentelemetry/instrumentation/nocode/NocodeSpanNameExtractor.java
+++ b/instrumentation/nocode/src/main/java/com/splunk/opentelemetry/instrumentation/nocode/NocodeSpanNameExtractor.java
@@ -33,9 +33,9 @@ public class NocodeSpanNameExtractor implements SpanNameExtractor<NocodeMethodIn
   public String extract(NocodeMethodInvocation mi) {
     NocodeRules.Rule rule = mi.getRule();
     if (rule != null && rule.spanName != null) {
-      String name = NocodeEvaluation.evaluate(rule.spanName, mi.getThiz(), mi.getParameters());
+      Object name = NocodeEvaluation.evaluate(rule.spanName, mi.getThiz(), mi.getParameters());
       if (name != null) {
-        return name;
+        return name.toString();
       }
     }
     return defaultNamer.extract(mi.getClassAndMethod());

--- a/instrumentation/nocode/src/test/config/nocode.yml
+++ b/instrumentation/nocode/src/test/config/nocode.yml
@@ -6,6 +6,14 @@
       value: this.getDetails()
     - key: "map.size"
       value: this.getMap().entrySet().size()
+    - key: "map.isEmpty"
+      value: this.getMap().isEmpty()
+    - key: getFloat
+      value: this.getFloat()
+    - key: getDouble
+      value: this.getDouble()
+    - key: getLong
+      value: this.getLong()
 
 - class: com.splunk.opentelemetry.instrumentation.nocode.NocodeInstrumentationTest$SampleClass
   method: throwException

--- a/instrumentation/nocode/src/test/java/com/splunk/opentelemetry/instrumentation/nocode/JexlTest.java
+++ b/instrumentation/nocode/src/test/java/com/splunk/opentelemetry/instrumentation/nocode/JexlTest.java
@@ -41,7 +41,7 @@ class JexlTest {
     param0.add("present");
   }
 
-  private static String evalJexl(String jexl, Object thiz, Object[] params) {
+  private static Object evalJexl(String jexl, Object thiz, Object[] params) {
     return new JexlEvaluator().evaluate(jexl, thiz, params);
   }
 
@@ -49,19 +49,23 @@ class JexlTest {
     return Stream.of(
         arguments("this", "{key=value}"),
         arguments("this.toString()", "{key=value}"),
-        arguments("this.toString().length()", "11"),
+        arguments("this.toString().length()", 11),
         arguments("this.get(\"key\")", "value"),
         arguments("this.get(\"key\").substring(1)", "alue"),
-        arguments("param0.isEmpty()", "false"),
-        arguments("param0.contains(\"present\")", "true"),
+        arguments("param0.isEmpty()", false),
+        arguments("param0.contains(\"present\")", true),
         arguments("\"prefix: \"+this.toString()+\" (suffix)\"", "prefix: {key=value} (suffix)"),
-        arguments("this.entrySet().size()", "1"));
+        arguments("this.entrySet().size()", 1));
   }
 
   @ParameterizedTest
   @MethodSource("jexlToExpected")
-  void testBasicBehavior(String jexl, String expected) {
-    assertEquals(expected, evalJexl(jexl, thiz, new Object[] {param0}), jexl);
+  void testBasicBehavior(String jexl, Object expected) {
+    Object result = evalJexl(jexl, thiz, new Object[] {param0});
+    if (expected instanceof String) {
+      result = result == null ? null : result.toString();
+    }
+    assertEquals(expected, result, jexl);
   }
 
   @ParameterizedTest
@@ -89,7 +93,7 @@ class JexlTest {
         "param1.toString()", // no such param
       })
   void testInvalidJexlReturnNull(String invalid) {
-    String answer = evalJexl(invalid, thiz, new Object[] {param0});
+    Object answer = evalJexl(invalid, thiz, new Object[] {param0});
     assertNull(answer, "Expected null for \"" + invalid + "\" but was \"" + answer + "\"");
   }
 

--- a/instrumentation/nocode/src/test/java/com/splunk/opentelemetry/instrumentation/nocode/NocodeInstrumentationTest.java
+++ b/instrumentation/nocode/src/test/java/com/splunk/opentelemetry/instrumentation/nocode/NocodeInstrumentationTest.java
@@ -45,7 +45,11 @@ class NocodeInstrumentationTest {
                         .hasKind(SpanKind.INTERNAL)
                         .hasStatus(StatusData.unset())
                         .hasAttributesSatisfying(
-                            equalTo(AttributeKey.stringKey("map.size"), "2"),
+                            equalTo(AttributeKey.doubleKey("getFloat"), 7.0),
+                            equalTo(AttributeKey.doubleKey("getDouble"), 8.0),
+                            equalTo(AttributeKey.longKey("getLong"), 9),
+                            equalTo(AttributeKey.booleanKey("map.isEmpty"), false),
+                            equalTo(AttributeKey.longKey("map.size"), 2),
                             equalTo(AttributeKey.stringKey("details"), "details"))));
   }
 
@@ -89,6 +93,18 @@ class NocodeInstrumentationTest {
 
     public String getDetails() {
       return "details";
+    }
+
+    public float getFloat() {
+      return 7.0f;
+    }
+
+    public double getDouble() {
+      return 8.0;
+    }
+
+    public long getLong() {
+      return 9L;
     }
 
     public Map<String, String> getMap() {


### PR DESCRIPTION
Set span attribute type for a nocode expression based on what boxed type was returned from the expression:
- `boolean` from `Boolean`
- `double` from `Float` or `Double`
- `long` from `Long` or `Integer`
- `String` from everything else (via `toString()`)

This changed the types of some existing tests in desired ways, and I added additional yml-to-span instrumentation tests to cover all the cases above.