### PR TITLE
Fix Flaky test in ScheduledExecutorStackTraceSamplerTest

### DIFF
--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/ScheduledExecutorStackTraceSamplerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/ScheduledExecutorStackTraceSamplerTest.java
@@ -137,8 +137,9 @@ class ScheduledExecutorStackTraceSamplerTest {
 
     try {
       start1.countDown();
-      start2.countDown();
       await().until(() -> staging.allStackTraces().size() > 1);
+      start2.countDown();
+      await().until(() -> staging.allStackTraces().size() > 2);
 
       stop2.countDown();
       int numberOfStackTraces = staging.allStackTraces().size();


### PR DESCRIPTION
This PR fixes an unreliable test recently introduced in `ScheduledExecutorStackTraceSamplerTest`. The test relied on a specific span to start the trace profiling.