### PR TITLE
Restrict nocode instrumentation to methods

### DIFF
--- a/instrumentation/nocode/src/main/java/com/splunk/opentelemetry/instrumentation/nocode/NocodeInstrumentation.java
+++ b/instrumentation/nocode/src/main/java/com/splunk/opentelemetry/instrumentation/nocode/NocodeInstrumentation.java
@@ -18,6 +18,7 @@ package com.splunk.opentelemetry.instrumentation.nocode;
 
 import static com.splunk.opentelemetry.instrumentation.nocode.NocodeSingletons.instrumenter;
 import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.none;
 
 import com.splunk.opentelemetry.javaagent.bootstrap.nocode.NocodeRules;
@@ -51,7 +52,7 @@ public final class NocodeInstrumentation implements TypeInstrumentation {
   @Override
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(
-        rule != null ? rule.getMethodMatcher() : none(),
+        rule != null ? isMethod().and(rule.getMethodMatcher()) : none(),
         mapping ->
             mapping
                 .bind(RuleId.class, JavaConstant.Simple.ofLoaded(rule != null ? rule.getId() : -1))


### PR DESCRIPTION
The advice code does not work for constructors. Explicitly restrict the matching to methods in case other rules allow matching a constructor.