### PR TITLE
[File based config] Component provider implemented for SnapshotProfilingVolumePropagator

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotVolumePropagatorComponentProvider.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotVolumePropagatorComponentProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler.snapshot;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
+
+@SuppressWarnings("rawtypes")
+@AutoService(ComponentProvider.class)
+public class SnapshotVolumePropagatorComponentProvider
+    implements ComponentProvider<TextMapPropagator> {
+
+  @Override
+  public Class<TextMapPropagator> getType() {
+    return TextMapPropagator.class;
+  }
+
+  @Override
+  public String getName() {
+    return "splunk_snapshot_volume";
+  }
+
+  @Override
+  public TextMapPropagator create(DeclarativeConfigProperties propagatorProperties) {
+    double selectionProbability =
+        propagatorProperties.getDouble("snapshot_selection_probability", 0.01);
+    return new SnapshotVolumePropagator(selector(selectionProbability));
+  }
+
+  private SnapshotSelector selector(double selectionProbability) {
+    return new TraceIdBasedSnapshotSelector(selectionProbability)
+        .or(new ProbabilisticSnapshotSelector(selectionProbability));
+  }
+}


### PR DESCRIPTION
Propagator should be provided in the YAML file in the following way:
```yaml
propagator:
  composite:
    - tracecontext:
    - baggage:
    - splunk_snapshot_volume: # requires tracecontext and baggage propagators
        snapshot_selection_probability: 0.02 # optional (default: 0.01)
```
Please note that according to comments in `SnapshotProfilingSdkCustomizer::autoConfigureSnapshotVolumePropagator` the `SnapshotProfilingVolumePropagator` requires `tracecontext` and `baggage` propagators configured and executed in specific order.
