### PR TITLE
Fix csa service file merging

### DIFF
--- a/agent-csa-bundle/build.gradle.kts
+++ b/agent-csa-bundle/build.gradle.kts
@@ -104,12 +104,14 @@ tasks {
       into("inst/com/cisco/mtagent/adaptors/")
       include("AgentOSSAgentExtension.classdata", "AgentOSSAgentExtensionUtil.classdata")
     }
-    // Merge service descriptor files
-    mergeServiceFiles {
-      include("inst/META-INF/services/io.opentelemetry.javaagent.extension.AgentListener")
-    }
+    // Merge service descriptor files requires duplicatesStrategy to be set
+    // Defaulted here to FAIL, because we only want to merge the one
+    duplicatesStrategy = DuplicatesStrategy.FAIL
+    mergeServiceFiles(rootPath = "inst/META-INF/services")
     from("build/ext-exploded/") {
       include("inst/META-INF/services/io.opentelemetry.javaagent.extension.AgentListener")
+      // Explicitly specify that this needs to be merged
+      duplicatesStrategy = DuplicatesStrategy.INCLUDE
     }
   }
 


### PR DESCRIPTION
With gradle 9 came a new shadow plugin, which handles this merging of service files in a slightly different way...and requires specifying the `duplicatesStrategy`. As a result, without this fix, the `AgentListener` service file is rooted incorrectly in the csa combined jar.