### PR TITLE
Suppress java 8 suorce warning on modern jdks

### DIFF
--- a/buildSrc/src/main/kotlin/splunk.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.java-conventions.gradle.kts
@@ -47,5 +47,9 @@ tasks.withType<Test>().configureEach {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-  options.isDeprecation = true
+  with(options) {
+    isDeprecation = true
+    // suppress warning about source/target 8 being obsolete
+    compilerArgs.add("-Xlint:-options")
+  }
 }


### PR DESCRIPTION
Not an issue with jdk 17, that is the minimum supported for this project.