### PR TITLE
Use Daemon Threads In Trace Snapshot Profiler

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/AsyncStackTraceExporter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/AsyncStackTraceExporter.java
@@ -19,18 +19,19 @@ package com.splunk.opentelemetry.profiler.snapshot;
 import com.splunk.opentelemetry.profiler.InstrumentationSource;
 import com.splunk.opentelemetry.profiler.exporter.CpuEventExporter;
 import com.splunk.opentelemetry.profiler.exporter.PprofCpuEventExporter;
+import com.splunk.opentelemetry.profiler.util.HelpfulExecutors;
 import io.opentelemetry.api.logs.Logger;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.logging.Level;
 
 class AsyncStackTraceExporter implements StackTraceExporter {
   private static final java.util.logging.Logger logger =
       java.util.logging.Logger.getLogger(AsyncStackTraceExporter.class.getName());
 
-  private final ExecutorService executor = Executors.newSingleThreadExecutor();
+  private final ExecutorService executor =
+      HelpfulExecutors.newSingleThreadExecutor("async-stack-trace-exporter");
   private final Logger otelLogger;
   private final Duration samplingPeriod;
   private final int maxDepth;

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/ScheduledExecutorStackTraceSampler.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/ScheduledExecutorStackTraceSampler.java
@@ -16,6 +16,7 @@
 
 package com.splunk.opentelemetry.profiler.snapshot;
 
+import com.splunk.opentelemetry.profiler.util.HelpfulExecutors;
 import io.opentelemetry.api.trace.SpanContext;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
@@ -24,7 +25,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -70,11 +70,14 @@ class ScheduledExecutorStackTraceSampler implements StackTraceSampler {
   }
 
   private class ThreadSampler {
-    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    private final ScheduledExecutorService scheduler;
     private final SpanContext spanContext;
 
     ThreadSampler(SpanContext spanContext, Duration samplingPeriod) {
       this.spanContext = spanContext;
+      scheduler =
+          HelpfulExecutors.newSingleThreadedScheduledExecutor(
+              "stack-trace-sampler-" + spanContext.getTraceId());
       scheduler.scheduleAtFixedRate(
           new StackTraceGatherer(samplingPeriod, spanContext.getTraceId(), Thread.currentThread()),
           SCHEDULER_INITIAL_DELAY,


### PR DESCRIPTION
This PR updates the `ExecutorService` and `ScheduledExecutorService` instances in the trace snapshot profiler to use implementations that create daemon threads.