### PR TITLE
[File based config] Snapshot profiling span processor automatically added when callgraphs enabled

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSpanProcessorComponentProvider.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSpanProcessorComponentProvider.java
@@ -23,6 +23,7 @@ import io.opentelemetry.sdk.trace.SpanProcessor;
 
 @AutoService(ComponentProvider.class)
 public class SnapshotProfilingSpanProcessorComponentProvider implements ComponentProvider {
+  static final String NAME = "splunk_snapshot_profiling";
   private final TraceRegistry traceRegistry;
 
   public SnapshotProfilingSpanProcessorComponentProvider() {
@@ -40,7 +41,7 @@ public class SnapshotProfilingSpanProcessorComponentProvider implements Componen
 
   @Override
   public String getName() {
-    return "splunk_snapshot_profiling";
+    return NAME;
   }
 
   @Override


### PR DESCRIPTION
followup of https://github.com/signalfx/splunk-otel-java/pull/2601