### PR TITLE
Update configs to match gdi-spec changes

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingConfiguration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingConfiguration.java
@@ -34,7 +34,7 @@ public class SnapshotProfilingConfiguration implements AutoConfigurationCustomiz
       "splunk.snapshot.profiler.enabled";
   private static final String SELECTION_PROBABILITY_KEY = "splunk.snapshot.selection.probability";
   private static final String STACK_DEPTH_KEY = "splunk.snapshot.profiler.max.stack.depth";
-  private static final String SAMPLING_INTERVAL_KEY = "splunk.snapshot.profiler.sampling.interval";
+  private static final String SAMPLING_INTERVAL_KEY = "splunk.snapshot.sampling.interval";
   private static final String EXPORT_INTERVAL_KEY = "splunk.snapshot.profiler.export.interval";
   private static final String STAGING_CAPACITY_KEY = "splunk.snapshot.profiler.staging.capacity";
 

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingConfigurationTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingConfigurationTest.java
@@ -53,7 +53,7 @@ class SnapshotProfilingConfigurationTest {
       assertEquals("false", properties.getString("splunk.snapshot.profiler.enabled"));
       assertEquals("0.01", properties.getString("splunk.snapshot.selection.probability"));
       assertEquals("1024", properties.getString("splunk.snapshot.profiler.max.stack.depth"));
-      assertEquals("10ms", properties.getString("splunk.snapshot.profiler.sampling.interval"));
+      assertEquals("10ms", properties.getString("splunk.snapshot.sampling.interval"));
       assertEquals("5s", properties.getString("splunk.snapshot.profiler.export.interval"));
       assertEquals("2000", properties.getString("splunk.snapshot.profiler.staging.capacity"));
     }
@@ -142,7 +142,7 @@ class SnapshotProfilingConfigurationTest {
   void getConfiguredSnapshotProfilerSamplingInterval(int milliseconds) {
     var properties =
         DefaultConfigProperties.create(
-            Map.of("splunk.snapshot.profiler.sampling.interval", String.valueOf(milliseconds)),
+            Map.of("splunk.snapshot.sampling.interval", String.valueOf(milliseconds)),
             COMPONENT_LOADER);
     assertEquals(
         Duration.ofMillis(milliseconds),
@@ -245,12 +245,12 @@ class SnapshotProfilingConfigurationTest {
     void includeSnapshotProfilingSamplingInterval(String interval) {
       var properties =
           DefaultConfigProperties.create(
-              Map.of("splunk.snapshot.profiler.sampling.interval", interval), COMPONENT_LOADER);
+              Map.of("splunk.snapshot.sampling.interval", interval), COMPONENT_LOADER);
 
       SnapshotProfilingConfiguration.log(properties);
 
-      var duration = properties.getDuration("splunk.snapshot.profiler.sampling.interval");
-      log.assertContains("splunk.snapshot.profiler.sampling.interval" + " : " + duration);
+      var duration = properties.getDuration("splunk.snapshot.sampling.interval");
+      log.assertContains("splunk.snapshot.sampling.interval" + " : " + duration);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Aligns with [#353](https://github.com/signalfx/gdi-specification/pull/353) in gdi-spec. 
This should be considered a breaking change for any users currently using snapshots.