### PR TITLE
Fix Flaky Test

### DIFF
--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/InMemoryStagingArea.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/InMemoryStagingArea.java
@@ -16,9 +16,7 @@
 
 package com.splunk.opentelemetry.profiler.snapshot;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/InMemoryStagingArea.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/InMemoryStagingArea.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
 /**
@@ -27,7 +29,7 @@ import java.util.stream.Collectors;
  * the stockpiled {@link StackTrace}s. Intended for testing use only.
  */
 class InMemoryStagingArea implements StagingArea {
-  private final Map<String, List<StackTrace>> stackTraces = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, List<StackTrace>> stackTraces = new ConcurrentHashMap<>();
 
   @Override
   public void stage(String traceId, StackTrace stackTrace) {
@@ -35,7 +37,7 @@ class InMemoryStagingArea implements StagingArea {
         traceId,
         (id, stackTraces) -> {
           if (stackTraces == null) {
-            stackTraces = new ArrayList<>();
+            stackTraces = new CopyOnWriteArrayList<>();
           }
           stackTraces.add(stackTrace);
           return stackTraces;

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/ScheduledExecutorStackTraceSamplerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/ScheduledExecutorStackTraceSamplerTest.java
@@ -93,7 +93,7 @@ class ScheduledExecutorStackTraceSamplerTest {
             startSampling(randomSpanContext(traceId), latch), 0, TimeUnit.MILLISECONDS);
     scheduler.schedule(startSampling(randomSpanContext(traceId), latch), 25, TimeUnit.MILLISECONDS);
 
-    await().atMost(HALF_SECOND).until(() -> staging.allStackTraces().size() > 5);
+    await().until(() -> staging.allStackTraces().size() > 5);
     latch.countDown();
 
     var threadIds =

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/ScheduledExecutorStackTraceSamplerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/ScheduledExecutorStackTraceSamplerTest.java
@@ -90,16 +90,18 @@ class ScheduledExecutorStackTraceSamplerTest {
     var spanContext2 = randomSpanContext(traceId);
     var spanContext1 = randomSpanContext(traceId);
 
-    var threadOne = scheduler.schedule(startSampling(spanContext1, latch), 0, TimeUnit.MILLISECONDS);
+    var threadOne =
+        scheduler.schedule(startSampling(spanContext1, latch), 0, TimeUnit.MILLISECONDS);
     scheduler.schedule(startSampling(spanContext2, latch), 25, TimeUnit.MILLISECONDS);
 
     try {
       await().until(() -> staging.allStackTraces().size() > 5);
       latch.countDown();
 
-      var threadIds = staging.allStackTraces().stream()
-          .map(StackTrace::getThreadId)
-          .collect(Collectors.toSet());
+      var threadIds =
+          staging.allStackTraces().stream()
+              .map(StackTrace::getThreadId)
+              .collect(Collectors.toSet());
       assertThat(threadIds).containsOnly(threadOne.get().getId());
     } finally {
       sampler.stop(spanContext1);


### PR DESCRIPTION
Use a scheduler to stagger the simulated concurrent start span operations in the test that verifies only a single thread is profiled at a time.