### PR TITLE
Put url from realm building into its own class

### DIFF
--- a/custom/src/main/java/com/splunk/opentelemetry/RealmUrls.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/RealmUrls.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry;
+
+public final class RealmUrls {
+
+  private final MODE mode;
+
+  public static final RealmUrls INSTANCE = legacy();
+
+  private static RealmUrls legacy() {
+    return new RealmUrls(MODE.SFX_LEGACY);
+  }
+
+  private static RealmUrls current() {
+    throw new UnsupportedOperationException("New realms not supported yet.");
+    // TODO: Uncomment when ready
+    // return new RealmUrls(MODE.SFX_LEGACY);
+  }
+
+  private RealmUrls(MODE mode) {
+    this.mode = mode;
+  }
+
+  public String otlpEndpoint(String realm) {
+    if (mode == MODE.SFX_LEGACY) {
+      return "https://ingest." + realm + ".signalfx.com";
+    }
+    return "https://ingest." + realm + ".observability.splunkcloud.com";
+  }
+
+  public String otlpMetrics(String realm) {
+    if (mode == MODE.SFX_LEGACY) {
+      return "https://ingest." + realm + ".signalfx.com/v2/datapoint/otlp";
+    }
+    return "https://ingest." + realm + ".observability.splunkcloud.com/v2/datapoint/otlp";
+  }
+
+  public String otlpLogs(String realm) {
+    if (mode == MODE.SFX_LEGACY) {
+      return "https://ingest." + realm + ".signalfx.com"; // ???
+    }
+    // return "https://ingest." + realm + ".observability.splunkcloud.com/v1/log";
+    // Unclear why we didn't include a path before
+    return "https://ingest." + realm + ".observability.splunkcloud.com";
+  }
+
+  public boolean isIngestUrl(String url) {
+    return url.startsWith("https://ingest.")
+        && (url.endsWith(".signalfx.com") || url.endsWith(".observability.splunkcloud.com"));
+  }
+
+  private enum MODE {
+    SFX_LEGACY,
+    CURRENT
+  }
+}

--- a/custom/src/main/java/com/splunk/opentelemetry/SplunkConfiguration.java
+++ b/custom/src/main/java/com/splunk/opentelemetry/SplunkConfiguration.java
@@ -69,7 +69,7 @@ public class SplunkConfiguration implements AutoConfigurationCustomizerProvider 
           customized,
           config,
           "otel.exporter.otlp.endpoint",
-          "https://ingest." + realm + ".signalfx.com");
+          RealmUrls.INSTANCE.otlpEndpoint(realm));
 
       // metrics ingest doesn't currently accept grpc
       addIfAbsent(customized, config, "otel.exporter.otlp.metrics.protocol", "http/protobuf");
@@ -77,7 +77,7 @@ public class SplunkConfiguration implements AutoConfigurationCustomizerProvider 
           customized,
           config,
           "otel.exporter.otlp.metrics.endpoint",
-          "https://ingest." + realm + ".signalfx.com/v2/datapoint/otlp");
+          RealmUrls.INSTANCE.otlpMetrics(realm));
 
       if (config.getString("otel.exporter.otlp.logs.endpoint") == null) {
         String logsEndpoint = getDefaultLogsEndpoint(config);
@@ -85,7 +85,7 @@ public class SplunkConfiguration implements AutoConfigurationCustomizerProvider 
             WARNING,
             "Logs can not be sent to {0}, using {1} instead. "
                 + "You can override it by setting otel.exporter.otlp.logs.endpoint",
-            new Object[] {"https://ingest." + realm + ".signalfx.com", logsEndpoint});
+            new Object[] {RealmUrls.INSTANCE.otlpLogs(realm), logsEndpoint});
 
         addIfAbsent(customized, config, "otel.exporter.otlp.logs.endpoint", logsEndpoint);
       }

--- a/custom/src/test/java/com/splunk/opentelemetry/SplunkConfigurationTest.java
+++ b/custom/src/test/java/com/splunk/opentelemetry/SplunkConfigurationTest.java
@@ -48,8 +48,8 @@ class SplunkConfigurationTest {
   @Test
   void realmIsNotHardcoded() {
     var config = configuration(() -> Map.of(SplunkConfiguration.SPLUNK_REALM_PROPERTY, "test1"));
-
-    assertThat(config.getString(OTLP_ENDPOINT)).isEqualTo("https://ingest.test1.signalfx.com");
+    var expected = RealmUrls.INSTANCE.otlpEndpoint("test1");
+    assertThat(config.getString(OTLP_ENDPOINT)).isEqualTo(expected);
   }
 
   @Test

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/Configuration.java
@@ -21,6 +21,7 @@ import static com.splunk.opentelemetry.SplunkConfiguration.PROFILER_MEMORY_ENABL
 import static java.util.logging.Level.WARNING;
 
 import com.google.auto.service.AutoService;
+import com.splunk.opentelemetry.RealmUrls;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
@@ -89,8 +90,7 @@ public class Configuration implements AutoConfigurationCustomizerProvider {
   public static String getConfigUrl(ConfigProperties config) {
     String ingestUrl = config.getString(CONFIG_KEY_OTEL_OTLP_URL, null);
     if (ingestUrl != null) {
-      if (ingestUrl.startsWith("https://ingest.")
-          && ingestUrl.endsWith(".signalfx.com")
+      if (RealmUrls.INSTANCE.isIngestUrl(ingestUrl)
           && config.getString(CONFIG_KEY_INGEST_URL) == null) {
         logger.log(
             WARNING,

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/ConfigurationTest.java
@@ -69,7 +69,7 @@ class ConfigurationTest {
   void getConfigUrlSplunkRealm() {
     ConfigProperties config = mock(ConfigProperties.class);
     when(config.getString(Configuration.CONFIG_KEY_OTEL_OTLP_URL, null))
-        .thenReturn("https://ingest.us0.signalfx.com");
+        .thenReturn("https://ingest.y33t.whatever.doesntmatter.com");
     when(config.getString(Configuration.CONFIG_KEY_INGEST_URL, null)).thenReturn(null);
     String result = Configuration.getConfigUrl(config);
     assertNull(result);


### PR DESCRIPTION
This is just frontloading some work around changing ingest urls from signalfx.com to observability.splunkcloud.com.  Draft for now, because only one internal realm has been built.