### PR TITLE
Migrate from FOSSA to SRS configuration

### DIFF
--- a/srs.yaml
+++ b/srs.yaml
@@ -1,0 +1,16 @@
+# SRS configuration file
+# Generated from .fossa.yml
+#
+# WARNING: The following FOSSA features are NOT supported in SRS
+# (only skip-files and skip-dirs are supported for now):
+#
+#   - experimental.gradle.configurations-only: ['runtimeClasspath', 'runtime', 'runtimeOnly', 'runtimeOnlyDependenciesMetadata']
+#     FOSSA was configured to scan only Gradle configurations: ['runtimeClasspath', 'runtime', 'runtimeOnly', 'runtimeOnlyDependenciesMetadata']
+#     SRS does not support Gradle configuration filtering.
+#     Only 'compileClasspath', 'runtimeClasspath' configurations will be scanned.
+#
+
+scan:
+  scanners:
+  - vuln
+  - license


### PR DESCRIPTION
**Summary**

This PR adds a srs.yaml configuration file generated from the existing .fossa.yml configuration.

**What Changed**

Added srs.yaml with settings migrated from .fossa.yml
Mapped FOSSA paths.exclude to SRS skip-dirs
Mapped FOSSA targets.exclude (type + path) to SRS skip-files

**Next Steps**

- Review the generated srs.yaml configuration
- Check warning comments for any unsupported features