### PR TITLE
Rework advice

### DIFF
--- a/instrumentation/jdbc/src/main/java/com/splunk/opentelemetry/instrumentation/jdbc/mariadb/MariaDbStatementInstrumentation.java
+++ b/instrumentation/jdbc/src/main/java/com/splunk/opentelemetry/instrumentation/jdbc/mariadb/MariaDbStatementInstrumentation.java
@@ -60,19 +60,17 @@ public class MariaDbStatementInstrumentation implements TypeInstrumentation {
   @SuppressWarnings("unused")
   public static class SetContextAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void onEnter(
-        @Advice.This Statement statement, @Advice.Local("splunkCallDepth") CallDepth callDepth)
-        throws Exception {
-      callDepth = CallDepth.forClass(MariaDbContextPropagator.class);
-      if (callDepth.getAndIncrement() > 0) {
-        return;
+    public static CallDepth onEnter(@Advice.This Statement statement) throws Exception {
+      CallDepth callDepth = CallDepth.forClass(MariaDbContextPropagator.class);
+      if (callDepth.getAndIncrement() == 0) {
+        MariaDbContextPropagator.INSTANCE.propagateContext(statement.getConnection());
       }
 
-      MariaDbContextPropagator.INSTANCE.propagateContext(statement.getConnection());
+      return callDepth;
     }
 
     @Advice.OnMethodExit(suppress = Throwable.class)
-    public static void onExit(@Advice.Local("splunkCallDepth") CallDepth callDepth) {
+    public static void onExit(@Advice.Enter CallDepth callDepth) {
       callDepth.decrementAndGet();
     }
   }

--- a/instrumentation/jdbc/src/main/java/com/splunk/opentelemetry/instrumentation/jdbc/mysql/MySqlStatementInstrumentation.java
+++ b/instrumentation/jdbc/src/main/java/com/splunk/opentelemetry/instrumentation/jdbc/mysql/MySqlStatementInstrumentation.java
@@ -51,19 +51,17 @@ public class MySqlStatementInstrumentation implements TypeInstrumentation {
   @SuppressWarnings("unused")
   public static class SetContextAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void onEnter(
-        @Advice.This Statement statement, @Advice.Local("splunkCallDepth") CallDepth callDepth)
-        throws Exception {
-      callDepth = CallDepth.forClass(MySqlContextPropagator.class);
-      if (callDepth.getAndIncrement() > 0) {
-        return;
+    public static CallDepth onEnter(@Advice.This Statement statement) throws Exception {
+      CallDepth callDepth = CallDepth.forClass(MySqlContextPropagator.class);
+      if (callDepth.getAndIncrement() == 0) {
+        MySqlContextPropagator.INSTANCE.propagateContext(statement.getConnection());
       }
 
-      MySqlContextPropagator.INSTANCE.propagateContext(statement.getConnection());
+      return callDepth;
     }
 
     @Advice.OnMethodExit(suppress = Throwable.class)
-    public static void onExit(@Advice.Local("splunkCallDepth") CallDepth callDepth) {
+    public static void onExit(@Advice.Enter CallDepth callDepth) {
       callDepth.decrementAndGet();
     }
   }

--- a/instrumentation/jdbc/src/main/java/com/splunk/opentelemetry/instrumentation/jdbc/oracle/OracleStatementInstrumentation.java
+++ b/instrumentation/jdbc/src/main/java/com/splunk/opentelemetry/instrumentation/jdbc/oracle/OracleStatementInstrumentation.java
@@ -52,19 +52,17 @@ public class OracleStatementInstrumentation implements TypeInstrumentation {
   @SuppressWarnings("unused")
   public static class SetActionAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void onEnter(
-        @Advice.This Statement statement, @Advice.Local("splunkCallDepth") CallDepth callDepth)
-        throws Exception {
-      callDepth = CallDepth.forClass(OracleContextPropagator.class);
-      if (callDepth.getAndIncrement() > 0) {
-        return;
+    public static CallDepth onEnter(@Advice.This Statement statement) throws Exception {
+      CallDepth callDepth = CallDepth.forClass(OracleContextPropagator.class);
+      if (callDepth.getAndIncrement() == 0) {
+        OracleContextPropagator.INSTANCE.propagateContext(statement.getConnection());
       }
 
-      OracleContextPropagator.INSTANCE.propagateContext(statement.getConnection());
+      return callDepth;
     }
 
     @Advice.OnMethodExit(suppress = Throwable.class)
-    public static void onExit(@Advice.Local("splunkCallDepth") CallDepth callDepth) {
+    public static void onExit(@Advice.Enter CallDepth callDepth) {
       callDepth.decrementAndGet();
     }
   }

--- a/instrumentation/jdbc/src/main/java/com/splunk/opentelemetry/instrumentation/jdbc/postgresql/PostgreSqlStatementInstrumentation.java
+++ b/instrumentation/jdbc/src/main/java/com/splunk/opentelemetry/instrumentation/jdbc/postgresql/PostgreSqlStatementInstrumentation.java
@@ -50,19 +50,17 @@ public class PostgreSqlStatementInstrumentation implements TypeInstrumentation {
   @SuppressWarnings("unused")
   public static class SetActionAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void onEnter(
-        @Advice.This Statement statement, @Advice.Local("splunkCallDepth") CallDepth callDepth)
-        throws Exception {
-      callDepth = CallDepth.forClass(PostgreSqlContextPropagator.class);
-      if (callDepth.getAndIncrement() > 0) {
-        return;
+    public static CallDepth onEnter(@Advice.This Statement statement) throws Exception {
+      CallDepth callDepth = CallDepth.forClass(PostgreSqlContextPropagator.class);
+      if (callDepth.getAndIncrement() == 0) {
+        PostgreSqlContextPropagator.INSTANCE.propagateContext(statement.getConnection());
       }
 
-      PostgreSqlContextPropagator.INSTANCE.propagateContext(statement.getConnection());
+      return callDepth;
     }
 
     @Advice.OnMethodExit(suppress = Throwable.class)
-    public static void onExit(@Advice.Local("splunkCallDepth") CallDepth callDepth) {
+    public static void onExit(@Advice.Enter CallDepth callDepth) {
       callDepth.decrementAndGet();
     }
   }

--- a/instrumentation/jdbc/src/main/java/com/splunk/opentelemetry/instrumentation/jdbc/sqlserver/SqlServerStatementInstrumentation.java
+++ b/instrumentation/jdbc/src/main/java/com/splunk/opentelemetry/instrumentation/jdbc/sqlserver/SqlServerStatementInstrumentation.java
@@ -52,19 +52,17 @@ public class SqlServerStatementInstrumentation implements TypeInstrumentation {
   @SuppressWarnings("unused")
   public static class SetContextAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void onEnter(
-        @Advice.This Statement statement, @Advice.Local("splunkCallDepth") CallDepth callDepth)
-        throws Exception {
-      callDepth = CallDepth.forClass(SqlServerContextPropagator.class);
-      if (callDepth.getAndIncrement() > 0) {
-        return;
+    public static CallDepth onEnter(@Advice.This Statement statement) throws Exception {
+      CallDepth callDepth = CallDepth.forClass(SqlServerContextPropagator.class);
+      if (callDepth.getAndIncrement() == 0) {
+        SqlServerContextPropagator.INSTANCE.propagateContext(statement.getConnection());
       }
 
-      SqlServerContextPropagator.INSTANCE.propagateContext(statement.getConnection());
+      return callDepth;
     }
 
     @Advice.OnMethodExit(suppress = Throwable.class)
-    public static void onExit(@Advice.Local("splunkCallDepth") CallDepth callDepth) {
+    public static void onExit(@Advice.Enter CallDepth callDepth) {
       callDepth.decrementAndGet();
     }
   }

--- a/instrumentation/khttp/src/main/java/com/splunk/opentelemetry/instrumentation/khttp/KHttpInstrumentation.java
+++ b/instrumentation/khttp/src/main/java/com/splunk/opentelemetry/instrumentation/khttp/KHttpInstrumentation.java
@@ -17,7 +17,6 @@
 package com.splunk.opentelemetry.instrumentation.khttp;
 
 import static com.splunk.opentelemetry.instrumentation.khttp.KHttpSingletons.instrumenter;
-import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.extendsClass;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static net.bytebuddy.matcher.ElementMatchers.isAbstract;
@@ -33,8 +32,11 @@ import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 import khttp.responses.Response;
 import net.bytebuddy.asm.Advice;
+import net.bytebuddy.asm.Advice.AssignReturned;
+import net.bytebuddy.asm.Advice.AssignReturned.ToArguments.ToArgument;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
@@ -62,41 +64,67 @@ public class KHttpInstrumentation implements TypeInstrumentation {
         KHttpInstrumentation.class.getName() + "$RequestAdvice");
   }
 
+  @SuppressWarnings("unused")
   public static class RequestAdvice {
 
-    @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void methodEnter(
-        @Advice.Argument(value = 0) String method,
-        @Advice.Argument(value = 1) String uri,
-        @Advice.Argument(value = 2, readOnly = false) Map<String, String> headers,
-        @Advice.Local("otelRequest") RequestWrapper request,
-        @Advice.Local("otelContext") Context context,
-        @Advice.Local("otelScope") Scope scope) {
-      Context parentContext = currentContext();
-      // Kotlin likes to use read-only data structures, so wrap into new writable map
-      headers = new HashMap<>(headers);
-      request = new RequestWrapper(method, uri, headers);
-      if (!instrumenter().shouldStart(parentContext, request)) {
-        return;
+    public static class AdviceScope {
+      private final RequestWrapper request;
+      private final Context context;
+      private final Scope scope;
+
+      private AdviceScope(RequestWrapper request, Context context, Scope scope) {
+        this.request = request;
+        this.context = context;
+        this.scope = scope;
       }
 
-      context = instrumenter().start(parentContext, request);
-      scope = context.makeCurrent();
+      @Nullable
+      public static AdviceScope start(String method, String uri, Map<String, String> headers) {
+        Context parentContext = Context.current();
+        // Kotlin likes to use read-only data structures, so wrap into new writable map
+        headers = new HashMap<>(headers);
+        RequestWrapper request = new RequestWrapper(method, uri, headers);
+        if (!instrumenter().shouldStart(parentContext, request)) {
+          return null;
+        }
+
+        Context context = instrumenter().start(parentContext, request);
+        return new AdviceScope(request, context, context.makeCurrent());
+      }
+
+      public void end(Response response, @Nullable Throwable throwable) {
+        scope.close();
+        instrumenter().end(context, request, response, throwable);
+      }
+
+      public Map<String, String> getHeaders() {
+        return request.getHeaders();
+      }
+    }
+
+    @AssignReturned.ToArguments(@ToArgument(value = 2, index = 1))
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static Object[] methodEnter(
+        @Advice.Argument(0) String method,
+        @Advice.Argument(1) String uri,
+        @Advice.Argument(2) Map<String, String> headers) {
+      AdviceScope adviceScope = AdviceScope.start(method, uri, headers);
+      if (adviceScope == null) {
+        return new Object[] {null, headers};
+      }
+
+      return new Object[] {adviceScope, adviceScope.getHeaders()};
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void methodExit(
         @Advice.Return Response response,
         @Advice.Thrown Throwable throwable,
-        @Advice.Local("otelRequest") RequestWrapper request,
-        @Advice.Local("otelContext") Context context,
-        @Advice.Local("otelScope") Scope scope) {
-      if (scope == null) {
-        return;
+        @Advice.Enter Object[] enterResult) {
+      AdviceScope adviceScope = (AdviceScope) enterResult[0];
+      if (adviceScope != null) {
+        adviceScope.end(response, throwable);
       }
-
-      scope.close();
-      instrumenter().end(context, request, response, throwable);
     }
   }
 }

--- a/instrumentation/khttp/src/main/java/com/splunk/opentelemetry/instrumentation/khttp/RequestWrapper.java
+++ b/instrumentation/khttp/src/main/java/com/splunk/opentelemetry/instrumentation/khttp/RequestWrapper.java
@@ -33,6 +33,10 @@ public class RequestWrapper {
     this.parsedUri = parseUri(uri);
   }
 
+  public Map<String, String> getHeaders() {
+    return headers;
+  }
+
   private static URI parseUri(String uri) {
     if (uri == null) {
       return null;

--- a/instrumentation/nocode/src/main/java/com/splunk/opentelemetry/instrumentation/nocode/NocodeInstrumentation.java
+++ b/instrumentation/nocode/src/main/java/com/splunk/opentelemetry/instrumentation/nocode/NocodeInstrumentation.java
@@ -17,7 +17,6 @@
 package com.splunk.opentelemetry.instrumentation.nocode;
 
 import static com.splunk.opentelemetry.instrumentation.nocode.NocodeSingletons.instrumenter;
-import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.none;
 
@@ -28,7 +27,7 @@ import io.opentelemetry.instrumentation.api.annotation.support.async.AsyncOperat
 import io.opentelemetry.instrumentation.api.incubator.semconv.util.ClassAndMethod;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
-import java.lang.reflect.Method;
+import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.implementation.bytecode.assign.Assigner;
@@ -72,45 +71,67 @@ public final class NocodeInstrumentation implements TypeInstrumentation {
 
   @SuppressWarnings("unused")
   public static class NocodeAdvice {
+    public static class AdviceScope {
+      private final NocodeMethodInvocation otelInvocation;
+      private final Context context;
+      private final Scope scope;
+
+      private AdviceScope(NocodeMethodInvocation otelInvocation, Context context, Scope scope) {
+        this.otelInvocation = otelInvocation;
+        this.context = context;
+        this.scope = scope;
+      }
+
+      @Nullable
+      public static AdviceScope start(
+          int ruleId,
+          Class<?> declaringClass,
+          String methodName,
+          Object thiz,
+          Object[] methodParams) {
+        NocodeRules.Rule rule = NocodeRules.find(ruleId);
+        NocodeMethodInvocation otelInvocation =
+            new NocodeMethodInvocation(
+                rule, ClassAndMethod.create(declaringClass, methodName), thiz, methodParams);
+
+        Context parentContext = Context.current();
+        if (!instrumenter().shouldStart(parentContext, otelInvocation)) {
+          return null;
+        }
+        Context context = instrumenter().start(parentContext, otelInvocation);
+        return new AdviceScope(otelInvocation, context, context.makeCurrent());
+      }
+
+      public Object end(
+          Class<?> methodReturnType, Object returnValue, @Nullable Throwable throwable) {
+        scope.close();
+        return AsyncOperationEndSupport.create(instrumenter(), Object.class, methodReturnType)
+            .asyncEnd(context, otelInvocation, returnValue, throwable);
+      }
+    }
+
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void onEnter(
+    @Nullable
+    public static AdviceScope onEnter(
         @RuleId int ruleId,
         @Advice.Origin("#t") Class<?> declaringClass,
         @Advice.Origin("#m") String methodName,
-        @Advice.Local("otelInvocation") NocodeMethodInvocation otelInvocation,
-        @Advice.Local("otelContext") Context context,
-        @Advice.Local("otelScope") Scope scope,
         @Advice.This Object thiz,
         @Advice.AllArguments Object[] methodParams) {
-      NocodeRules.Rule rule = NocodeRules.find(ruleId);
-      otelInvocation =
-          new NocodeMethodInvocation(
-              rule, ClassAndMethod.create(declaringClass, methodName), thiz, methodParams);
-      Context parentContext = currentContext();
-
-      if (!instrumenter().shouldStart(parentContext, otelInvocation)) {
-        return;
-      }
-      context = instrumenter().start(parentContext, otelInvocation);
-      scope = context.makeCurrent();
+      return AdviceScope.start(ruleId, declaringClass, methodName, thiz, methodParams);
     }
 
+    @Advice.AssignReturned.ToReturned
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-    public static void stopSpan(
-        @Advice.Origin Method method,
-        @Advice.Local("otelInvocation") NocodeMethodInvocation otelInvocation,
-        @Advice.Local("otelContext") Context context,
-        @Advice.Local("otelScope") Scope scope,
-        @Advice.Return(readOnly = false, typing = Assigner.Typing.DYNAMIC) Object returnValue,
+    public static Object stopSpan(
+        @MethodReturnType Class<?> methodReturnType,
+        @Advice.Enter @Nullable AdviceScope adviceScope,
+        @Advice.Return(typing = Assigner.Typing.DYNAMIC) Object returnValue,
         @Advice.Thrown Throwable error) {
-      if (scope == null) {
-        return;
+      if (adviceScope != null) {
+        return adviceScope.end(methodReturnType, returnValue, error);
       }
-      scope.close();
-
-      returnValue =
-          AsyncOperationEndSupport.create(instrumenter(), Object.class, method.getReturnType())
-              .asyncEnd(context, otelInvocation, returnValue, error);
+      return returnValue;
     }
   }
 }

--- a/instrumentation/wildfly/src/main/java/com/splunk/opentelemetry/instrumentation/wildfly/WildFlyAttributesInstrumentationModule.java
+++ b/instrumentation/wildfly/src/main/java/com/splunk/opentelemetry/instrumentation/wildfly/WildFlyAttributesInstrumentationModule.java
@@ -68,14 +68,15 @@ public class WildFlyAttributesInstrumentationModule extends InstrumentationModul
   @SuppressWarnings("unused")
   public static class WebengineInitializedAdvice {
     @Advice.OnMethodEnter
-    public static void onEnter(@Advice.Local("splunkCallDepth") CallDepth callDepth) {
-      callDepth = CallDepth.forClass(ProductConfig.class);
+    public static CallDepth onEnter() {
+      CallDepth callDepth = CallDepth.forClass(ProductConfig.class);
       callDepth.getAndIncrement();
+      return callDepth;
     }
 
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void onExit(
-        @Advice.Local("splunkCallDepth") CallDepth callDepth,
+        @Advice.Enter CallDepth callDepth,
         @Advice.FieldValue("productConfig") ProductConfig productConfig) {
       if (callDepth.decrementAndGet() == 0 && productConfig != null) {
         WebengineHolder.trySetName(productConfig.resolveName());


### PR DESCRIPTION
In upstream agent there is plan to transition from inline to non-inline advice. In non-inline advice some constructs such as `@Advice.Local` or `readOnly = false` are not available. This PR rewrites the advice so that they are ready to be used as non-inline but still work as inline for now. While some parts of the advice will be slightly more complicated non-inline advice may open up other options, such as advice having access to agent code without the need to go through boot loader, that make it worth it.