### PR TITLE
Publish CSA bundle

### DIFF
--- a/agent-csa-bundle/README.md
+++ b/agent-csa-bundle/README.md
@@ -1,9 +1,28 @@
 
 # Agent-CSA Bundle
 
+> :construction: &nbsp;Status: Experimental
+
 This directory exists purely to contain scripts/toold to build
 and publish a module that contains the Cisco Secure Application (CSA)
 extension bundled with `splunk-otel-java`.
 
 * group: `com.splunk`
 * artifact: `splunk-otel-javaagent-csa`
+
+## Build locally:
+
+Requirements:
+* Internet
+* Docker client
+* Java `jar` command in path
+* common unix tools
+
+From the root of the project:
+
+```bash
+$ ./gradlew agent-csa-bundle:assemble
+```
+
+The resulting bundle will be located at 
+`agent-csa-bundle/build/splunk-otel-javaagent-csa-<version>.jar`.

--- a/agent-csa-bundle/README.md
+++ b/agent-csa-bundle/README.md
@@ -1,0 +1,9 @@
+
+# Agent-CSA Bundle
+
+This directory exists purely to contain scripts/toold to build
+and publish a module that contains the Cisco Secure Application (CSA)
+extension bundled with `splunk-otel-java`.
+
+* group: `com.splunk`
+* artifact: `splunk-otel-javaagent-csa`

