### PR TITLE
Rename `rate` to `probability` for snapshotting

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingConfiguration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingConfiguration.java
@@ -33,7 +33,7 @@ public class SnapshotProfilingConfiguration implements AutoConfigurationCustomiz
   private static final String PREFIX = "splunk.snapshot.profiler";
   public static final String CONFIG_KEY_ENABLE_SNAPSHOT_PROFILER = PREFIX + ".enabled";
 
-  private static final String SELECTION_RATE_KEY = "splunk.snapshot.selection.rate";
+  private static final String SELECTION_PROBABILITY_KEY = "splunk.snapshot.selection.probability";
   private static final double DEFAULT_SELECTION_RATE = 0.01;
   private static final double MAX_SELECTION_RATE = 0.10;
 
@@ -57,7 +57,7 @@ public class SnapshotProfilingConfiguration implements AutoConfigurationCustomiz
         () -> {
           Map<String, String> map = new HashMap<>();
           map.put(CONFIG_KEY_ENABLE_SNAPSHOT_PROFILER, String.valueOf(false));
-          map.put(SELECTION_RATE_KEY, String.valueOf(DEFAULT_SELECTION_RATE));
+          map.put(SELECTION_PROBABILITY_KEY, String.valueOf(DEFAULT_SELECTION_RATE));
           map.put(STACK_DEPTH_KEY, String.valueOf(DEFAULT_STACK_DEPTH));
           map.put(SAMPLING_INTERVAL_KEY, DEFAULT_SAMPLING_INTERVAL_STRING);
           map.put(EXPORT_INTERVAL_KEY, DEFAULT_EXPORT_INTERVAL_STRING);
@@ -66,13 +66,26 @@ public class SnapshotProfilingConfiguration implements AutoConfigurationCustomiz
         });
   }
 
+  static void log(ConfigProperties properties) {
+    logger.fine("Snapshot Profiler Configuration:");
+    logger.fine("-------------------------------------------------------");
+
+    log(CONFIG_KEY_ENABLE_SNAPSHOT_PROFILER, isSnapshotProfilingEnabled(properties));
+    log(SELECTION_PROBABILITY_KEY, getSnapshotSelectionProbability(properties));
+    log(STACK_DEPTH_KEY, getStackDepth(properties));
+    log(SAMPLING_INTERVAL_KEY, getSamplingInterval(properties));
+    log(EXPORT_INTERVAL_KEY, getExportInterval(properties));
+    log(STAGING_CAPACITY_KEY, getStagingCapacity(properties));
+    logger.fine("-------------------------------------------------------");
+  }
+
   static boolean isSnapshotProfilingEnabled(ConfigProperties properties) {
     return properties.getBoolean(CONFIG_KEY_ENABLE_SNAPSHOT_PROFILER, false);
   }
 
