### PR TITLE
Decrease the trace profiling snapshot interval to 10ms.

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
@@ -79,7 +79,7 @@ public class Configuration implements AutoConfigurationCustomizerProvider {
   private static final int DEFAULT_SNAPSHOT_PROFILER_STACK_DEPTH = 1024;
   private static final String CONFIG_KEY_SNAPSHOT_PROFILER_SAMPLING_INTERVAL =
       "splunk.snapshot.profiler.sampling.interval";
-  public static final Duration DEFAULT_SNAPSHOT_PROFILER_SAMPLING_INTERVAL = Duration.ofMillis(20);
+  private static final Duration DEFAULT_SNAPSHOT_PROFILER_SAMPLING_INTERVAL = Duration.ofMillis(10);
 
   @Override
   public void customize(AutoConfigurationCustomizer autoConfiguration) {

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationTest.java
@@ -202,6 +202,6 @@ class ConfigurationTest {
   void getDefaultSnapshotProfilerSamplingInterval() {
     var properties = DefaultConfigProperties.create(Collections.emptyMap());
     assertEquals(
-        Duration.ofMillis(20), Configuration.getSnapshotProfilerSamplingInterval(properties));
+        Duration.ofMillis(10), Configuration.getSnapshotProfilerSamplingInterval(properties));
   }
 }


### PR DESCRIPTION
Lowering the default snapshot interval to 10ms to align with the default behavior of the AppDynamics agents.