--- a/agent-csa-bundle/README.md
+++ b/agent-csa-bundle/README.md
@@ -24,5 +24,5 @@ From the root of the project:
 $ ./gradlew agent-csa-bundle:assemble
 ```
 
-The resulting bundle will be located at 
+The resulting bundle will be located at
 `agent-csa-bundle/build/splunk-otel-javaagent-csa-<version>.jar`.

--- a/agent-csa-bundle/build-agent-csa-fat-jar.sh
+++ b/agent-csa-bundle/build-agent-csa-fat-jar.sh
@@ -30,12 +30,10 @@ mkdir -p "${SPLUNK_TEMP}"
 mkdir -p "${CSA_TEMP}"
 mkdir -p "${ADAPTORS_DIR}"
 
-# Fetch CSA extension from relases repo
-# FIXME XXX this is for local development until the repo is public:
-cp /tmp/${CSA_EXT_JAR} ${WORKING_DIR}/${CSA_EXT_JAR}
-#curl --fail --show-error -o \
-#  ${WORKING_DIR}/${CSA_EXT_JAR} \
-#  https://github.com/signalfx/csa-releases/releases/download/${CSA_VERSION}/${CSA_EXT_JAR}
+# Fetch CSA extension from releases repo
+curl --fail --show-error -o \
+  ${WORKING_DIR}/${CSA_EXT_JAR} \
+  https://github.com/signalfx/csa-releases/releases/download/${CSA_VERSION}/${CSA_EXT_JAR}
 
 # copy splunk-otel-java jar
 MYDIR=`dirname $0`

--- a/agent-csa-bundle/build-agent-csa-fat-jar.sh
+++ b/agent-csa-bundle/build-agent-csa-fat-jar.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+set -e
+
+VERSION=$1
+CSA_VERSION=$2
+if [ "" == "$VERSION" ] ; then
+  echo "Missing version parameter to $0"
+  exit 1
+fi
+if [ "" == "$CSA_VERSION" ] ; then
+  echo "Missing CSA version param to $0"
+  exit 1
+fi
+echo "Building version $VERSION for CSA version $CSA_VERSION"
+
+export CSA_EXT_CONFIG_PROPERTIES="otel-extension-system.properties"
+export SPLUNK_FAT_JAR="splunk-otel-javaagent-${VERSION}.jar"
+export CSA_EXT_JAR="oss-agent-mtagent-extension-deployment.jar"
+
+export BUILD_DIR=build
+export WORKING_DIR=${BUILD_DIR}/temp
+export SPLUNK_TEMP=${WORKING_DIR}/splunk
+export CSA_TEMP=${WORKING_DIR}/csa
+export ADAPTORS_DIR="${WORKING_DIR}/inst/com/cisco/mtagent/adaptors"
+export OUTPUT_JAR="${BUILD_DIR}/splunk-otel-javaagent-csa-${VERSION}.jar"
+
+rm -rf "${BUILD_DIR}" "${WORKING_DIR}" "${SPLUNK_TEMP}" "${CSA_TEMP}"
+mkdir -p "${SPLUNK_TEMP}"
+mkdir -p "${CSA_TEMP}"
+mkdir -p "${ADAPTORS_DIR}"
+
+# Fetch CSA extension via dockerhub image
+
+docker pull appdynamics/secureapp-otel-java-extension:latest
+EXT_IMG=$(docker create --name tmpc appdynamics/secureapp-otel-java-extension:latest)
+docker cp \
+  ${EXT_IMG}:/opt/appdynamics/otel-java-extensions/oss-agent-mtagent-extension-deployment.jar \
+  ${WORKING_DIR}/${CSA_EXT_JAR}
+docker rm tmpc
+
+# FIXME XXX this is for local development until the repo is public:
+#cp /tmp/${CSA_EXT_JAR} ${WORKING_DIR}/${CSA_EXT_JAR}
+#curl --fail --show-error -o \
+#  ${WORKING_DIR}/${CSA_EXT_JAR} \
+#  https://github.com/signalfx/csa-releases/releases/download/${CSA_VERSION}/${CSA_EXT_JAR}
+
+# copy splunk-otel-java jar
+MYDIR=`dirname $0`
+cp ${MYDIR}/../agent/build/libs/${SPLUNK_FAT_JAR} ${OUTPUT_JAR}
+
+cp ${CSA_EXT_CONFIG_PROPERTIES} ${WORKING_DIR}/${CSA_EXT_CONFIG_PROPERTIES}
+
+# unpack csa jar into csa dir
+unzip -o "${WORKING_DIR}/${CSA_EXT_JAR}" -d "${CSA_TEMP}" \
+  com/cisco/mtagent/adaptors/AgentOSSAgentExtension.class \
+  com/cisco/mtagent/adaptors/AgentOSSAgentExtensionUtil.class
+
+# add extension interface and util/helper
+cp ${CSA_TEMP}/com/cisco/mtagent/adaptors/AgentOSSAgentExtension.class \
+  ${ADAPTORS_DIR}/AgentOSSAgentExtension.classdata
+cp ${CSA_TEMP}/com/cisco/mtagent/adaptors/AgentOSSAgentExtensionUtil.class \
+  ${ADAPTORS_DIR}/AgentOSSAgentExtensionUtil.classdata
+jar uf ${OUTPUT_JAR} -C "${WORKING_DIR}"  \
+  inst/com/cisco/mtagent/adaptors/AgentOSSAgentExtension.classdata
+jar uf ${OUTPUT_JAR} -C "${WORKING_DIR}" \
+  inst/com/cisco/mtagent/adaptors/AgentOSSAgentExtensionUtil.classdata
+
+# add extension to service loader
+unzip -o "${OUTPUT_JAR}" -d "${WORKING_DIR}" \
+  inst/META-INF/services/io.opentelemetry.javaagent.extension.AgentListener
+echo "com.cisco.mtagent.adaptors.AgentOSSAgentExtension" \
+  >> "${WORKING_DIR}/inst/META-INF/services/io.opentelemetry.javaagent.extension.AgentListener"
+jar uf "${OUTPUT_JAR}" -C "${WORKING_DIR}" \
+  inst/META-INF/services/io.opentelemetry.javaagent.extension.AgentListener
+
+# add config properties
+jar uf "${OUTPUT_JAR}" -C "${WORKING_DIR}" "${CSA_EXT_CONFIG_PROPERTIES}"
+# add csa extension jar to splunk fat jar
+jar uf "${OUTPUT_JAR}" -C "${WORKING_DIR}" "${CSA_EXT_JAR}"
+
+# add csa version to manifest
+echo "Cisco-Secure-Application-Version: ${CSA_VERSION}" >> "${WORKING_DIR}/MANIFEST.MF"
+jar -u -m "${WORKING_DIR}/MANIFEST.MF" -f "${OUTPUT_JAR}"
+
+# show modifications
+echo
+echo "====== Modifications to Splunk Fat Jar Here ====>"
+jar tf "${OUTPUT_JAR}" | grep "${CSA_EXT_CONFIG_PROPERTIES}"
+jar tf "${OUTPUT_JAR}" | grep "${CSA_EXT_JAR}"
+jar tf "${OUTPUT_JAR}" | grep AgentOSSAgentExtension
+jar tf "${OUTPUT_JAR}" | grep services/io.opentelemetry.javaagent.extension.AgentListener
+jar tf "${OUTPUT_JAR}" | grep ^META-INF/MANIFEST.MF
+echo "====== Modifications Done."
+echo

--- a/agent-csa-bundle/build-agent-csa-fat-jar.sh
+++ b/agent-csa-bundle/build-agent-csa-fat-jar.sh
@@ -31,7 +31,7 @@ mkdir -p "${CSA_TEMP}"
 mkdir -p "${ADAPTORS_DIR}"
 
 # Fetch CSA extension from releases repo
-curl --fail --show-error -o \
+curl --fail --show-error -L -o \
   ${WORKING_DIR}/${CSA_EXT_JAR} \
   https://github.com/signalfx/csa-releases/releases/download/${CSA_VERSION}/${CSA_EXT_JAR}
 

--- a/agent-csa-bundle/build-agent-csa-fat-jar.sh
+++ b/agent-csa-bundle/build-agent-csa-fat-jar.sh
@@ -33,7 +33,7 @@ mkdir -p "${ADAPTORS_DIR}"
 # Fetch CSA extension via dockerhub image
 
 docker pull appdynamics/secureapp-otel-java-extension:latest
-EXT_IMG=$(docker create --name tmpc appdynamics/secureapp-otel-java-extension:latest)
+EXT_IMG=$(docker create --name tmpc appdynamics/secureapp-otel-java-extension:${CSA_VERSION})
 docker cp \
   ${EXT_IMG}:/opt/appdynamics/otel-java-extensions/oss-agent-mtagent-extension-deployment.jar \
   ${WORKING_DIR}/${CSA_EXT_JAR}

--- a/agent-csa-bundle/build-agent-csa-fat-jar.sh
+++ b/agent-csa-bundle/build-agent-csa-fat-jar.sh
@@ -30,17 +30,9 @@ mkdir -p "${SPLUNK_TEMP}"
 mkdir -p "${CSA_TEMP}"
 mkdir -p "${ADAPTORS_DIR}"
 
-# Fetch CSA extension via dockerhub image
-
-docker pull appdynamics/secureapp-otel-java-extension:latest
-EXT_IMG=$(docker create --name tmpc appdynamics/secureapp-otel-java-extension:${CSA_VERSION})
-docker cp \
-  ${EXT_IMG}:/opt/appdynamics/otel-java-extensions/oss-agent-mtagent-extension-deployment.jar \
-  ${WORKING_DIR}/${CSA_EXT_JAR}
-docker rm tmpc
-
+# Fetch CSA extension from relases repo
 # FIXME XXX this is for local development until the repo is public:
-#cp /tmp/${CSA_EXT_JAR} ${WORKING_DIR}/${CSA_EXT_JAR}
+cp /tmp/${CSA_EXT_JAR} ${WORKING_DIR}/${CSA_EXT_JAR}
 #curl --fail --show-error -o \
 #  ${WORKING_DIR}/${CSA_EXT_JAR} \
 #  https://github.com/signalfx/csa-releases/releases/download/${CSA_VERSION}/${CSA_EXT_JAR}

--- a/agent-csa-bundle/build.gradle.kts
+++ b/agent-csa-bundle/build.gradle.kts
@@ -1,0 +1,82 @@
+
+plugins {
+  id("maven-publish")
+  id("signing")
+}
+
+dependencies {
+  implementation(project(":agent"))
+}
+
+// This should be updated for every CSA release
+val csaVersion = "25.3.0-1321"
+base.archivesName.set("splunk-otel-javaagent-csa")
+
+tasks {
+  val bundleSecureApp by registering(Exec::class) {
+    description = "Bundle the Cisco SecureApp with splunk-otel-java"
+    dependsOn(":agent:assemble")
+    isIgnoreExitValue = false
+    commandLine("./build-agent-csa-fat-jar.sh", version, csaVersion)
+    outputs.file(File("build/splunk-otel-javaagent-csa-$version.jar"))
+  }
+
+  jar {
+    inputs.files(bundleSecureApp)
+  }
+
+  assemble {
+    dependsOn(bundleSecureApp)
+  }
+
+  publishing {
+    publications {
+      register<MavenPublication>("maven") {
+        artifactId = "splunk-otel-javaagent-csa"
+        groupId = "com.splunk"
+        version = project.version.toString()
+
+        artifact(bundleSecureApp)
+
+        pom {
+          name.set("splunk-otel-java with Cisco SecureApp bundle")
+          description.set("A distribution of the OpenTelemetry Instrumentation for Java which includes a bundled version of the Cisco SecureApp")
+          url.set("https://github.com/signalfx/splunk-otel-java")
+          packaging = "jar"
+
+          licenses {
+            license {
+              name.set("The Apache License, Version 2.0")
+              url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+            }
+          }
+
+          developers {
+            developer {
+              id.set("splunk")
+              name.set("Splunk Instrumentation Authors")
+              email.set("support+java@signalfx.com")
+              organization.set("Splunk")
+              organizationUrl.set("https://www.splunk.com")
+            }
+          }
+
+          scm {
+            connection.set("https://github.com/signalfx/splunk-otel-java.git")
+            developerConnection.set("https://github.com/signalfx/splunk-otel-java.git")
+            url.set("https://github.com/signalfx/splunk-otel-java")
+          }
+        }
+      }
+    }
+  }
+
+  val gpgSecretKey = System.getenv("GPG_SECRET_KEY")
+  val gpgPassword = System.getenv("GPG_PASSWORD")
+  if (gpgSecretKey != null && gpgPassword != null) {
+    signing {
+      useInMemoryPgpKeys(gpgSecretKey, gpgPassword)
+      sign(publishing.publications["maven"])
+    }
+  }
+}

--- a/agent-csa-bundle/build.gradle.kts
+++ b/agent-csa-bundle/build.gradle.kts
@@ -9,7 +9,9 @@ dependencies {
 }
 
 // This should be updated for every CSA release
-val csaVersion = "25.3.0-1321"
+// This version must match the version in dockerhub
+//val csaVersion = "25.3.0-1321"
+val csaVersion = "23.10.0-1153"
 base.archivesName.set("splunk-otel-javaagent-csa")
 
 tasks {

--- a/agent-csa-bundle/build.gradle.kts
+++ b/agent-csa-bundle/build.gradle.kts
@@ -9,9 +9,7 @@ dependencies {
 }
 
 // This should be updated for every CSA release
-// This version must match the version in dockerhub
-//val csaVersion = "25.3.0-1321"
-val csaVersion = "23.10.0-1153"
+val csaVersion = "25.3.0-1321"
 base.archivesName.set("splunk-otel-javaagent-csa")
 
 tasks {

--- a/agent-csa-bundle/otel-extension-system.properties
+++ b/agent-csa-bundle/otel-extension-system.properties
@@ -1,0 +1,22 @@
+# OTEL Extension Properties - NOTE: These are System Properties and can be overridden if set on the startup command line
+#
+#---- Enable full OTEL for CSaaS (CSA Controller) and for the Pipeline (OTIS, AppD Cloud) - send Event Signal
+#
+# multi.tenant.agent.otel.csaas.enabled=true          // Set to enable sending to CSA Controller in CSaas - if OTEL and disabled - it means standalone mode
+# multi.tenant.agent.otel.pipeline.enabled=false      // Set to enable sending Events, etc. to the OTEL Collector as Events and Span Events, Attributes, etc.
+# multi.tenant.agent.otel.send.log.events=false       // Set to enable sending standalone Events not attached to a Span
+# multi.tenant.agent.otel.send.fake.log.events=false  // Set to enable sending Generic Data as Standalone Events
+#
+#---- AppDynamics Configuration to find CSaaS CSA Controller - app/tier/node will be defined via the OSS Agent otel.resource.attributes=
+#
+# appdynamics.controller.hostName=fusion-master.saas.appd-test.com   // CSaas Host
+# appdynamics.controller.ssl.enabled=true                            // SSL (actually TLS)
+# appdynamics.controller.port=443                                    // TLS Port
+# appdynamics.agent.accountName=<account-name>                       // CSaas Tenant
+# appdynamics.agent.accountAccessKey=<accessKey>                     // CSaas Tenant Key
+#
+#---- For OTIS Registration (Disabled by default - need more work to enable Java 9+)
+#
+# multi.tenant.agent.local.otis.registration.attempts=0                                                             // Use Agent OTEL Exporter to register with OTIS (if value > 0)
+# multi.tenant.agent.local.otis.registration.endpoint=https://pdx-sls-agent-api.saas.appdynamics.com/v1/traces      // OTIS Endpoint
+# multi.tenant.agent.local.otis.registration.endpoint.apikey=<key>                                                  // OTIS Endpoint API Key

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,7 @@ rootProject.name = "splunk-otel-java"
 include(":dependencyManagement")
 include(
     "agent",
+    "agent-csa-bundle",
     "bootstrap",
     "custom",
     "instrumentation",


### PR DESCRIPTION
This adds a module that will publish a second jar file that contains the Cisco Secure Application extension bundled inside `splunk-otel-java`. The output jar is named `splunk-otel-javaagent-csa-<version>.jar`.
