### PR TITLE
Only Stop Trace Profiling When Same Span Ends

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/ScheduledExecutorStackTraceSampler.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/ScheduledExecutorStackTraceSampler.java
@@ -36,8 +36,7 @@ class ScheduledExecutorStackTraceSampler implements StackTraceSampler {
       Logger.getLogger(ScheduledExecutorStackTraceSampler.class.getName());
   private static final int SCHEDULER_INITIAL_DELAY = 0;
 
-  private final ConcurrentMap<String, ScheduledExecutorService> samplers =
-      new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, ThreadSampler> samplers = new ConcurrentHashMap<>();
   private final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
   private final StagingArea stagingArea;
   private final Supplier<SpanTracker> spanTracker;
@@ -53,29 +52,46 @@ class ScheduledExecutorStackTraceSampler implements StackTraceSampler {
   @Override
   public void start(SpanContext spanContext) {
     samplers.computeIfAbsent(
-        spanContext.getTraceId(),
-        traceId -> {
-          ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
-          scheduler.scheduleAtFixedRate(
-              new StackTraceGatherer(
-                  samplingPeriod, spanContext.getTraceId(), Thread.currentThread()),
-              SCHEDULER_INITIAL_DELAY,
-              samplingPeriod.toMillis(),
-              TimeUnit.MILLISECONDS);
-          return scheduler;
-        });
+        spanContext.getTraceId(), id -> new ThreadSampler(spanContext, samplingPeriod));
   }
 
   @Override
   public void stop(SpanContext spanContext) {
-    ScheduledExecutorService scheduler = samplers.remove(spanContext.getTraceId());
-    if (scheduler != null) {
-      scheduler.shutdown();
-    }
-    stagingArea.empty(spanContext.getTraceId());
+    samplers.computeIfPresent(
+        spanContext.getTraceId(),
+        (traceId, sampler) -> {
+          if (spanContext.equals(sampler.getSpanContext())) {
+            sampler.shutdown();
+            stagingArea.empty(spanContext.getTraceId());
+            return null;
+          }
+          return sampler;
+        });
   }
 
-  class StackTraceGatherer implements Runnable {
+  private class ThreadSampler {
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    private final SpanContext spanContext;
+
+    ThreadSampler(SpanContext spanContext, Duration samplingPeriod) {
+      this.spanContext = spanContext;
+      scheduler.scheduleAtFixedRate(
+          new StackTraceGatherer(samplingPeriod, spanContext.getTraceId(), Thread.currentThread()),
+          SCHEDULER_INITIAL_DELAY,
+          samplingPeriod.toMillis(),
+          TimeUnit.MILLISECONDS);
+    }
+
+    void shutdown() {
+      scheduler.shutdown();
+    }
+
+    SpanContext getSpanContext() {
+      return spanContext;
+    }
+  }
+
+  private class StackTraceGatherer implements Runnable {
     private final Duration samplingPeriod;
     private final String traceId;
     private final Thread thread;


### PR DESCRIPTION
This PR closes a bug that could cause the snapshot profiling of a trace to be stopped before the thread being profiled has actually stopped processing that trace. This is possible when multiple API calls are made to a service simultaneously the a thread that did not start the profiling is the first thread to finish processing its request.