### PR TITLE
[File based config] SnapshotVolumePropagator component config taken form distribution node

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotVolumePropagatorComponentProvider.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotVolumePropagatorComponentProvider.java
@@ -17,14 +17,14 @@
 package com.splunk.opentelemetry.profiler.snapshot;
 
 import com.google.auto.service.AutoService;
+import com.google.common.annotations.VisibleForTesting;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigException;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
 
 @AutoService(ComponentProvider.class)
 public class SnapshotVolumePropagatorComponentProvider implements ComponentProvider {
-  private static final String SELECTION_PROBABILITY_PROPERTY = "snapshot_selection_probability";
-
   @Override
   public Class<TextMapPropagator> getType() {
     return TextMapPropagator.class;
@@ -37,16 +37,17 @@ public class SnapshotVolumePropagatorComponentProvider implements ComponentProvi
 
   @Override
   public TextMapPropagator create(DeclarativeConfigProperties propagatorProperties) {
-    // TODO: This class probably should use SnapshotProfilingDeclarativeConfiguration class instead
-    // of propagatorProperties
-    //       to get config values
+    if (!SnapshotProfilingDeclarativeConfiguration.SUPPLIER.isConfigured()) {
+      throw new DeclarativeConfigException("Snapshot profiling is not configured");
+    }
     double selectionProbability =
-        propagatorProperties.getDouble(SELECTION_PROBABILITY_PROPERTY, 0.01);
+        SnapshotProfilingDeclarativeConfiguration.SUPPLIER.get().getSnapshotSelectionProbability();
 
     return new SnapshotVolumePropagator(selector(selectionProbability));
   }
 
-  private SnapshotSelector selector(double selectionProbability) {
+  @VisibleForTesting
+  SnapshotSelector selector(double selectionProbability) {
     return new TraceIdBasedSnapshotSelector(selectionProbability)
         .or(new ProbabilisticSnapshotSelector(selectionProbability));
   }


### PR DESCRIPTION
Common Splunk profiling declarative config contains setting for snapshot `selection_probability` that is needed by `SnapshotVolumePropagator`.
**This is current format introduced with this PR**:
```yaml
# Required for callgraphs
propagator:
  composite:
    - tracecontext:
    - baggage:
    - splunk_snapshot_volume:
distribution:
  splunk:
    profiling:
      callgraphs:
        selection_probability: 0.123
        sampling_interval: 5
```
Unfortunately, there is one issue with this solution.
Convention established by declarative config recommends putting the component's config under the component's node in YAML. With this convention it should look like as follows:
```yaml
# Required for callgraphs
propagator:
  composite:
    - tracecontext:
    - baggage:
    - splunk_snapshot_volume:
       selection_probability: 0.123
distribution:
  splunk:
    profiling:
      callgraphs:
        sampling_interval: 5
```

It is incompatible with common Splunk distribution config idea, but I think that common config has a great value for the users.