-  static double getSnapshotSelectionRate(ConfigProperties properties) {
+  static double getSnapshotSelectionProbability(ConfigProperties properties) {
     String selectionRatePropertyValue =
-        properties.getString(SELECTION_RATE_KEY, String.valueOf(DEFAULT_SELECTION_RATE));
+        properties.getString(SELECTION_PROBABILITY_KEY, String.valueOf(DEFAULT_SELECTION_RATE));
     try {
       double selectionRate = Double.parseDouble(selectionRatePropertyValue);
       if (selectionRate > MAX_SELECTION_RATE) {
@@ -110,19 +123,6 @@ public class SnapshotProfilingConfiguration implements AutoConfigurationCustomiz
 
   static int getStagingCapacity(ConfigProperties properties) {
     return properties.getInt(STAGING_CAPACITY_KEY, DEFAULT_STAGING_CAPACITY);
-  }
-
-  static void log(ConfigProperties properties) {
-    logger.fine("Snapshot Profiler Configuration:");
-    logger.fine("-------------------------------------------------------");
-
-    log(CONFIG_KEY_ENABLE_SNAPSHOT_PROFILER, isSnapshotProfilingEnabled(properties));
-    log(SELECTION_RATE_KEY, getSnapshotSelectionRate(properties));
-    log(STACK_DEPTH_KEY, getStackDepth(properties));
-    log(SAMPLING_INTERVAL_KEY, getSamplingInterval(properties));
-    log(EXPORT_INTERVAL_KEY, getExportInterval(properties));
-    log(STAGING_CAPACITY_KEY, getStagingCapacity(properties));
-    logger.fine("-------------------------------------------------------");
   }
 
   private static void log(String key, Object value) {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotVolumePropagatorProvider.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotVolumePropagatorProvider.java
@@ -27,13 +27,14 @@ public class SnapshotVolumePropagatorProvider implements ConfigurablePropagatorP
 
   @Override
   public TextMapPropagator getPropagator(ConfigProperties config) {
-    double snapshotSelectionRate = SnapshotProfilingConfiguration.getSnapshotSelectionRate(config);
-    return new SnapshotVolumePropagator(selector(snapshotSelectionRate));
+    double selectionProbability =
+        SnapshotProfilingConfiguration.getSnapshotSelectionProbability(config);
+    return new SnapshotVolumePropagator(selector(selectionProbability));
   }
 
-  private SnapshotSelector selector(double selectionRate) {
-    return new TraceIdBasedSnapshotSelector(selectionRate)
-        .or(new ProbabilisticSnapshotSelector(selectionRate));
+  private SnapshotSelector selector(double selectionProbability) {
+    return new TraceIdBasedSnapshotSelector(selectionProbability)
+        .or(new ProbabilisticSnapshotSelector(selectionProbability));
   }
 
   @Override

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/TraceIdBasedSnapshotSelector.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/TraceIdBasedSnapshotSelector.java
@@ -29,11 +29,11 @@ import java.util.Collections;
 class TraceIdBasedSnapshotSelector implements SnapshotSelector {
   private final Sampler sampler;
 
-  TraceIdBasedSnapshotSelector(double selectionRate) {
-    if (selectionRate < 0 || selectionRate > 1) {
-      throw new IllegalArgumentException("Selection rate must be between 0 and 1.");
+  TraceIdBasedSnapshotSelector(double selectionProbability) {
+    if (selectionProbability < 0 || selectionProbability > 1) {
+      throw new IllegalArgumentException("Selection probability must be between 0 and 1.");
     }
-    this.sampler = Sampler.traceIdRatioBased(selectionRate);
+    this.sampler = Sampler.traceIdRatioBased(selectionProbability);
   }
 
   @Override

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingConfigurationTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingConfigurationTest.java
@@ -51,7 +51,7 @@ class SnapshotProfilingConfigurationTest {
     void defaultValuesAreProvidedToOpenTelemetry() {
       var properties = sdk.getConfig();
       assertEquals("false", properties.getString("splunk.snapshot.profiler.enabled"));
-      assertEquals("0.01", properties.getString("splunk.snapshot.selection.rate"));
+      assertEquals("0.01", properties.getString("splunk.snapshot.selection.probability"));
       assertEquals("1024", properties.getString("splunk.snapshot.profiler.max.stack.depth"));
       assertEquals("10ms", properties.getString("splunk.snapshot.profiler.sampling.interval"));
       assertEquals("5s", properties.getString("splunk.snapshot.profiler.export.interval"));
@@ -76,48 +76,48 @@ class SnapshotProfilingConfigurationTest {
 
   @ParameterizedTest
   @ValueSource(doubles = {0.10, 0.05, 0.0})
-  void getSnapshotSelectionRate(double selectionRate) {
+  void getSnapshotSelectionProbability(double selectionRate) {
     var properties =
         DefaultConfigProperties.create(
-            Map.of("splunk.snapshot.selection.rate", String.valueOf(selectionRate)),
+            Map.of("splunk.snapshot.selection.probability", String.valueOf(selectionRate)),
             COMPONENT_LOADER);
 
     double actualSelectionRate =
-        SnapshotProfilingConfiguration.getSnapshotSelectionRate(properties);
+        SnapshotProfilingConfiguration.getSnapshotSelectionProbability(properties);
     assertEquals(selectionRate, actualSelectionRate);
   }
 
   @Test
-  void getSnapshotSelectionRateUsesDefaultWhenPropertyNotSet() {
+  void getSnapshotSelectionProbabilityUsesDefaultWhenPropertyNotSet() {
     var properties = DefaultConfigProperties.create(Collections.emptyMap(), COMPONENT_LOADER);
 
     double actualSelectionRate =
-        SnapshotProfilingConfiguration.getSnapshotSelectionRate(properties);
+        SnapshotProfilingConfiguration.getSnapshotSelectionProbability(properties);
     assertEquals(0.01, actualSelectionRate);
   }
 
   @Test
-  void getSnapshotSelectionRateUsesDefaultValueIsNotNumeric() {
+  void getSnapshotSelectionProbabilityUsesDefaultValueIsNotNumeric() {
     var properties =
         DefaultConfigProperties.create(
-            Map.of("splunk.snapshot.selection.rate", "not-a-number"), COMPONENT_LOADER);
+            Map.of("splunk.snapshot.selection.probability", "not-a-number"), COMPONENT_LOADER);
 
     double actualSelectionRate =
-        SnapshotProfilingConfiguration.getSnapshotSelectionRate(properties);
+        SnapshotProfilingConfiguration.getSnapshotSelectionProbability(properties);
     assertEquals(0.01, actualSelectionRate);
   }
 
   @ParameterizedTest
   @ValueSource(doubles = {1.0, 0.5, 0.11})
-  void getSnapshotSelectionRateUsesMaxSelectionRateWhenConfiguredRateIsHigher(
+  void getSnapshotSelectionRateUsesMaxSelectionRateWhenConfiguredProbabilityIsHigher(
       double selectionRate) {
     var properties =
         DefaultConfigProperties.create(
-            Map.of("splunk.snapshot.selection.rate", String.valueOf(selectionRate)),
+            Map.of("splunk.snapshot.selection.probability", String.valueOf(selectionRate)),
             COMPONENT_LOADER);
 
     double actualSelectionRate =
-        SnapshotProfilingConfiguration.getSnapshotSelectionRate(properties);
+        SnapshotProfilingConfiguration.getSnapshotSelectionProbability(properties);
     assertEquals(0.10, actualSelectionRate);
   }
 
@@ -223,9 +223,10 @@ class SnapshotProfilingConfigurationTest {
     void includeSnapshotProfilingSelectionRate(double rate) {
       var properties =
           DefaultConfigProperties.create(
-              Map.of("splunk.snapshot.selection.rate", String.valueOf(rate)), COMPONENT_LOADER);
+              Map.of("splunk.snapshot.selection.probability", String.valueOf(rate)),
+              COMPONENT_LOADER);
       SnapshotProfilingConfiguration.log(properties);
-      log.assertContains("splunk.snapshot.selection.rate" + " : " + rate);
+      log.assertContains("splunk.snapshot.selection.probability" + " : " + rate);
     }
 
     @ParameterizedTest

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotVolumePropagatorProviderTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotVolumePropagatorProviderTest.java
@@ -57,7 +57,7 @@ class SnapshotVolumePropagatorProviderTest {
   void probabilisticSelectorIsConfigured() {
     var properties =
         DefaultConfigProperties.create(
-            Map.of("splunk.snapshot.selection.rate", "0.10"), COMPONENT_LOADER);
+            Map.of("splunk.snapshot.selection.probability", "0.10"), COMPONENT_LOADER);
 
     var carrier = new ObservableCarrier();
     var propagator = provider.getPropagator(properties);
@@ -77,7 +77,7 @@ class SnapshotVolumePropagatorProviderTest {
   void traceIdSelectorIsConfigured(String traceId) {
     var properties =
         DefaultConfigProperties.create(
-            Map.of("splunk.snapshot.selection.rate", "0.10"), COMPONENT_LOADER);
+            Map.of("splunk.snapshot.selection.probability", "0.10"), COMPONENT_LOADER);
 
     var remoteSpanContext = Snapshotting.spanContext().withTraceId(traceId).remote().build();
     var remoteParentSpan = Span.wrap(remoteSpanContext);

--- a/smoke-tests/src/test/java/com/splunk/opentelemetry/SnapshotProfilerSmokeTest.java
+++ b/smoke-tests/src/test/java/com/splunk/opentelemetry/SnapshotProfilerSmokeTest.java
@@ -156,7 +156,7 @@ public abstract class SnapshotProfilerSmokeTest {
                 "-Dotel.javaagent.debug=true",
                 "-Dotel.logs.exporter=none",
                 "-Dsplunk.snapshot.profiler.enabled=true",
-                "-Dsplunk.snapshot.selection.rate=0.1",
+                "-Dsplunk.snapshot.selection.probability=0.1",
                 "-Dsplunk.profiler.logs-endpoint=http://collector:4318/v1/logs",
                 // uncomment to enable exporting traces
                 // "-Dotel.exporter.otlp.endpoint=http://collector:4318",


### PR DESCRIPTION
This is simply a cosmetic rename of the term `rate`, which I think is too suggestive of time. I thought the term `probability` was more fitting here -- as it's the chance of something happening.