### PR TITLE
Update GitLab templates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,9 @@
 include:
-  - project: 'prodsec/scp-scanning/gitlab-checkmarx'
-    ref: latest
-    file: '/templates/.sast_scan.yml'
   - project: 'ci-cd/templates'
-    ref: master
+    ref: main
+    file: '/prodsec/.sast-scan.yml'
+  - project: 'ci-cd/templates'
+    ref: main
     file: '/prodsec/.oss-scan.yml'
 
 image:


### PR DESCRIPTION
* fix incorrect ref name
* address warning in build output:
```
==============================================================
[WARNING] This is NOT the official SAST template!
Using this template may lead to inaccurate scan results.
Please include the official template in your pipeline as shown below:
  - project: 'ci-cd/templates'
    file: '/prodsec/.sast-scan.yml'
==============================================================
```