### PR TITLE
update windows backend for smoke tests

### DIFF
--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/windows/WindowsTestContainerManager.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/windows/WindowsTestContainerManager.java
@@ -95,7 +95,7 @@ public class WindowsTestContainerManager extends AbstractTestContainerManager {
             .getId();
 
     String backendImageName =
-        "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-fake-backend-windows:20220411.2147767274";
+        "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-fake-backend-windows:20250530.15353244158";
 
     if (!imageExists(backendImageName)) {
       pullImage(backendImageName);


### PR DESCRIPTION
Related to #2335. Not super confident that this will fix the nightly build failure, but it looked from the build scans that they were all failing to stand up the windows backend.

<img width="962" alt="image" src="https://github.com/user-attachments/assets/8aa6f630-9149-4130-960e-9286a2caa8f7" />

Our reference was to a 3 year old image...so maybe they aged out? Let's see what this does anyway...even if it doesn't fix it, maybe it's a reasonable upgrade. 