### PR TITLE
Update flightrecorder dependency

### DIFF
--- a/profiler/build.gradle.kts
+++ b/profiler/build.gradle.kts
@@ -32,7 +32,9 @@ dependencies {
   implementation("io.opentelemetry:opentelemetry-sdk-logs")
   implementation("io.opentelemetry:opentelemetry-exporter-otlp")
   implementation("com.google.protobuf:protobuf-java")
-  implementation("org.openjdk.jmc:flightrecorder:8.3.1")
+  implementation("org.openjdk.jmc:flightrecorder:9.1.0") {
+    exclude(group = "org.lz4", module = "lz4-java")
+  }
 
   annotationProcessor("com.google.auto.service:auto-service")
   compileOnly("com.google.auto.service:auto-service")


### PR DESCRIPTION
We are currently behind a major version for some reason. Not sure why renovate didn't pick it up (but maybe just because it's a major).

Furthermore, we have a transitive dependency on `lz4-java` which contains binary libs (`.so` and `.dynlib` files), and there's a long-standing CVE that triggers on those binaries. The transitive dependency comes in through `jmc` via `flightrecorder`. Unfortunately, even this new/latest version of flightrecorder still depends on an old/vulnerable version of `lz4-java` ([see here](https://github.com/openjdk/jmc/blob/612df4b11eb65bd6e1666c6e774dc6c9c7bed60b/core/org.openjdk.jmc.common/pom.xml#L53)).

See also the discussions in the `lz4-java` issues [#217](https://github.com/lz4/lz4-java/issues/217) and [#221](https://github.com/lz4/lz4-java/issues/221). It looks like `lz4-java` is probably abandonware at this point, and jmc will either fork it or drop the dependency.

In the meantime, there's really no need for us to include the lz4 dependency at all -- we don't use lz4 compressed flightrecorder files. I tested JFR-based profiling with this latest setting and confirmed that the the telemetry looks good and that the lz4 classes and binaries no longer show up in our distro.