### PR TITLE
consolidate the lychee config under one roof

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,11 +24,7 @@ jobs:
           lycheeVersion: v0.18.1
           args: >-
             -v -n "*.md" "**/*.md"
-            --include-fragments
-            --exclude "https://developers.redhat.com/download-manager/file/jboss-eap-.*.zip"
-            --exclude "http://localhost*"
-            --exclude "https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/splunk/"
-            --max-retries 6
+            --config .lychee.toml
             --github-token ${{ github.token }}
 
   build:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -18,11 +18,7 @@ jobs:
           lycheeVersion: v0.18.1
           args: >-
             -v -n "*.md" "**/*.md"
-            --include-fragments
-            --exclude "https://developers.redhat.com/download-manager/file/jboss-eap-.*.zip"
-            --exclude "http://localhost*"
-            --exclude "https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/splunk/"
-            --max-retries 6
+            --config .lychee.toml
             --github-token ${{ github.token }}
 
   build:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,11 +20,7 @@ jobs:
           lycheeVersion: v0.18.1
           args: >-
             -v -n "*.md" "**/*.md"
-            --include-fragments
-            --exclude "https://developers.redhat.com/download-manager/file/jboss-eap-.*.zip"
-            --exclude "http://localhost*"
-            --exclude "https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/splunk/"
-            --max-retries 6
+            --config .lychee.toml
 
   build:
     runs-on: ubuntu-24.04

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,14 @@
+timeout = 30
+retry_wait_time = 5
+max_retries = 6
+max_concurrency = 4
+
+# Check link anchors
+include_fragments = true
+
+exclude = [
+  '^https://developers.redhat.com/download-manager/file/jboss-eap-.*.zip',
+  '^http://localhost.*',
+  '^https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/splunk/',
+  '^https://quickdraw.splunk.com/redirect/.*'
+]

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -6,9 +6,13 @@ max_concurrency = 4
 # Check link anchors
 include_fragments = true
 
+# Use a custom header to prevent being blocked from docs site
+header = { 'User-Agent' = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Lychee' }
+
 exclude = [
   '^https://developers.redhat.com/download-manager/file/jboss-eap-.*.zip',
   '^http://localhost.*',
   '^https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/splunk/',
-  '^https://quickdraw.splunk.com/redirect/.*'
+  '^https://quickdraw.splunk.com/redirect/.*',
+  '^https://docs.splunk.com/redirect/.*'
 ]

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -6,8 +6,6 @@ max_concurrency = 4
 # Check link anchors
 include_fragments = true
 
-cache = false
-
 # Use a custom user agent to prevent being blocked by Splunk docs site
 user_agent = 'User-Agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/115.0'
 

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -8,7 +8,7 @@ include_fragments = true
 
 # Use a custom header to prevent being blocked from docs site
 header = [
-  'User-Agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Lychee'
+  'User-Agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/115.0'
 ]
 
 exclude = [

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -8,10 +8,8 @@ include_fragments = true
 
 cache = false
 
-# Use a custom header to prevent being blocked from docs site
-header = [
-  'User-Agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/115.0'
-]
+# Use a custom user agent to prevent being blocked by Splunk docs site
+user_agent = 'User-Agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/115.0'
 
 exclude = [
   '^https://developers.redhat.com/download-manager/file/jboss-eap-.*.zip',

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -8,7 +8,7 @@ include_fragments = true
 
 # Use a custom header to prevent being blocked from docs site
 header = [
-  'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Lychee'
+  'User-Agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Lychee'
 ]
 
 exclude = [

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -7,7 +7,7 @@ max_concurrency = 4
 include_fragments = true
 
 # Use a custom user agent to prevent being blocked by Splunk docs site
-user_agent = 'User-Agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/115.0'
+user_agent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/115.0'
 
 exclude = [
   '^https://developers.redhat.com/download-manager/file/jboss-eap-.*.zip',

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -6,6 +6,8 @@ max_concurrency = 4
 # Check link anchors
 include_fragments = true
 
+cache = false
+
 # Use a custom header to prevent being blocked from docs site
 header = [
   'User-Agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/115.0'

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -13,6 +13,4 @@ exclude = [
   '^https://developers.redhat.com/download-manager/file/jboss-eap-.*.zip',
   '^http://localhost.*',
   '^https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/splunk/',
-  '^https://quickdraw.splunk.com/redirect/.*',
-  '^https://docs.splunk.com/redirect/.*'
 ]

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -7,7 +7,9 @@ max_concurrency = 4
 include_fragments = true
 
 # Use a custom header to prevent being blocked from docs site
-header = { 'User-Agent' = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Lychee' }
+header = [
+  'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Lychee'
+]
 
 exclude = [
   '^https://developers.redhat.com/download-manager/file/jboss-eap-.*.zip',

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,6 @@ When filing an issue, do *NOT* include:
 See [SECURITY.md](SECURITY.md#reporting-security-issues) for instructions.
 
 ## Documentation
-[shit](http://192.168.66.246:4001/shit)
 
 The Splunk Observability documentation is hosted on the [Splunk Observability
 Cloud docs site](https://docs.splunk.com/Observability), which contains all the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,7 @@ When filing an issue, do *NOT* include:
 See [SECURITY.md](SECURITY.md#reporting-security-issues) for instructions.
 
 ## Documentation
+[shit](http://192.168.66.246:4001/shit)
 
 The Splunk Observability documentation is hosted on the [Splunk Observability
 Cloud docs site](https://docs.splunk.com/Observability), which contains all the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,11 +40,6 @@ consists of step-by-step instructions, conceptual material, and decision support
 for customers. Reference documentation and development documentation is still
 hosted on this repository.
 
-To contribute documentation for this project, open a pull request in the
-[public-o11y-docs](https://github.com/splunk/public-o11y-docs) repository. See
-the [CONTRIBUTING.md](https://github.com/splunk/public-o11y-docs/blob/main/CONTRIBUTING.md)
-guide of the Splunk Observability Cloud documentation for more information.
-
 ## Contributing via Pull Requests
 
 Contributions via Pull Requests (PRs) are much appreciated. Before sending us a


### PR DESCRIPTION
... and add splunk quickdraw docs redirector as an exclude.

The quickdraw redirector is currently giving 403s and causing our jobs to fail.