### PR TITLE
Only root span gets AppD attributes set

### DIFF
--- a/custom/src/main/java/com/splunk/opentelemetry/appd/AppdBonusSpanProcessor.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/appd/AppdBonusSpanProcessor.java
@@ -37,17 +37,20 @@ public class AppdBonusSpanProcessor implements OnStartSpanProcessor.OnStart {
     if (ctx == null) {
       return;
     }
-    if (ctx.getAccountId() != null) {
-      span.setAttribute(APPD_ATTR_ACCT, ctx.getAccountId());
-    }
-    if (ctx.getAppId() != null) {
-      span.setAttribute(APPD_ATTR_APP, ctx.getAppId());
-    }
-    if (ctx.getBusinessTransactionId() != null) {
-      span.setAttribute(APPD_ATTR_BT, ctx.getBusinessTransactionId());
-    }
-    if (ctx.getTierId() != null) {
-      span.setAttribute(APPD_ATTR_TIER, ctx.getTierId());
+    // Set attributes only for the root span
+    if (span.getParentSpanContext() == null) {
+      if (ctx.getAccountId() != null) {
+        span.setAttribute(APPD_ATTR_ACCT, ctx.getAccountId());
+      }
+      if (ctx.getAppId() != null) {
+        span.setAttribute(APPD_ATTR_APP, ctx.getAppId());
+      }
+      if (ctx.getBusinessTransactionId() != null) {
+        span.setAttribute(APPD_ATTR_BT, ctx.getBusinessTransactionId());
+      }
+      if (ctx.getTierId() != null) {
+        span.setAttribute(APPD_ATTR_TIER, ctx.getTierId());
+      }
     }
   }
 }

--- a/custom/src/main/java/com/splunk/opentelemetry/appd/AppdBonusSpanProcessor.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/appd/AppdBonusSpanProcessor.java
@@ -20,6 +20,7 @@ import static com.splunk.opentelemetry.appd.AppdBonusPropagator.CONTEXT_KEY;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
 import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.extension.incubator.trace.OnStartSpanProcessor;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
@@ -38,7 +39,8 @@ public class AppdBonusSpanProcessor implements OnStartSpanProcessor.OnStart {
       return;
     }
     // Set attributes only for the root span
-    if (span.getParentSpanContext() == null) {
+    SpanContext parentSpanContext = span.getParentSpanContext();
+    if (!parentSpanContext.isValid() || parentSpanContext.isRemote()) {
       if (ctx.getAccountId() != null) {
         span.setAttribute(APPD_ATTR_ACCT, ctx.getAccountId());
       }

--- a/custom/src/main/java/com/splunk/opentelemetry/appd/AppdBonusSpanProcessor.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/appd/AppdBonusSpanProcessor.java
@@ -38,7 +38,7 @@ public class AppdBonusSpanProcessor implements OnStartSpanProcessor.OnStart {
     if (ctx == null) {
       return;
     }
-    // Set attributes only for the root span
+    // Set attributes only for the local root span
     SpanContext parentSpanContext = span.getParentSpanContext();
     if (!parentSpanContext.isValid() || parentSpanContext.isRemote()) {
       if (ctx.getAccountId() != null) {

--- a/custom/src/test/java/com/splunk/opentelemetry/appd/AppdBonusCustomizerTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/appd/AppdBonusCustomizerTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
@@ -98,8 +99,14 @@ class AppdBonusCustomizerTest {
     tpcCaptor.getValue().apply(builder, config);
     ArgumentCaptor<SpanProcessor> spCapture = ArgumentCaptor.forClass(SpanProcessor.class);
     verify(builder).addSpanProcessor(spCapture.capture());
+
     ReadWriteSpan span = mock();
+    SpanContext parentSpanContext = mock(SpanContext.class);
+    when(parentSpanContext.isValid()).thenReturn(false);
+    when(span.getParentSpanContext()).thenReturn(parentSpanContext);
+
     spCapture.getValue().onStart(context, span);
+
     verify(span).setAttribute(APPD_ATTR_APP, appdContext.getAppId());
     verify(span).setAttribute(APPD_ATTR_ACCT, appdContext.getAccountId());
     verify(span).setAttribute(APPD_ATTR_TIER, appdContext.getTierId());

--- a/custom/src/test/java/com/splunk/opentelemetry/appd/AppdBonusSpanProcessorTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/appd/AppdBonusSpanProcessorTest.java
@@ -41,6 +41,9 @@ class AppdBonusSpanProcessorTest {
     when(context.get(CONTEXT_KEY)).thenReturn(appdContext);
 
     ReadWriteSpan span = mock();
+    SpanContext parentSpanContext = mock(SpanContext.class);
+    when(parentSpanContext.isValid()).thenReturn(false);
+    when(span.getParentSpanContext()).thenReturn(parentSpanContext);
 
     AppdBonusSpanProcessor testClass = new AppdBonusSpanProcessor();
 
@@ -63,6 +66,8 @@ class AppdBonusSpanProcessorTest {
 
     ReadWriteSpan span = mock();
     SpanContext parentSpanContext = mock(SpanContext.class);
+    when(parentSpanContext.isValid()).thenReturn(true);
+    when(parentSpanContext.isRemote()).thenReturn(false);
     when(span.getParentSpanContext()).thenReturn(parentSpanContext);
 
     AppdBonusSpanProcessor testClass = new AppdBonusSpanProcessor();


### PR DESCRIPTION
As mentioned in https://github.com/signalfx/gdi-specification/pull/338, 4 AppD context headers should be transferred into corresponding span attributes only for the root span.

Related to https://github.com/signalfx/splunk-otel-java/pull/2198
