### PR TITLE
Increase pull timeout for windows images

### DIFF
--- a/smoke-tests/build.gradle.kts
+++ b/smoke-tests/build.gradle.kts
@@ -29,7 +29,6 @@ tasks {
       if (System.getenv().containsKey("CI")) {
         // You can see tests that were retried by this mechanism in the collected test reports and build scans.
         maxRetries.set(5)
-        failOnPassedAfterRetry.set(true)
       } else {
         maxRetries.set(0)
       }

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/windows/WindowsTestContainerManager.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/helper/windows/WindowsTestContainerManager.java
@@ -328,7 +328,7 @@ public class WindowsTestContainerManager extends AbstractTestContainerManager {
       client
           .pullImageCmd(imageName)
           .exec(new PullImageResultCallback())
-          .awaitCompletion(10, TimeUnit.MINUTES);
+          .awaitCompletion(15, TimeUnit.MINUTES);
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
Resolves https://github.com/signalfx/splunk-otel-java/issues/2370
Resolves https://github.com/signalfx/splunk-otel-java/issues/2369
Resolves https://github.com/signalfx/splunk-otel-java/issues/2364
Resolves https://github.com/signalfx/splunk-otel-java/issues/2359

I recently added 10min timeout to windows images, apparently this is not enough and has been causing nightly build failures lately, so lets try increasing it. Also lets not fail the build when smoke tests succeed on retry. Upstream doesn't fail them either.