### PR TITLE
Attempt to fix gitlab build

### DIFF
--- a/agent-csa-bundle/build.gradle.kts
+++ b/agent-csa-bundle/build.gradle.kts
@@ -52,7 +52,9 @@ tasks {
   // This exists purely to get the extension jar into our build dir
   val copyCsaJar by registering(Jar::class) {
     archiveFileName.set("oss-agent-mtagent-extension-deployment.jar")
-    from(zipTree(csaReleases.singleFile))
+    doFirst {
+      from(zipTree(csaReleases.singleFile))
+    }
   }
 
   // Extract and rename extension classes


### PR DESCRIPTION
After #2287 was merged, the snapshot builds in _gitlab_ began failing due to 

```
FAILURE: Build failed with an exception.
* What went wrong:
A problem occurred configuring project ':agent-csa-bundle'.
> Cannot change hierarchy of dependency configuration ':agent-csa-bundle:csaReleases' after it has been resolved.
```

Obviously a very clear and helpful error message. 🙄 

Especially weird that the exact same gradle command passes both locally on my box but also in GitHub. Feh.

Anyway, I found some prior art that this kind of problem is caused by stuff being done at config time. Because it's complaining about the `csReleases` config, and the config is only mentioned in 3 places (the declaration of the config itself, once in the dependency block, and the `zipTree()` copy [as changed in this PR]), I figured it was worth a shot. It doesn't seem to break anything anyway.