### PR TITLE
Pass through configured otlp headers for logs containing profiles.

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/LogExporterBuilder.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/LogExporterBuilder.java
@@ -56,6 +56,10 @@ class LogExporterBuilder {
       ConfigProperties config, Supplier<OtlpHttpLogRecordExporterBuilder> makeBuilder) {
     OtlpHttpLogRecordExporterBuilder builder = makeBuilder.get();
     String ingestUrl = Configuration.getConfigUrl(config);
+
+    config.getMap("otel.exporter.otlp.headers").forEach(builder::addHeader);
+    config.getMap("otel.exporter.otlp.logs.headers").forEach(builder::addHeader);
+
     if (ingestUrl != null) {
       builder.setEndpoint(ingestUrl);
     }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/LogExporterBuilder.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/LogExporterBuilder.java
@@ -16,9 +16,12 @@
 
 package com.splunk.opentelemetry.profiler;
 
+import static io.opentelemetry.exporter.otlp.internal.OtlpConfigUtil.DATA_TYPE_LOGS;
+
 import com.google.common.annotations.VisibleForTesting;
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter;
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder;
+import io.opentelemetry.exporter.otlp.internal.OtlpConfigUtil;
 import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporter;
 import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporterBuilder;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
@@ -57,8 +60,17 @@ class LogExporterBuilder {
     OtlpHttpLogRecordExporterBuilder builder = makeBuilder.get();
     String ingestUrl = Configuration.getConfigUrl(config);
 
-    config.getMap("otel.exporter.otlp.headers").forEach(builder::addHeader);
-    config.getMap("otel.exporter.otlp.logs.headers").forEach(builder::addHeader);
+    OtlpConfigUtil.configureOtlpExporterBuilder(
+        DATA_TYPE_LOGS,
+        config,
+        builder::setEndpoint,
+        builder::addHeader,
+        builder::setCompression,
+        builder::setTimeout,
+        builder::setTrustedCertificates,
+        builder::setClientTls,
+        builder::setRetryPolicy,
+        builder::setMemoryMode);
 
     if (ingestUrl != null) {
       builder.setEndpoint(ingestUrl);


### PR DESCRIPTION
This was a user request. They expect the profiling logs exporter to behave consistently with the other signals.

Seems like a reasonable ask, especially until/before we have native profiles ingest available.