### PR TITLE
Remove accidental usage of Map method added in JDK9.

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSdkCustomizer.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSdkCustomizer.java
@@ -87,7 +87,7 @@ public class SnapshotProfilingSdkCustomizer implements AutoConfigurationCustomiz
         }
         propagators.add("baggage");
         propagators.add(SnapshotVolumePropagatorProvider.NAME);
-        return Map.of("otel.propagators", String.join(",", propagators));
+        return Collections.singletonMap("otel.propagators", String.join(",", propagators));
       }
       return Collections.emptyMap();
     };


### PR DESCRIPTION
`Map::of` was added in JDK9 and therefore not compatible with Java 8 runtimes. Replacing in favor of `Collections.singletonMap`.