### PR TITLE
Signing docker images published on quay.io

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,6 +61,13 @@ publish-docker-image:
   stage: post-release
   rules:
     - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(-alpha)?.*/'
+  variables:
+    SIGNING_SERVICE_ADDR: "https://signing.prod.svc.splunk8s.io"
+  id_tokens:
+    CI_JOB_JWT:
+      aud:
+        - $CICD_VAULT_ADDR
+        - $SIGNING_SERVICE_ADDR
   before_script:
     - ./scripts/install-docker-deps.sh
     - ./scripts/install-gh-deps.sh

--- a/scripts/publish-docker-image.sh
+++ b/scripts/publish-docker-image.sh
@@ -47,6 +47,12 @@ publish_docker_image() {
   docker push "quay.io/signalfx/splunk-otel-instrumentation-java:$release_tag"
 }
 
+sign_published_docker_image() {
+  echo ">>> Signing the published operator docker image ..."
+  artifact-ci sign docker "quay.io/signalfx/splunk-otel-instrumentation-java:$release_tag"
+}
+
 build_docker_image
 login_to_quay_io
 publish_docker_image
+sign_published_docker_image


### PR DESCRIPTION
Automatic signing docker images published on quay.io during the release process.
Procedure is described [here](https://cd.splunkdev.com/cloud-automation/ci-cd/artifactory/artifact-ci#sign-docker)