### PR TITLE
Prevent renovate updating snakeyaml-engine to v3

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -34,6 +34,16 @@
       // of that release instead of the unstable version for a future release
       "ignoreUnstable": false,
       "allowedVersions": "!/\\-SNAPSHOT$/"
+    },
+    {
+      // snakeyaml-engine 3+ requires Java 11+
+      matchUpdateTypes: [
+        'major',
+      ],
+      enabled: false,
+      matchPackageNames: [
+        'org.snakeyaml:snakeyaml-engine'
+      ],
     }
   ]
 }

--- a/instrumentation/nocode-testing/build.gradle.kts
+++ b/instrumentation/nocode-testing/build.gradle.kts
@@ -1,7 +1,7 @@
 dependencies {
   testImplementation(project(":bootstrap"))
   testImplementation(project(":instrumentation:nocode"))
-  testImplementation("org.snakeyaml:snakeyaml-engine:2.8")
+  testImplementation("org.snakeyaml:snakeyaml-engine")
 }
 
 tasks {


### PR DESCRIPTION
Currently we use `snakeyaml-engine` only as a test dependency so the update would succeed, but upstream agent contains v2. Pinning to v2 ensures that won't accidentally embed v3 in the agent.