### PR TITLE
Fix khttp client instrumentation

### DIFF
--- a/instrumentation/khttp/src/main/java/com/splunk/opentelemetry/instrumentation/khttp/KHttpHttpClientHttpAttributesGetter.java
+++ b/instrumentation/khttp/src/main/java/com/splunk/opentelemetry/instrumentation/khttp/KHttpHttpClientHttpAttributesGetter.java
@@ -76,16 +76,10 @@ final class KHttpHttpClientHttpAttributesGetter
   @Nullable
   @Override
   public Integer getServerPort(RequestWrapper requestWrapper) {
-    Integer port = null;
-    String scheme = null;
     URI uri = requestWrapper.parsedUri;
-    if (uri != null) {
-      if (uri.getPort() > 0) {
-        port = uri.getPort();
-      }
-      scheme = uri.getScheme();
-    }
-    return HttpConstants.portOrDefaultFromScheme(port, scheme);
+    return uri != null
+        ? HttpConstants.portOrDefaultFromScheme(uri.getPort(), uri.getScheme())
+        : null;
   }
 
   @Nullable


### PR DESCRIPTION
The main build is currently broken, due to upstream snapshot test class changes around [#16388.](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/16388/)

The `server.port` is now required for http client spans, so we can default back to scheme if needed.