### PR TITLE
GHSA-72hv-8253-57qq - github reported vulernabilty fix for jackson

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -28,7 +28,7 @@ javaPlatform {
 dependencies {
 
   // BOMs
-  api(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.21.0"))
+  api(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.21.1"))
   api(enforcedPlatform("com.google.protobuf:protobuf-bom:$protobufVersion"))
   api(enforcedPlatform("com.squareup.okhttp3:okhttp-bom:5.3.2"))
   api(enforcedPlatform("io.grpc:grpc-bom:1.79.0"))


### PR DESCRIPTION
GHSA-72hv-8253-57qq : vulnerability fix for Jackson in version 2.25 .Same need to fix in version 2.9,2.10
https://github.com/FasterXML/jackson-core/security/advisories/GHSA-72hv-8253-57qq