### PR TITLE
Update repos for sonatype central

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,10 @@ nexusPublishing {
   packageGroup.set("com.splunk")
 
   repositories {
+    // see https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration
     sonatype {
+      nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+      snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
       username.set(System.getenv("SONATYPE_USER"))
       password.set(System.getenv("SONATYPE_KEY"))
     }


### PR DESCRIPTION
See this annoucement: https://central.sonatype.org/news/20250326_ossrh_sunset/

and see this for the docs on this change https://github.com/gradle-nexus/publish-plugin?tab=readme-ov-file#publishing-to-maven-central-via-sonatype-central

Once a new token is generated and put into GitLab releaser repo, we can merge this to get the new urls into place.