### PR TITLE
Autoconfigure Snapshot Volume Propagator

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSdkCustomizer.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSdkCustomizer.java
@@ -63,8 +63,9 @@ public class SnapshotProfilingSdkCustomizer implements AutoConfigurationCustomiz
 
   /**
    * Attempt to autoconfigure the OpenTelemetry propagators to include the Splunk snapshot volume
-   * propagator and ensure it runs after both the W3C Baggage and Trace Context propagators. In
-   * addition, take care to retain any propagators explicitly configured prior.
+   * propagator and ensure it runs after the W3C Baggage propagator and ensure that a trace context
+   * propagator is configured. In addition, take care to retain any propagators explicitly
+   * configured prior.
    *
    * <p>The Java agent uses the "otel.propagators" property and the value is assumed to be a comma
    * seperated list of propagator names. See <a

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSdkCustomizer.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSdkCustomizer.java
@@ -76,10 +76,14 @@ public class SnapshotProfilingSdkCustomizer implements AutoConfigurationCustomiz
     return properties -> {
       if (snapshotProfilingEnabled(properties)) {
         Set<String> propagators = new LinkedHashSet<>(properties.getList("otel.propagators"));
-        propagators.add("baggage");
+        if (propagators.contains("none")) {
+          return Collections.emptyMap();
+        }
+
         if (includeTraceContextPropagator(propagators)) {
           propagators.add("tracecontext");
         }
+        propagators.add("baggage");
         propagators.add(SnapshotVolumePropagatorProvider.NAME);
         return Map.of("otel.propagators", String.join(",", propagators));
       }
@@ -88,7 +92,7 @@ public class SnapshotProfilingSdkCustomizer implements AutoConfigurationCustomiz
   }
 
   private boolean includeTraceContextPropagator(Set<String> configuredPropagators) {
-    return !configuredPropagators.contains("b3") && !configuredPropagators.contains("b3multi");
+    return configuredPropagators.isEmpty();
   }
 
   private boolean snapshotProfilingEnabled(ConfigProperties config) {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSdkCustomizer.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSdkCustomizer.java
@@ -76,7 +76,8 @@ public class SnapshotProfilingSdkCustomizer implements AutoConfigurationCustomiz
     return properties -> {
       if (snapshotProfilingEnabled(properties)) {
         Set<String> propagators = new LinkedHashSet<>(properties.getList("otel.propagators"));
-        propagators.addAll(List.of("baggage", "tracecontext", "splunk-snapshot"));
+        propagators.addAll(
+            List.of("baggage", "tracecontext", SnapshotVolumePropagatorProvider.NAME));
         return Map.of("otel.propagators", String.join(",", propagators));
       }
       return Collections.emptyMap();

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotVolumePropagatorProvider.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotVolumePropagatorProvider.java
@@ -24,6 +24,8 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider;
 
 @AutoService(ConfigurablePropagatorProvider.class)
 public class SnapshotVolumePropagatorProvider implements ConfigurablePropagatorProvider {
+  public static final String NAME = "splunk-snapshot";
+
   @Override
   public TextMapPropagator getPropagator(ConfigProperties config) {
     double snapshotSelectionRate = Configuration.getSnapshotSelectionRate(config);
@@ -32,6 +34,6 @@ public class SnapshotVolumePropagatorProvider implements ConfigurablePropagatorP
 
   @Override
   public String getName() {
-    return "splunk-snapshot";
+    return NAME;
   }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/AutoConfigureSnapshotVolumePropagatorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/AutoConfigureSnapshotVolumePropagatorTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler.snapshot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.splunk.opentelemetry.profiler.Configuration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class AutoConfigureSnapshotVolumePropagatorTest {
+  @Test
+  void autoConfigureSnapshotVolumePropagator() {
+    try (var sdk = newSdk().build()) {
+      var properties = sdk.getProperties();
+      assertThat(properties.getList("otel.propagators")).contains("splunk-snapshot");
+    }
+  }
+
+  @Test
+  void snapshotVolumePropagatorMustBeAfterBaggageAndTraceContext() {
+    try (var sdk = newSdk().build()) {
+      var properties = sdk.getProperties();
+      assertThat(properties.getList("otel.propagators"))
+          .containsExactly("baggage", "tracecontext", "splunk-snapshot");
+    }
+  }
+
+  @Test
+  void appendSnapshotPropagatorToEndOfAlreadyConfiguredPropagators() {
+    try (var sdk =
+        newSdk()
+            .withProperty("otel.propagators", "baggage,tracecontext,some-other-propagator")
+            .build()) {
+      var properties = sdk.getProperties();
+      assertThat(properties.getList("otel.propagators"))
+          .containsExactly("baggage", "tracecontext", "some-other-propagator", "splunk-snapshot");
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"baggage", "tracecontext"})
+  void doNotDoubleCountDefaultOpenTelemetryPropagators(String propagatorName) {
+    try (var sdk = newSdk().withProperty("otel.propagators", propagatorName).build()) {
+      var properties = sdk.getProperties();
+      assertThat(properties.getList("otel.propagators")).containsOnlyOnce(propagatorName);
+    }
+  }
+
+  @Test
+  void doNotDoubleCountSnapshotVolumePropagator() {
+    try (var sdk = newSdk().withProperty("otel.propagators", "splunk-snapshot").build()) {
+      var properties = sdk.getProperties();
+      assertThat(properties.getList("otel.propagators")).containsOnlyOnce("splunk-snapshot");
+    }
+  }
+
+  @Test
+  void doNotAddSnapshotVolumePropagatorWhenTraceSnapshottingIsDisabled() {
+    try (var sdk =
+        newSdk().withProperty(Configuration.CONFIG_KEY_ENABLE_SNAPSHOT_PROFILER, "false").build()) {
+      var properties = sdk.getProperties();
+      assertThat(properties.getList("otel.propagators")).doesNotContain("splunk-snapshot");
+    }
+  }
+
+  private OpenTelemetrySdkExtension.Builder newSdk() {
+    return OpenTelemetrySdkExtension.builder()
+        .withProperty(Configuration.CONFIG_KEY_ENABLE_SNAPSHOT_PROFILER, "true")
+        .with(new SnapshotProfilingSdkCustomizer());
+  }
+}

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/AutoConfigureSnapshotVolumePropagatorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/AutoConfigureSnapshotVolumePropagatorTest.java
@@ -16,12 +16,12 @@
 
 package com.splunk.opentelemetry.profiler.snapshot;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.splunk.opentelemetry.profiler.Configuration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class AutoConfigureSnapshotVolumePropagatorTest {
   private static final String OTEL_PROPAGATORS = "otel-propagators";
@@ -94,16 +94,18 @@ class AutoConfigureSnapshotVolumePropagatorTest {
     try (var sdk = newSdk().withProperty(OTEL_PROPAGATORS, "none").build()) {
       var properties = sdk.getProperties();
       assertThat(properties.getList(OTEL_PROPAGATORS))
-              .doesNotContain(SnapshotVolumePropagatorProvider.NAME);
+          .doesNotContain(SnapshotVolumePropagatorProvider.NAME);
     }
   }
 
   @Test
   void doNotAddTraceContextPropagatorWhenOtherPropagatorsAreExplicitlyConfigured() {
-    try (var sdk = newSdk().withProperty(OTEL_PROPAGATORS, "some-other-propagator,baggage").build()) {
+    try (var sdk =
+        newSdk().withProperty(OTEL_PROPAGATORS, "some-other-propagator,baggage").build()) {
       var properties = sdk.getProperties();
       assertThat(properties.getList(OTEL_PROPAGATORS))
-              .containsExactly("some-other-propagator", "baggage", SnapshotVolumePropagatorProvider.NAME);
+          .containsExactly(
+              "some-other-propagator", "baggage", SnapshotVolumePropagatorProvider.NAME);
     }
   }
 
@@ -112,7 +114,8 @@ class AutoConfigureSnapshotVolumePropagatorTest {
     try (var sdk = newSdk().withProperty(OTEL_PROPAGATORS, "some-other-propagator").build()) {
       var properties = sdk.getProperties();
       assertThat(properties.getList(OTEL_PROPAGATORS))
-              .containsExactly("some-other-propagator", "baggage", SnapshotVolumePropagatorProvider.NAME);
+          .containsExactly(
+              "some-other-propagator", "baggage", SnapshotVolumePropagatorProvider.NAME);
     }
   }
 

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/AutoConfigureSnapshotVolumePropagatorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/AutoConfigureSnapshotVolumePropagatorTest.java
@@ -69,6 +69,15 @@ class AutoConfigureSnapshotVolumePropagatorTest {
     }
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = {"b3", "b3multi"})
+  void doNotAddTraceContextPropagatorWhenB3PropagatorPresent(String propagatorName) {
+    try (var sdk = newSdk().withProperty(OTEL_PROPAGATORS, propagatorName).build()) {
+      var properties = sdk.getProperties();
+      assertThat(properties.getList(OTEL_PROPAGATORS)).doesNotContain("tracecontext");
+    }
+  }
+
   @Test
   void doNotDoubleCountSnapshotVolumePropagator() {
     try (var sdk =

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/OpenTelemetrySdkExtension.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/OpenTelemetrySdkExtension.java
@@ -49,15 +49,17 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolver;
 
 public class OpenTelemetrySdkExtension
-    implements OpenTelemetry, AfterEachCallback, ParameterResolver {
+    implements OpenTelemetry, AfterEachCallback, ParameterResolver, AutoCloseable {
   public static Builder builder() {
     return new Builder();
   }
 
   private final OpenTelemetrySdk sdk;
+  private final ConfigProperties properties;
 
-  private OpenTelemetrySdkExtension(OpenTelemetrySdk sdk) {
+  private OpenTelemetrySdkExtension(OpenTelemetrySdk sdk, ConfigProperties properties) {
     this.sdk = sdk;
+    this.properties = properties;
   }
 
   @Override
@@ -83,6 +85,15 @@ public class OpenTelemetrySdkExtension
   @Override
   public void afterEach(ExtensionContext extensionContext) {
     sdk.close();
+  }
+
+  @Override
+  public void close() {
+    sdk.close();
+  }
+
+  public ConfigProperties getProperties() {
+    return properties;
   }
 
   @Override
@@ -144,7 +155,7 @@ public class OpenTelemetrySdkExtension
               .setTracerProvider(tracerProvider)
               .setPropagators(contextPropagators)
               .build();
-      return new OpenTelemetrySdkExtension(sdk);
+      return new OpenTelemetrySdkExtension(sdk, configProperties);
     }
 
     private ConfigProperties customizeProperties() {


### PR DESCRIPTION
This PR attempts to modify the `otel.propagators` value to autoconfigure the recently added `SnapshotVolumePropagatorProvider` as well as ensure the propagator is invoked after both the W3C baggage and trace context propagators.