### PR TITLE
Make AccumulatingStagingArea Thread Safe

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/AccumulatingStagingArea.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/AccumulatingStagingArea.java
@@ -16,7 +16,6 @@
 
 package com.splunk.opentelemetry.profiler.snapshot;
 
-import java.util.ArrayList;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -48,7 +47,7 @@ class AccumulatingStagingArea implements StagingArea {
   public void empty(String traceId) {
     Queue<StackTrace> stackTraces = this.stackTraces.remove(traceId);
     if (stackTraces != null) {
-      exporter.get().export(new ArrayList<>(stackTraces));
+      exporter.get().export(stackTraces);
     }
   }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/AccumulatingStagingArea.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/AccumulatingStagingArea.java
@@ -17,13 +17,14 @@
 package com.splunk.opentelemetry.profiler.snapshot;
 
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Supplier;
 
 class AccumulatingStagingArea implements StagingArea {
-  private final ConcurrentMap<String, List<StackTrace>> stackTraces = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, Queue<StackTrace>> stackTraces = new ConcurrentHashMap<>();
   private final Supplier<StackTraceExporter> exporter;
 
   AccumulatingStagingArea(Supplier<StackTraceExporter> exporter) {
@@ -36,7 +37,7 @@ class AccumulatingStagingArea implements StagingArea {
         traceId,
         (id, stackTraces) -> {
           if (stackTraces == null) {
-            stackTraces = new ArrayList<>();
+            stackTraces = new ConcurrentLinkedQueue<>();
           }
           stackTraces.add(stackTrace);
           return stackTraces;
@@ -45,9 +46,9 @@ class AccumulatingStagingArea implements StagingArea {
 
   @Override
   public void empty(String traceId) {
-    List<StackTrace> stackTraces = this.stackTraces.remove(traceId);
+    Queue<StackTrace> stackTraces = this.stackTraces.remove(traceId);
     if (stackTraces != null) {
-      exporter.get().export(stackTraces);
+      exporter.get().export(new ArrayList<>(stackTraces));
     }
   }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/AsyncStackTraceExporter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/AsyncStackTraceExporter.java
@@ -21,7 +21,7 @@ import com.splunk.opentelemetry.profiler.exporter.CpuEventExporter;
 import com.splunk.opentelemetry.profiler.exporter.PprofCpuEventExporter;
 import io.opentelemetry.api.logs.Logger;
 import java.time.Duration;
-import java.util.List;
+import java.util.Collection;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;
@@ -42,11 +42,11 @@ class AsyncStackTraceExporter implements StackTraceExporter {
   }
 
   @Override
-  public void export(List<StackTrace> stackTraces) {
+  public void export(Collection<StackTrace> stackTraces) {
     executor.submit(pprofExporter(otelLogger, stackTraces));
   }
 
-  private Runnable pprofExporter(Logger otelLogger, List<StackTrace> stackTraces) {
+  private Runnable pprofExporter(Logger otelLogger, Collection<StackTrace> stackTraces) {
     return () -> {
       try {
         CpuEventExporter cpuEventExporter =

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/StackTraceExporter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/StackTraceExporter.java
@@ -16,11 +16,11 @@
 
 package com.splunk.opentelemetry.profiler.snapshot;
 
-import java.util.List;
+import java.util.Collection;
 
 /** Works in concert with the {@link StagingArea} to export a batch of {@link StackTrace}s */
 interface StackTraceExporter {
   StackTraceExporter NOOP = stackTraces -> {};
 
-  void export(List<StackTrace> stackTraces);
+  void export(Collection<StackTrace> stackTraces);
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/InMemoryStackTraceExporter.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/InMemoryStackTraceExporter.java
@@ -17,6 +17,7 @@
 package com.splunk.opentelemetry.profiler.snapshot;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -28,7 +29,7 @@ class InMemoryStackTraceExporter implements StackTraceExporter {
   private final List<StackTrace> stackTraces = new ArrayList<>();
 
   @Override
-  public void export(List<StackTrace> stackTraces) {
+  public void export(Collection<StackTrace> stackTraces) {
     this.stackTraces.addAll(stackTraces);
   }
 


### PR DESCRIPTION
Stores staged `StackTrace` instances in a thread-safe `Queue` while exporting a "view" of that `Queue` when `empty` is called.