### PR TITLE
Avoid NPE when nocode configuration file is not set

### DIFF
--- a/instrumentation/nocode/src/main/java/com/splunk/opentelemetry/instrumentation/nocode/NocodeInitializer.java
+++ b/instrumentation/nocode/src/main/java/com/splunk/opentelemetry/instrumentation/nocode/NocodeInitializer.java
@@ -37,6 +37,9 @@ public class NocodeInitializer implements BeforeAgentListener {
   public void beforeAgent(AutoConfiguredOpenTelemetrySdk autoConfiguredOpenTelemetrySdk) {
     ConfigProperties config = getConfig(autoConfiguredOpenTelemetrySdk);
     String yamlFileName = config.getString(NOCODE_YMLFILE);
+    if (yamlFileName == null || yamlFileName.trim().isEmpty()) {
+      return;
+    }
     List<NocodeRules.Rule> instrumentationRules = Collections.emptyList();
     try {
       instrumentationRules = YamlParser.parseFromFile(yamlFileName);

--- a/instrumentation/nocode/src/main/java/com/splunk/opentelemetry/instrumentation/nocode/YamlParser.java
+++ b/instrumentation/nocode/src/main/java/com/splunk/opentelemetry/instrumentation/nocode/YamlParser.java
@@ -47,7 +47,7 @@ class YamlParser {
   private final List<NocodeRules.Rule> instrumentationRules;
   private JexlEvaluator evaluator;
 
-  public static List<NocodeRules.Rule> parseFromFile(String yamlFileName) throws IOException {
+  static List<NocodeRules.Rule> parseFromFile(String yamlFileName) throws IOException {
     try (Reader reader = Files.newBufferedReader(Paths.get(yamlFileName.trim()))) {
       return new YamlParser(reader).getInstrumentationRules();
     }
@@ -62,7 +62,7 @@ class YamlParser {
     instrumentationRules = Collections.unmodifiableList(new ArrayList<>(loadUnsafe(reader)));
   }
 
-  public List<NocodeRules.Rule> getInstrumentationRules() {
+  private List<NocodeRules.Rule> getInstrumentationRules() {
     return instrumentationRules;
   }
 


### PR DESCRIPTION
```

05:51:25.462 [docker-java-stream--1691006325] ERROR c.s.o.h.w.WindowsTestContainerManager - STDERR: [otel.javaagent 2025-06-05 05:51:25:461 +0000] [main] ERROR com.splunk.opentelemetry.instrumentation.nocode.NocodeInitializer - Can't load configured nocode yaml. |  
-- | --
  | 05:51:25.464 [docker-java-stream--1691006325] ERROR c.s.o.h.w.WindowsTestContainerManager - STDERR: java.lang.NullPointerException |  
  | 05:51:25.465 [docker-java-stream--1691006325] ERROR c.s.o.h.w.WindowsTestContainerManager - STDERR: 	at com.splunk.opentelemetry.instrumentation.nocode.YamlParser.parseFromFile(YamlParser.java:51) |  
  | 05:51:25.466 [docker-java-stream--1691006325] ERROR c.s.o.h.w.WindowsTestContainerManager - STDERR: 	at com.splunk.opentelemetry.instrumentation.nocode.NocodeInitializer.beforeAgent(NocodeInitializer.java:42) |  
  | 05:51:25.466 [docker-java-stream--1691006325] ERROR c.s.o.h.w.WindowsTestContainerManager - STDERR: 	at io.opentelemetry.javaagent.tooling.AgentInstaller.installBytebuddyAgent(AgentInstaller.java:172) |  
  | 05:51:25.466 [docker-java-stream--1691006325] ERROR c.s.o.h.w.WindowsTestContainerManager - STDERR: 	at io.opentelemetry.javaagent.tooling.AgentInstaller.installBytebuddyAgent(AgentInstaller.java:110) |  
  | 05:51:25.466 [docker-java-stream--1691006325] ERROR c.s.o.h.w.WindowsTestContainerManager - STDERR: 	at io.opentelemetry.javaagent.tooling.AgentStarterImpl.start(AgentStarterImpl.java:101) |  
  | 05:51:25.466 [docker-java-stream--1691006325] ERROR c.s.o.h.w.WindowsTestContainerManager - STDERR: 	at io.opentelemetry.javaagent.bootstrap.AgentInitializer$2.run(AgentInitializer.java:66) |  
  | 05:51:25.466 [docker-java-stream--1691006325] ERROR c.s.o.h.w.WindowsTestContainerManager - STDERR: 	at io.opentelemetry.javaagent.bootstrap.AgentInitializer$2.run(AgentInitializer.java:60) |  
  | 05:51:25.467 [docker-java-stream--1691006325] ERROR c.s.o.h.w.WindowsTestContainerManager - STDERR: 	at io.opentelemetry.javaagent.bootstrap.AgentInitializer.execute(AgentInitializer.java:82) |  
  | 05:51:25.468 [docker-java-stream--1691006325] ERROR c.s.o.h.w.WindowsTestContainerManager - STDERR: 	at io.opentelemetry.javaagent.bootstrap.AgentInitializer.initialize(AgentInitializer.java:59) |  
  | 05:51:25.468 [docker-java-stream--1691006325] ERROR c.s.o.h.w.WindowsTestContainerManager - STDERR: 	at io.opentelemetry.javaagent.OpenTelemetryAgent.startAgent(OpenTelemetryAgent.java:59) |  
  | 05:51:25.468 [docker-java-stream--1691006325] ERROR c.s.o.h.w.WindowsTestContainerManager - STDERR: 	at io.opentelemetry.javaagent.OpenTelemetryAgent.agentmain(OpenTelemetryAgent.java:50) |  
  | 05:51:25.468 [docker-java-stream--1691006325] ERROR c.s.o.h.w.WindowsTestContainerManager - STDERR: 	at com.splunk.opentelemetry.javaagent.SplunkAgent.agentmain(SplunkAgent.java:28) |  
  | 05:51:25.468 [docker-java-stream--1691006325] ERROR c.s.o.h.w.WindowsTestContainerManager - STDERR: 	at com.splunk.opentelemetry.javaagent.SplunkAgent.premain(SplunkAgent.java:24) |  
  | 05:51:25.469 [docker-java-stream--1691006325] ERROR c.s.o.h.w.WindowsTestContainerManager - STDERR: 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) |  
  | 05:51:25.469 [docker-java-stream--1691006325] ERROR c.s.o.h.w.WindowsTestContainerManager - STDERR: 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) |  
  | 05:51:25.469 [docker-java-stream--1691006325] ERROR c.s.o.h.w.WindowsTestContainerManager - STDERR: 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) |  
  | 05:51:25.470 [docker-java-stream--1691006325] ERROR c.s.o.h.w.WindowsTestContainerManager - STDERR: 	at java.lang.reflect.Method.invoke(Method.java:498) |  
  | 05:51:25.470 [docker-java-stream--1691006325] ERROR c.s.o.h.w.WindowsTestContainerManager - STDERR: 	at sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:386) |  
  | 05:51:25.470 [docker-java-stream--1691006325] ERROR c.s.o.h.w.WindowsTestContainerManager - STDERR: 	at sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:401)


```