### PR TITLE
Update TraceRegistry To Use A Set

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/TraceRegistry.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/TraceRegistry.java
@@ -17,18 +17,18 @@
 package com.splunk.opentelemetry.profiler.snapshot;
 
 import io.opentelemetry.api.trace.SpanContext;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 class TraceRegistry {
-  private final Map<String, SpanContext> traceIds = new ConcurrentHashMap<>();
+  private final Set<String> traceIds = new CopyOnWriteArraySet<>();
 
   public void register(SpanContext spanContext) {
-    traceIds.put(spanContext.getTraceId(), spanContext);
+    traceIds.add(spanContext.getTraceId());
   }
 
   public boolean isRegistered(SpanContext spanContext) {
-    return traceIds.containsKey(spanContext.getTraceId());
+    return traceIds.contains(spanContext.getTraceId());
   }
 
   public void unregister(SpanContext spanContext) {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/TraceRegistry.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/TraceRegistry.java
@@ -17,11 +17,12 @@
 package com.splunk.opentelemetry.profiler.snapshot;
 
 import io.opentelemetry.api.trace.SpanContext;
+import java.util.Collections;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.ConcurrentHashMap;
 
 class TraceRegistry {
-  private final Set<String> traceIds = new CopyOnWriteArraySet<>();
+  private final Set<String> traceIds = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
   public void register(SpanContext spanContext) {
     traceIds.add(spanContext.getTraceId());


### PR DESCRIPTION
This PR modifies `TraceRegistry` to use a `Set` instead of a `Map`. As noted by @laurit [here](https://github.com/signalfx/splunk-otel-java/pull/2251#discussion_r2024952775) only the keys of the `Map` are used.