### PR TITLE
Set petclinic rest version to 2.6.2

### DIFF
--- a/smoke-tests/profiling-base-petclinic/linux/Dockerfile
+++ b/smoke-tests/profiling-base-petclinic/linux/Dockerfile
@@ -5,7 +5,7 @@ ARG jdkVersion=8
 FROM eclipse-temurin:${jdkVersion}
 
 RUN apt update && apt install -y git
-RUN git clone https://github.com/spring-petclinic/spring-petclinic-rest.git /src
+RUN git clone --depth 1 --branch v2.6.2 https://github.com/spring-petclinic/spring-petclinic-rest.git /src
 
 WORKDIR /src
 RUN ./mvnw -Dmaven.test.skip=true package

--- a/smoke-tests/profiling-base-petclinic/windows/Dockerfile
+++ b/smoke-tests/profiling-base-petclinic/windows/Dockerfile
@@ -4,7 +4,7 @@ ARG jdkVersion=8
 
 FROM eclipse-temurin:${jdkVersion}-windowsservercore-1809 as builder
 
-ADD https://github.com/spring-petclinic/spring-petclinic-rest/archive/refs/heads/master.zip /src.zip
+ADD https://github.com/spring-petclinic/spring-petclinic-rest/archive/refs/tags/v2.6.2.zip /src.zip
 RUN ["powershell", "-Command", "expand-archive -Path /src.zip -DestinationPath /src"]
 
 WORKDIR /src/spring-petclinic-rest-master/


### PR DESCRIPTION
Current image seems to be also using 2.6.2. Setting the version should let us rebuild the images using newer base image. Currently we can't rebuild the images because current petclinic-rest requires jdk17.