### PR TITLE
[OpAMP] Reduced number of properties reported in effective config

### DIFF
--- a/opamp/src/main/java/com/splunk/opentelemetry/opamp/EffectiveConfigBuilder.java
+++ b/opamp/src/main/java/com/splunk/opentelemetry/opamp/EffectiveConfigBuilder.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.opamp;
+
+import java.time.Duration;
+
+class EffectiveConfigBuilder {
+  private final StringBuilder stringBuilder = new StringBuilder();
+
+  EffectiveConfigBuilder add(String propertyName, Object value) {
+    stringBuilder.append(propertyName).append('=').append(value).append('\n');
+    return this;
+  }
+
+  EffectiveConfigBuilder add(String propertyName, Duration value) {
+    return add(propertyName, value.toMillis() + "ms");
+  }
+
+  String build() {
+    return stringBuilder.toString();
+  }
+}

--- a/opamp/src/main/java/com/splunk/opentelemetry/opamp/EnvVarsEffectiveConfigFileFactory.java
+++ b/opamp/src/main/java/com/splunk/opentelemetry/opamp/EnvVarsEffectiveConfigFileFactory.java
@@ -24,16 +24,11 @@ import com.splunk.opentelemetry.profiler.ProfilerEnvVarsConfiguration;
 import com.splunk.opentelemetry.profiler.snapshot.SnapshotProfilingEnvVarsConfiguration;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
-import java.util.function.UnaryOperator;
 import okio.ByteString;
 import opamp.proto.AgentConfigFile;
 
 class EnvVarsEffectiveConfigFileFactory {
-  static final String REDACTION_MARKER = "**Redacted**";
   private static final String OTEL_EXPORTER_OTLP_ENDPOINT = "otel.exporter.otlp.endpoint";
   private static final String OTEL_EXPORTER_OTLP_PROTOCOL = "otel.exporter.otlp.protocol";
   private static final String OTLP_PROTOCOL_HTTP_PROTOBUF = "http/protobuf";
@@ -62,327 +57,31 @@ class EnvVarsEffectiveConfigFileFactory {
     SnapshotProfilingEnvVarsConfiguration snapshotConfiguration =
         new SnapshotProfilingEnvVarsConfiguration(config);
 
-    // Mask SPLUNK_ACCESS_TOKEN in the effective config file because it is a sensitive data.
-    if (config.getString(SplunkConfiguration.SPLUNK_ACCESS_TOKEN) != null) {
-      builder.addValue(SplunkConfiguration.SPLUNK_ACCESS_TOKEN, REDACTION_MARKER);
-    }
-
     return builder
-        .add(SplunkConfiguration.METRICS_FULL_COMMAND_LINE, false)
-        .add("splunk.otel.instrumentation.nocode.yml.file", "")
-        .addValue(
-            ProfilerEnvVarsConfiguration.CONFIG_KEY_CALL_STACK_INTERVAL,
-            profilerConfiguration.getCallStackInterval())
-        .addValue(
-            ProfilerEnvVarsConfiguration.CONFIG_KEY_PROFILER_DIRECTORY,
-            profilerConfiguration.getProfilerDirectory())
         .addValue(SplunkConfiguration.PROFILER_ENABLED_PROPERTY, profilerConfiguration.isEnabled())
-        .addValue(
-            ProfilerEnvVarsConfiguration.CONFIG_KEY_INCLUDE_AGENT_INTERNALS,
-            profilerConfiguration.getIncludeAgentInternalStacks())
-        .addValue(
-            ProfilerEnvVarsConfiguration.CONFIG_KEY_INCLUDE_INTERNAL_STACKS,
-            config.getBoolean(
-                ProfilerEnvVarsConfiguration.CONFIG_KEY_INCLUDE_INTERNAL_STACKS, false))
-        .addValue(
-            ProfilerEnvVarsConfiguration.CONFIG_KEY_INCLUDE_JVM_INTERNALS,
-            profilerConfiguration.getIncludeJvmInternalStacks())
-        .addValue(
-            ProfilerEnvVarsConfiguration.CONFIG_KEY_KEEP_FILES,
-            profilerConfiguration.getKeepFiles())
-        .addValue(
-            ProfilerEnvVarsConfiguration.CONFIG_KEY_INGEST_URL,
-            profilerConfiguration.getIngestUrl())
-        .addValue(
-            ProfilerEnvVarsConfiguration.CONFIG_KEY_STACK_DEPTH,
-            profilerConfiguration.getStackDepth())
         .addValue(
             ProfilerEnvVarsConfiguration.CONFIG_KEY_MEMORY_ENABLED,
             profilerConfiguration.getMemoryEnabled())
         .addValue(
-            ProfilerEnvVarsConfiguration.CONFIG_KEY_MEMORY_EVENT_RATE,
-            profilerConfiguration.getMemoryEventRate())
-        .addValue(
-            ProfilerEnvVarsConfiguration.CONFIG_KEY_MEMORY_EVENT_RATE_LIMIT_ENABLED,
-            profilerConfiguration.getMemoryEventRateLimitEnabled())
-        .addValue(
-            ProfilerEnvVarsConfiguration.CONFIG_KEY_MEMORY_NATIVE_SAMPLING,
-            profilerConfiguration.getUseAllocationSampleEvent())
-        .addValue(
-            ProfilerEnvVarsConfiguration.CONFIG_KEY_PROFILER_OTLP_PROTOCOL,
-            profilerConfiguration.getOtlpProtocol())
-        .addValue(
-            ProfilerEnvVarsConfiguration.CONFIG_KEY_RECORDING_DURATION,
-            profilerConfiguration.getRecordingDuration())
-        .addValue(
-            ProfilerEnvVarsConfiguration.CONFIG_KEY_TRACING_STACKS_ONLY,
-            profilerConfiguration.getTracingStacksOnly())
-        .add(SplunkConfiguration.SPLUNK_REALM_PROPERTY, SplunkConfiguration.SPLUNK_REALM_NONE)
-        .add("splunk.trace-response-header.enabled", true)
-        .addValue(
             SnapshotProfilingEnvVarsConfiguration.CONFIG_KEY_ENABLE_SNAPSHOT_PROFILER,
             snapshotConfiguration.isEnabled())
-        .addValue(
-            SnapshotProfilingEnvVarsConfiguration.SELECTION_PROBABILITY_KEY,
-            snapshotConfiguration.getSnapshotSelectionProbability())
-        .addValue(
-            SnapshotProfilingEnvVarsConfiguration.STACK_DEPTH_KEY,
-            snapshotConfiguration.getStackDepth())
         .addValue(
             SnapshotProfilingEnvVarsConfiguration.SAMPLING_INTERVAL_KEY,
             snapshotConfiguration.getSamplingInterval())
         .addValue(
-            SnapshotProfilingEnvVarsConfiguration.EXPORT_INTERVAL_KEY,
-            snapshotConfiguration.getExportInterval())
-        .addValue(
-            SnapshotProfilingEnvVarsConfiguration.STAGING_CAPACITY_KEY,
-            snapshotConfiguration.getStagingCapacity());
+            ProfilerEnvVarsConfiguration.CONFIG_KEY_CALL_STACK_INTERVAL,
+            profilerConfiguration.getCallStackInterval());
   }
 
   private FileContentBuilder addOtelEnvVars(FileContentBuilder builder) {
     return builder
-        .add("otel.attribute.count.limit", 128)
-        .addInt("otel.attribute.value.length.limit")
-        .add("otel.blrp.export.timeout", 30000)
-        .add("otel.blrp.max.export.batch.size", 512)
-        .add("otel.blrp.max.queue.size", 2048)
-        .add("otel.blrp.schedule.delay", 1000)
-        .add("otel.bsp.export.timeout", 30000)
-        .add("otel.bsp.max.export.batch.size", 512)
-        .add("otel.bsp.max.queue.size", 2048)
-        .add("otel.bsp.schedule.delay", 5000)
-        .add("otel.config.file", "")
-        .add("otel.experimental.javascript-snippet", "")
-        .add("otel.experimental.resource.disabled-keys", "")
-        .add("otel.exporter.otlp.certificate", "")
-        .add("otel.exporter.otlp.client.certificate", "")
-        .add("otel.exporter.otlp.client.key", "")
-        .add("otel.exporter.otlp.compression", "")
-        .add(OTEL_EXPORTER_OTLP_ENDPOINT, getOtlpEndpoint(config))
-        .add("otel.exporter.otlp.headers", "", EnvVarsEffectiveConfigFileFactory::sanitizeHeaders)
-        .add("otel.exporter.otlp.logs.certificate", "")
-        .add("otel.exporter.otlp.logs.client.certificate", "")
-        .add("otel.exporter.otlp.logs.client.key", "")
-        .add("otel.exporter.otlp.logs.compression", "")
-        .add("otel.exporter.otlp.logs.endpoint", getSignalOtlpEndpoint(config, OTLP_SIGNAL_LOGS))
-        .add(
-            "otel.exporter.otlp.logs.headers",
-            "",
-            EnvVarsEffectiveConfigFileFactory::sanitizeHeaders)
-        .add("otel.exporter.otlp.logs.protocol", getSignalOtlpProtocol(config, OTLP_SIGNAL_LOGS))
-        .add("otel.exporter.otlp.logs.timeout", 10000)
-        .add("otel.exporter.otlp.metrics.certificate", "")
-        .add("otel.exporter.otlp.metrics.client.certificate", "")
-        .add("otel.exporter.otlp.metrics.client.key", "")
-        .add("otel.exporter.otlp.metrics.compression", "")
-        .add(
-            "otel.exporter.otlp.metrics.default.histogram.aggregation", "EXPLICIT_BUCKET_HISTOGRAM")
-        .add(
-            "otel.exporter.otlp.metrics.endpoint",
-            getSignalOtlpEndpoint(config, OTLP_SIGNAL_METRICS))
-        .add(
-            "otel.exporter.otlp.metrics.headers",
-            "",
-            EnvVarsEffectiveConfigFileFactory::sanitizeHeaders)
-        .add(
-            "otel.exporter.otlp.metrics.protocol",
-            getSignalOtlpProtocol(config, OTLP_SIGNAL_METRICS))
-        .add("otel.exporter.otlp.metrics.temporality.preference", "CUMULATIVE")
-        .add("otel.exporter.otlp.metrics.timeout", 10000)
-        .add(OTEL_EXPORTER_OTLP_PROTOCOL, getOtlpProtocol(config))
-        .add("otel.exporter.otlp.timeout", 10000)
-        .add("otel.exporter.otlp.traces.certificate", "")
-        .add("otel.exporter.otlp.traces.client.certificate", "")
-        .add("otel.exporter.otlp.traces.client.key", "")
-        .add("otel.exporter.otlp.traces.compression", "")
-        .add(
-            "otel.exporter.otlp.traces.endpoint", getSignalOtlpEndpoint(config, OTLP_SIGNAL_TRACES))
-        .add(
-            "otel.exporter.otlp.traces.headers",
-            "",
-            EnvVarsEffectiveConfigFileFactory::sanitizeHeaders)
-        .add(
-            "otel.exporter.otlp.traces.protocol", getSignalOtlpProtocol(config, OTLP_SIGNAL_TRACES))
-        .add("otel.exporter.otlp.traces.timeout", 10000)
-        .add("otel.exporter.prometheus.host", "0.0.0.0")
-        .add("otel.exporter.prometheus.port", 9464)
-        .add("otel.exporter.zipkin.endpoint", "http://localhost:9411/api/v2/spans")
-        .add("otel.instrumentation.apache-elasticjob.experimental-span-attributes", false)
-        .add("otel.instrumentation.apache-shenyu.experimental-span-attributes", false)
-        .add("otel.instrumentation.aws-sdk.experimental-span-attributes", false)
-        .add("otel.instrumentation.aws-sdk.experimental-use-propagator-for-messaging", false)
-        .add("otel.instrumentation.camel.experimental-span-attributes", false)
-        .add("otel.instrumentation.common.db-statement-sanitizer.enabled", true)
-        .add("otel.instrumentation.common.default-enabled", true)
-        .add("otel.instrumentation.common.enduser.enabled", false)
-        .add("otel.instrumentation.common.enduser.id.enabled", false)
-        .add("otel.instrumentation.common.enduser.role.enabled", false)
-        .add("otel.instrumentation.common.enduser.scope.enabled", false)
-        .add("otel.instrumentation.common.experimental.controller-telemetry.enabled", false)
-        .add("otel.instrumentation.common.experimental.view-telemetry.enabled", false)
-        .add("otel.instrumentation.common.logging.span-id", "span_id")
-        .add("otel.instrumentation.common.logging.trace-flags", "trace_flags")
-        .add("otel.instrumentation.common.logging.trace-id", "trace_id")
-        .add("otel.instrumentation.common.mdc.resource-attributes", "")
-        .add("otel.instrumentation.common.peer-service-mapping", "")
-        .add("otel.instrumentation.couchbase.experimental-span-attributes", false)
-        .add("otel.instrumentation.elasticsearch.capture-search-query", false)
-        .add("otel.instrumentation.elasticsearch.experimental-span-attributes", false)
-        .add("otel.instrumentation.experimental.span-suppression-strategy", "semconv")
-        .add("otel.instrumentation.genai.capture-message-content", false)
-        .add("otel.instrumentation.graphql.add-operation-name-to-span-name.enabled", false)
-        .add("otel.instrumentation.graphql.capture-query", true)
-        .add("otel.instrumentation.graphql.data-fetcher.enabled", false)
-        .add("otel.instrumentation.graphql.query-sanitizer.enabled", true)
-        .add("otel.instrumentation.graphql.trivial-data-fetcher.enabled", false)
-        .add("otel.instrumentation.grpc.capture-metadata.client.request", "")
-        .add("otel.instrumentation.grpc.capture-metadata.server.request", "")
-        .add("otel.instrumentation.grpc.emit-message-events", true)
-        .add("otel.instrumentation.grpc.experimental-span-attributes", false)
-        .add("otel.instrumentation.guava.experimental-span-attributes", false)
-        .add("otel.instrumentation.hibernate.experimental-span-attributes", false)
-        .add("otel.instrumentation.http.client.capture-request-headers", "")
-        .add("otel.instrumentation.http.client.capture-response-headers", "")
-        .add("otel.instrumentation.http.client.emit-experimental-telemetry", false)
-        .add("otel.instrumentation.http.client.experimental.redact-query-parameters", true)
-        .add(
-            "otel.instrumentation.http.known-methods",
-            "CONNECT, DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT, TRACE")
-        .add("otel.instrumentation.http.server.capture-request-headers", "")
-        .add("otel.instrumentation.http.server.capture-response-headers", "")
-        .add("otel.instrumentation.http.server.emit-experimental-telemetry", false)
-        .add("otel.instrumentation.hystrix.experimental-span-attributes", false)
-        .add("otel.instrumentation.java-util-logging.experimental-log-attributes", false)
-        .add("otel.instrumentation.jaxrs.experimental-span-attributes", false)
-        .add("otel.instrumentation.jboss-logmanager.experimental.capture-event-name", false)
-        .add("otel.instrumentation.jboss-logmanager.experimental.capture-mdc-attributes", "")
-        .add("otel.instrumentation.jboss-logmanager.experimental-log-attributes", false)
-        .add("otel.instrumentation.jdbc.experimental.capture-query-parameters", false)
-        .add("otel.instrumentation.jdbc.experimental.sqlcommenter.enabled", false)
-        .add("otel.instrumentation.jdbc.experimental.transaction.enabled", false)
-        .add("otel.instrumentation.jdbc.statement-sanitizer.enabled", true)
-        .add("otel.instrumentation.jsp.experimental-span-attributes", false)
-        .add("otel.instrumentation.kafka.experimental-span-attributes", false)
-        .add("otel.instrumentation.kafka.producer-propagation.enabled", true)
-        .add("otel.instrumentation.kubernetes-client.experimental-span-attributes", false)
-        .add("otel.instrumentation.lettuce.experimental-span-attributes", false)
-        .add("otel.instrumentation.log4j-appender.experimental.capture-code-attributes", false)
-        .add("otel.instrumentation.log4j-appender.experimental.capture-event-name", false)
-        .add(
-            "otel.instrumentation.log4j-appender.experimental.capture-map-message-attributes",
-            false)
-        .add("otel.instrumentation.log4j-appender.experimental.capture-marker-attribute", false)
-        .add("otel.instrumentation.log4j-appender.experimental.capture-mdc-attributes", "")
-        .add("otel.instrumentation.log4j-appender.experimental-log-attributes", false)
-        .add("otel.instrumentation.log4j-context-data.add-baggage", false)
-        .add("otel.instrumentation.logback-appender.experimental.capture-arguments", false)
-        .add("otel.instrumentation.logback-appender.experimental.capture-code-attributes", false)
-        .add("otel.instrumentation.logback-appender.experimental.capture-event-name", false)
-        .add(
-            "otel.instrumentation.logback-appender.experimental.capture-key-value-pair-attributes",
-            false)
-        .add(
-            "otel.instrumentation.logback-appender.experimental.capture-logger-context-attributes",
-            false)
-        .add(
-            "otel.instrumentation.logback-appender.experimental.capture-logstash-marker-attributes",
-            false)
-        .add(
-            "otel.instrumentation.logback-appender.experimental.capture-logstash-structured-arguments",
-            false)
-        .add("otel.instrumentation.logback-appender.experimental.capture-marker-attribute", false)
-        .add("otel.instrumentation.logback-appender.experimental.capture-mdc-attributes", "")
-        .add("otel.instrumentation.logback-appender.experimental-log-attributes", false)
-        .add("otel.instrumentation.logback-mdc.add-baggage", false)
-        .add("otel.instrumentation.messaging.experimental.receive-telemetry.enabled", false)
-        .add("otel.instrumentation.methods.include", "")
-        .add("otel.instrumentation.micrometer.base-time-unit", "s")
-        .add("otel.instrumentation.micrometer.histogram-gauges.enabled", false)
-        .add("otel.instrumentation.micrometer.prometheus-mode.enabled", false)
-        .add("otel.instrumentation.mongo.statement-sanitizer.enabled", true)
-        .add("otel.instrumentation.netty.connection-telemetry.enabled", false)
-        .add("otel.instrumentation.netty.ssl-telemetry.enabled", false)
-        .add("otel.instrumentation.opensearch.capture-search-query", true)
-        .add("otel.instrumentation.opensearch.experimental-span-attributes", false)
-        .add("otel.instrumentation.opentelemetry-annotations.exclude-methods", "")
-        .add("otel.instrumentation.opentelemetry-instrumentation-annotations.exclude-methods", "")
-        .add("otel.instrumentation.oshi.experimental-metrics.enabled", false)
-        .add("otel.instrumentation.powerjob.experimental-span-attributes", false)
-        .add("otel.instrumentation.pulsar.experimental-span-attributes", false)
-        .add("otel.instrumentation.quartz.experimental-span-attributes", false)
-        .add("otel.instrumentation.r2dbc.statement-sanitizer.enabled", true)
-        .add("otel.instrumentation.rabbitmq.experimental-span-attributes", false)
-        .add("otel.instrumentation.reactor.experimental-span-attributes", false)
-        .add("otel.instrumentation.reactor-netty.connection-telemetry.enabled", false)
-        .add("otel.instrumentation.rocketmq-client.experimental-span-attributes", false)
-        .add("otel.instrumentation.runtime-telemetry.emit-experimental-telemetry", false)
-        .add("otel.instrumentation.runtime-telemetry-java17.enabled", false)
-        .add("otel.instrumentation.runtime-telemetry-java17.enable-all", false)
-        .add("otel.instrumentation.runtime-telemetry.package-emitter.enabled", false)
-        .add("otel.instrumentation.runtime-telemetry.package-emitter.jars-per-second", 10)
-        .add("otel.instrumentation.rxjava.experimental-span-attributes", false)
-        .add(
-            "otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters",
-            "AWSAccessKeyId, Signature, sig, X-Goog-Signature")
-        .add("otel.instrumentation.servlet.experimental.capture-request-parameters", "")
-        .add("otel.instrumentation.servlet.experimental-span-attributes", false)
-        .add("otel.instrumentation.spring-batch.experimental.chunk.new-trace", false)
-        .add("otel.instrumentation.spring-batch.item.enabled", false)
-        .add("otel.instrumentation.spring-cloud-gateway.experimental-span-attributes", false)
-        .add("otel.instrumentation.spring-integration.global-channel-interceptor-patterns", "*")
-        .add("otel.instrumentation.spring-integration.producer.enabled", false)
-        .add("otel.instrumentation.spring-scheduling.experimental-span-attributes", false)
-        .add("otel.instrumentation.spring-security.enduser.role.granted-authority-prefix", "ROLE_")
-        .add(
-            "otel.instrumentation.spring-security.enduser.scope.granted-authority-prefix", "SCOPE_")
-        .add("otel.instrumentation.spring-webflux.experimental-span-attributes", false)
-        .add("otel.instrumentation.spring-webmvc.experimental-span-attributes", false)
-        .add("otel.instrumentation.spymemcached.experimental-span-attributes", false)
-        .add("otel.instrumentation.twilio.experimental-span-attributes", false)
-        .add("otel.instrumentation.xxl-job.experimental-span-attributes", false)
-        .add("otel.javaagent.configuration-file", "")
-        .add("otel.javaagent.debug", false)
-        .add("otel.javaagent.enabled", true)
-        .add("otel.javaagent.exclude-classes", "")
-        .add("otel.javaagent.exclude-class-loaders", "")
-        .add("otel.javaagent.experimental.security-manager-support.enabled", false)
-        .add("otel.javaagent.extensions", "")
-        .add("otel.javaagent.logging", "simple")
-        .add("otel.java.disabled.resource.providers", "")
-        .add("otel.java.enabled.resource.providers", "")
-        .add("otel.java.experimental.exporter.memory_mode", "immutable_data")
-        .add("otel.java.exporter.otlp.retry.disabled", true)
-        .add("otel.java.metrics.cardinality.limit", 2000)
-        .add("otel.logs.exporter", "otlp")
-        .add("otel.metrics.exemplar.filter", "TRACE_BASED")
-        .add("otel.metrics.exporter", "otlp")
-        .add("otel.metric.export.interval", 60000)
-        .add("otel.propagators", "tracecontext,baggage")
-        .add("otel.resource.attributes", "")
-        .add("otel.resource.providers.aws.enabled", false)
-        .add("otel.resource.providers.gcp.enabled", false)
-        .add("otel.sdk.disabled", false)
-        .add("otel.service.name", "")
-        .add("otel.span.attribute.count.limit", 128)
-        .addInt("otel.span.attribute.value.length.limit")
-        .add("otel.span.event.count.limit", 128)
-        .add("otel.span.link.count.limit", 128)
-        .add("otel.traces.exporter", "otlp")
-        .add("otel.traces.sampler", "always_on")
-        .add("otel.traces.sampler.arg", "");
+        .add("otel.exporter.otlp.traces.endpoint", getSignalEndpoint(config, OTLP_SIGNAL_TRACES))
+        .add("otel.exporter.otlp.metrics.endpoint", getSignalEndpoint(config, OTLP_SIGNAL_METRICS))
+        .add("otel.exporter.otlp.logs.endpoint", getSignalEndpoint(config, OTLP_SIGNAL_LOGS))
+        .add("otel.service.name", "");
   }
 
-  private static String getOtlpEndpoint(ConfigProperties config) {
-    String endpoint = config.getString(OTEL_EXPORTER_OTLP_ENDPOINT);
-    if (endpoint != null) {
-      return endpoint;
-    }
-    return OTLP_PROTOCOL_HTTP_PROTOBUF.equals(getOtlpProtocol(config))
-        ? "http://localhost:4318"
-        : "http://localhost:4317";
-  }
-
-  private static String getSignalOtlpEndpoint(ConfigProperties config, String signal) {
+  private static String getSignalEndpoint(ConfigProperties config, String signal) {
     String propertyName = "otel.exporter.otlp." + signal + ".endpoint";
     String endpoint = config.getString(propertyName);
     if (endpoint != null) {
@@ -390,22 +89,17 @@ class EnvVarsEffectiveConfigFileFactory {
     }
 
     String baseEndpoint = config.getString(OTEL_EXPORTER_OTLP_ENDPOINT);
+    boolean isProtBuf = OTLP_PROTOCOL_HTTP_PROTOBUF.equals(getSignalOtlpProtocol(config, signal));
     if (baseEndpoint == null) {
-      return OTLP_PROTOCOL_HTTP_PROTOBUF.equals(getSignalOtlpProtocol(config, signal))
-          ? "http://localhost:4318/v1/" + signal
-          : "http://localhost:4317";
+      return isProtBuf ? "http://localhost:4318/v1/" + signal : "http://localhost:4317";
     }
-    if (OTLP_PROTOCOL_HTTP_PROTOBUF.equals(getSignalOtlpProtocol(config, signal))) {
+    if (isProtBuf) {
       return appendSignalPath(baseEndpoint, signal);
     }
     return baseEndpoint;
   }
 
   private static String getSignalOtlpProtocol(ConfigProperties config, String signal) {
-    if (OTLP_SIGNAL_LOGS.equals(signal)) {
-      String protocol = SplunkConfiguration.getOtlpLogsProtocol(config);
-      return protocol == null ? getOtlpProtocol(config) : protocol;
-    }
     String propertyName = "otel.exporter.otlp." + signal + ".protocol";
     return config.getString(propertyName, getOtlpProtocol(config));
   }
@@ -430,31 +124,6 @@ class EnvVarsEffectiveConfigFileFactory {
     return name.toUpperCase(Locale.ROOT).replace('.', '_').replace('-', '_');
   }
 
-  @VisibleForTesting
-  static String sanitizeHeaders(String headers) {
-    if (headers.isEmpty()) {
-      return headers;
-    }
-
-    List<String> sanitized = new ArrayList<>();
-    for (String header : headers.split(",")) {
-      String trimmedHeader = header.trim();
-      if (trimmedHeader.isEmpty()) {
-        continue;
-      }
-
-      int separator = trimmedHeader.indexOf('=');
-      String headerName = separator == -1 ? trimmedHeader : trimmedHeader.substring(0, separator);
-      // Mask X-SF-TOKEN values because they are sensitive data
-      if ("X-SF-TOKEN".equalsIgnoreCase(headerName.trim())) {
-        sanitized.add(headerName + "=" + REDACTION_MARKER);
-      } else {
-        sanitized.add(trimmedHeader);
-      }
-    }
-    return String.join(",", sanitized);
-  }
-
   private class FileContentBuilder {
     private final StringBuilder stringBuilder = new StringBuilder();
 
@@ -463,39 +132,12 @@ class EnvVarsEffectiveConfigFileFactory {
       return this;
     }
 
-    FileContentBuilder addValue(String propertyName, int value) {
-      return addValue(propertyName, Integer.valueOf(value));
-    }
-
-    FileContentBuilder addValue(String propertyName, double value) {
-      return addValue(propertyName, Double.valueOf(value));
-    }
-
     FileContentBuilder addValue(String propertyName, Duration value) {
       return addValue(propertyName, value.toMillis() + "ms");
     }
 
     FileContentBuilder add(String propertyName, String defaultValue) {
       return addValue(propertyName, config.getString(propertyName, defaultValue));
-    }
-
-    FileContentBuilder add(String propertyName, boolean defaultValue) {
-      return addValue(propertyName, config.getBoolean(propertyName, defaultValue));
-    }
-
-    FileContentBuilder add(String propertyName, int defaultValue) {
-      return addValue(propertyName, config.getInt(propertyName, defaultValue));
-    }
-
-    FileContentBuilder addInt(String propertyName) {
-      Integer value = config.getInt(propertyName);
-      return addValue(propertyName, Objects.toString(value, ""));
-    }
-
-    FileContentBuilder add(
-        String propertyName, String defaultValue, UnaryOperator<String> valueTransformer) {
-      return addValue(
-          propertyName, valueTransformer.apply(config.getString(propertyName, defaultValue)));
     }
 
     String build() {

--- a/opamp/src/main/java/com/splunk/opentelemetry/opamp/EnvVarsEffectiveConfigFileFactory.java
+++ b/opamp/src/main/java/com/splunk/opentelemetry/opamp/EnvVarsEffectiveConfigFileFactory.java
@@ -19,12 +19,9 @@ package com.splunk.opentelemetry.opamp;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.splunk.opentelemetry.SplunkConfiguration;
 import com.splunk.opentelemetry.profiler.ProfilerEnvVarsConfiguration;
 import com.splunk.opentelemetry.profiler.snapshot.SnapshotProfilingEnvVarsConfiguration;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
-import java.time.Duration;
-import java.util.Locale;
 import okio.ByteString;
 import opamp.proto.AgentConfigFile;
 
@@ -49,36 +46,30 @@ class EnvVarsEffectiveConfigFileFactory {
 
   @VisibleForTesting
   String buildFileContent() {
-    return addSplunkEnvVars(addOtelEnvVars(new FileContentBuilder())).build();
+    return addSplunkEnvVars(addOtelEnvVars(new EffectiveConfigBuilder())).build();
   }
 
-  private FileContentBuilder addSplunkEnvVars(FileContentBuilder builder) {
+  private EffectiveConfigBuilder addSplunkEnvVars(EffectiveConfigBuilder builder) {
     ProfilerEnvVarsConfiguration profilerConfiguration = new ProfilerEnvVarsConfiguration(config);
     SnapshotProfilingEnvVarsConfiguration snapshotConfiguration =
         new SnapshotProfilingEnvVarsConfiguration(config);
 
     return builder
-        .addValue(SplunkConfiguration.PROFILER_ENABLED_PROPERTY, profilerConfiguration.isEnabled())
-        .addValue(
-            ProfilerEnvVarsConfiguration.CONFIG_KEY_MEMORY_ENABLED,
-            profilerConfiguration.getMemoryEnabled())
-        .addValue(
-            SnapshotProfilingEnvVarsConfiguration.CONFIG_KEY_ENABLE_SNAPSHOT_PROFILER,
-            snapshotConfiguration.isEnabled())
-        .addValue(
-            SnapshotProfilingEnvVarsConfiguration.SAMPLING_INTERVAL_KEY,
+        .add("SPLUNK_PROFILER_ENABLED", profilerConfiguration.isEnabled())
+        .add("SPLUNK_PROFILER_MEMORY_ENABLED", profilerConfiguration.getMemoryEnabled())
+        .add("SPLUNK_SNAPSHOT_PROFILER_ENABLED", snapshotConfiguration.isEnabled())
+        .add(
+            "SPLUNK_SNAPSHOT_PROFILER_SAMPLING_INTERVAL",
             snapshotConfiguration.getSamplingInterval())
-        .addValue(
-            ProfilerEnvVarsConfiguration.CONFIG_KEY_CALL_STACK_INTERVAL,
-            profilerConfiguration.getCallStackInterval());
+        .add("SPLUNK_PROFILER_CALL_STACK_INTERVAL", profilerConfiguration.getCallStackInterval());
   }
 
-  private FileContentBuilder addOtelEnvVars(FileContentBuilder builder) {
+  private EffectiveConfigBuilder addOtelEnvVars(EffectiveConfigBuilder builder) {
     return builder
-        .add("otel.exporter.otlp.traces.endpoint", getSignalEndpoint(config, OTLP_SIGNAL_TRACES))
-        .add("otel.exporter.otlp.metrics.endpoint", getSignalEndpoint(config, OTLP_SIGNAL_METRICS))
-        .add("otel.exporter.otlp.logs.endpoint", getSignalEndpoint(config, OTLP_SIGNAL_LOGS))
-        .add("otel.service.name", "");
+        .add("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", getSignalEndpoint(config, OTLP_SIGNAL_TRACES))
+        .add("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", getSignalEndpoint(config, OTLP_SIGNAL_METRICS))
+        .add("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", getSignalEndpoint(config, OTLP_SIGNAL_LOGS))
+        .add("OTEL_SERVICE_NAME", config.getString("otel.service.name", ""));
   }
 
   private static String getSignalEndpoint(ConfigProperties config, String signal) {
@@ -117,31 +108,5 @@ class EnvVarsEffectiveConfigFileFactory {
       endpoint += "/";
     }
     return endpoint + signalPath;
-  }
-
-  @VisibleForTesting
-  static String toEnvVarName(String name) {
-    return name.toUpperCase(Locale.ROOT).replace('.', '_').replace('-', '_');
-  }
-
-  private class FileContentBuilder {
-    private final StringBuilder stringBuilder = new StringBuilder();
-
-    FileContentBuilder addValue(String propertyName, Object value) {
-      stringBuilder.append(toEnvVarName(propertyName)).append('=').append(value).append('\n');
-      return this;
-    }
-
-    FileContentBuilder addValue(String propertyName, Duration value) {
-      return addValue(propertyName, value.toMillis() + "ms");
-    }
-
-    FileContentBuilder add(String propertyName, String defaultValue) {
-      return addValue(propertyName, config.getString(propertyName, defaultValue));
-    }
-
-    String build() {
-      return stringBuilder.toString();
-    }
   }
 }

--- a/opamp/src/test/java/com/splunk/opentelemetry/opamp/EnvVarsEffectiveConfigFileFactoryTest.java
+++ b/opamp/src/test/java/com/splunk/opentelemetry/opamp/EnvVarsEffectiveConfigFileFactoryTest.java
@@ -16,7 +16,6 @@
 
 package com.splunk.opentelemetry.opamp;
 
-import static com.splunk.opentelemetry.opamp.EnvVarsEffectiveConfigFileFactory.toEnvVarName;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
@@ -47,15 +46,15 @@ class EnvVarsEffectiveConfigFileFactoryTest {
     assertProperties(
         fileContent,
         Map.of(
-            "splunk.profiler.enabled", "true",
-            "splunk.profiler.memory.enabled", "true",
-            "splunk.snapshot.profiler.enabled", "true",
-            "splunk.snapshot.sampling.interval", "26ms",
-            "splunk.profiler.call.stack.interval", "1235ms",
-            "otel.exporter.otlp.traces.endpoint", "https://traces.example.com",
-            "otel.exporter.otlp.metrics.endpoint", "https://metrics.example.com",
-            "otel.exporter.otlp.logs.endpoint", "https://logs.example.com",
-            "otel.service.name", "checkout"));
+            "SPLUNK_PROFILER_ENABLED", "true",
+            "SPLUNK_PROFILER_MEMORY_ENABLED", "true",
+            "SPLUNK_SNAPSHOT_PROFILER_ENABLED", "true",
+            "SPLUNK_SNAPSHOT_PROFILER_SAMPLING_INTERVAL", "26ms",
+            "SPLUNK_PROFILER_CALL_STACK_INTERVAL", "1235ms",
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "https://traces.example.com",
+            "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "https://metrics.example.com",
+            "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "https://logs.example.com",
+            "OTEL_SERVICE_NAME", "checkout"));
     assertThat(fileContent.size()).isEqualTo(9);
   }
 
@@ -66,15 +65,15 @@ class EnvVarsEffectiveConfigFileFactoryTest {
     assertProperties(
         fileContent,
         Map.of(
-            "splunk.profiler.enabled", "false",
-            "splunk.profiler.memory.enabled", "false",
-            "splunk.snapshot.profiler.enabled", "false",
-            "splunk.snapshot.sampling.interval", "10ms",
-            "splunk.profiler.call.stack.interval", "10000ms",
-            "otel.exporter.otlp.traces.endpoint", "http://localhost:4318/v1/traces",
-            "otel.exporter.otlp.metrics.endpoint", "http://localhost:4318/v1/metrics",
-            "otel.exporter.otlp.logs.endpoint", "http://localhost:4318/v1/logs",
-            "otel.service.name", ""));
+            "SPLUNK_PROFILER_ENABLED", "false",
+            "SPLUNK_PROFILER_MEMORY_ENABLED", "false",
+            "SPLUNK_SNAPSHOT_PROFILER_ENABLED", "false",
+            "SPLUNK_SNAPSHOT_PROFILER_SAMPLING_INTERVAL", "10ms",
+            "SPLUNK_PROFILER_CALL_STACK_INTERVAL", "10000ms",
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://localhost:4318/v1/traces",
+            "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://localhost:4318/v1/metrics",
+            "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "http://localhost:4318/v1/logs",
+            "OTEL_SERVICE_NAME", ""));
     assertThat(fileContent.size()).isEqualTo(9);
   }
 
@@ -86,9 +85,9 @@ class EnvVarsEffectiveConfigFileFactoryTest {
     assertProperties(
         fileContent,
         Map.of(
-            "otel.exporter.otlp.traces.endpoint", "https://collector:4318/v1/traces",
-            "otel.exporter.otlp.metrics.endpoint", "https://collector:4318/v1/metrics",
-            "otel.exporter.otlp.logs.endpoint", "https://collector:4318/v1/logs"));
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "https://collector:4318/v1/traces",
+            "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "https://collector:4318/v1/metrics",
+            "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "https://collector:4318/v1/logs"));
   }
 
   @Test
@@ -102,9 +101,9 @@ class EnvVarsEffectiveConfigFileFactoryTest {
     assertProperties(
         fileContent,
         Map.of(
-            "otel.exporter.otlp.traces.endpoint", "https://collector:4317",
-            "otel.exporter.otlp.metrics.endpoint", "https://collector:4317",
-            "otel.exporter.otlp.logs.endpoint", "https://collector:4317"));
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "https://collector:4317",
+            "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "https://collector:4317",
+            "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "https://collector:4317"));
   }
 
   @Test
@@ -120,9 +119,9 @@ class EnvVarsEffectiveConfigFileFactoryTest {
     assertProperties(
         fileContent,
         Map.of(
-            "otel.exporter.otlp.traces.endpoint", "https://collector:4317",
-            "otel.exporter.otlp.metrics.endpoint", "https://collector:4317",
-            "otel.exporter.otlp.logs.endpoint", "https://collector:4317"));
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "https://collector:4317",
+            "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "https://collector:4317",
+            "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "https://collector:4317"));
   }
 
   private static String createFileContent(Map<String, String> configMap) {
@@ -143,6 +142,6 @@ class EnvVarsEffectiveConfigFileFactoryTest {
 
   private static void assertProperty(
       Properties fileContent, String propertyName, String expectedValue) {
-    assertThat(fileContent.getProperty(toEnvVarName(propertyName))).isEqualTo(expectedValue);
+    assertThat(fileContent.getProperty(propertyName)).isEqualTo(expectedValue);
   }
 }

--- a/opamp/src/test/java/com/splunk/opentelemetry/opamp/EnvVarsEffectiveConfigFileFactoryTest.java
+++ b/opamp/src/test/java/com/splunk/opentelemetry/opamp/EnvVarsEffectiveConfigFileFactoryTest.java
@@ -16,651 +16,113 @@
 
 package com.splunk.opentelemetry.opamp;
 
-import static com.splunk.opentelemetry.SplunkConfiguration.METRICS_FULL_COMMAND_LINE;
-import static com.splunk.opentelemetry.SplunkConfiguration.SPLUNK_ACCESS_TOKEN;
-import static com.splunk.opentelemetry.opamp.EnvVarsEffectiveConfigFileFactory.REDACTION_MARKER;
 import static com.splunk.opentelemetry.opamp.EnvVarsEffectiveConfigFileFactory.toEnvVarName;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.splunk.opentelemetry.profiler.ProfilerConfiguration;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
 import java.io.IOException;
 import java.io.StringReader;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
 
 class EnvVarsEffectiveConfigFileFactoryTest {
-  private static final String OTEL_EXPORTER_OTLP_HEADERS_PROPERTY = "otel.exporter.otlp.headers";
-  private static final String OTEL_EXPORTER_OTLP_LOGS_HEADERS_PROPERTY =
-      "otel.exporter.otlp.logs.headers";
-  private static final String OTEL_EXPORTER_OTLP_METRICS_HEADERS_PROPERTY =
-      "otel.exporter.otlp.metrics.headers";
-  private static final String OTEL_EXPORTER_OTLP_TRACES_HEADERS_PROPERTY =
-      "otel.exporter.otlp.traces.headers";
 
   @Test
-  void testReportedValuesInitiallySetToNonDefaultValues() throws IOException {
-    Map<String, String> configuredValues = createConfiguredValues();
-    Properties fileContent = loadProperties(createFileContent(configuredValues));
+  void buildFileContent_reportsConfiguredValues() throws IOException {
+    Properties fileContent =
+        loadProperties(
+            Map.of(
+                "splunk.profiler.enabled", "true",
+                "splunk.profiler.memory.enabled", "true",
+                "splunk.snapshot.profiler.enabled", "true",
+                "splunk.snapshot.sampling.interval", "26ms",
+                "splunk.profiler.call.stack.interval", "1235ms",
+                "otel.exporter.otlp.endpoint", "https://base.example.com",
+                "otel.exporter.otlp.traces.endpoint", "https://traces.example.com",
+                "otel.exporter.otlp.metrics.endpoint", "https://metrics.example.com",
+                "otel.exporter.otlp.logs.endpoint", "https://logs.example.com",
+                "otel.service.name", "checkout"));
 
-    assertReportedConfiguredValues(fileContent, configuredValues);
+    assertProperties(
+        fileContent,
+        Map.of(
+            "splunk.profiler.enabled", "true",
+            "splunk.profiler.memory.enabled", "true",
+            "splunk.snapshot.profiler.enabled", "true",
+            "splunk.snapshot.sampling.interval", "26ms",
+            "splunk.profiler.call.stack.interval", "1235ms",
+            "otel.exporter.otlp.traces.endpoint", "https://traces.example.com",
+            "otel.exporter.otlp.metrics.endpoint", "https://metrics.example.com",
+            "otel.exporter.otlp.logs.endpoint", "https://logs.example.com",
+            "otel.service.name", "checkout"));
+    assertThat(fileContent.size()).isEqualTo(9);
   }
 
   @Test
-  void testReportedDefaultValues() throws IOException {
-    Properties fileContent = loadProperties(createFileContent(Map.of()));
+  void buildFileContent_reportsDefaultValuesWhenNotConfigured() throws IOException {
+    Properties fileContent = loadProperties(Map.of());
 
-    assertReportedDefaultValues(fileContent);
+    assertProperties(
+        fileContent,
+        Map.of(
+            "splunk.profiler.enabled", "false",
+            "splunk.profiler.memory.enabled", "false",
+            "splunk.snapshot.profiler.enabled", "false",
+            "splunk.snapshot.sampling.interval", "10ms",
+            "splunk.profiler.call.stack.interval", "10000ms",
+            "otel.exporter.otlp.traces.endpoint", "http://localhost:4318/v1/traces",
+            "otel.exporter.otlp.metrics.endpoint", "http://localhost:4318/v1/metrics",
+            "otel.exporter.otlp.logs.endpoint", "http://localhost:4318/v1/logs",
+            "otel.service.name", ""));
+    assertThat(fileContent.size()).isEqualTo(9);
   }
 
   @Test
-  void testSanitization() {
-    assertThat(EnvVarsEffectiveConfigFileFactory.sanitizeHeaders("")).isEqualTo("");
+  void buildFileContent_appendsSignalPathsToBaseHttpProtobufEndpoint() throws IOException {
+    Properties fileContent =
+        loadProperties(Map.of("otel.exporter.otlp.endpoint", "https://collector:4318"));
 
-    assertThat(EnvVarsEffectiveConfigFileFactory.sanitizeHeaders("header-1=abc"))
-        .isEqualTo("header-1=abc");
-
-    assertThat(EnvVarsEffectiveConfigFileFactory.sanitizeHeaders("x-sf-token=something"))
-        .isEqualTo("x-sf-token=" + EnvVarsEffectiveConfigFileFactory.REDACTION_MARKER);
-
-    assertThat(
-            EnvVarsEffectiveConfigFileFactory.sanitizeHeaders(
-                "HEADER-1=abc, X-SF-TOKEN=something, HEADER-2=def"))
-        .isEqualTo(
-            "HEADER-1=abc,X-SF-TOKEN="
-                + EnvVarsEffectiveConfigFileFactory.REDACTION_MARKER
-                + ",HEADER-2=def");
+    assertProperties(
+        fileContent,
+        Map.of(
+            "otel.exporter.otlp.traces.endpoint", "https://collector:4318/v1/traces",
+            "otel.exporter.otlp.metrics.endpoint", "https://collector:4318/v1/metrics",
+            "otel.exporter.otlp.logs.endpoint", "https://collector:4318/v1/logs"));
   }
 
-  private static Map<String, String> createConfiguredValues() {
-    Map<String, String> config = new HashMap<>();
+  @Test
+  void buildFileContent_usesBaseGrpcEndpointForAllSignals() throws IOException {
+    Properties fileContent =
+        loadProperties(
+            Map.of(
+                "otel.exporter.otlp.endpoint", "https://collector:4317",
+                "otel.exporter.otlp.protocol", "grpc"));
 
-    config.put("otel.attribute.count.limit", "129");
-    config.put("otel.attribute.value.length.limit", "256");
-    config.put("otel.blrp.export.timeout", "30001");
-    config.put("otel.blrp.max.export.batch.size", "513");
-    config.put("otel.blrp.max.queue.size", "2049");
-    config.put("otel.blrp.schedule.delay", "1001");
-    config.put("otel.bsp.export.timeout", "30001");
-    config.put("otel.bsp.max.export.batch.size", "513");
-    config.put("otel.bsp.max.queue.size", "2049");
-    config.put("otel.bsp.schedule.delay", "5001");
-    config.put("otel.config.file", "/tmp/otel_config_file");
-    config.put("otel.experimental.javascript.snippet", "configured.javascript");
-    config.put("otel.experimental.resource.disabled.keys", "service.name,process.pid");
-    config.put("otel.exporter.otlp.certificate", "/tmp/otel_exporter_otlp_certificate.crt");
-    config.put(
-        "otel.exporter.otlp.client.certificate", "/tmp/otel_exporter_otlp_client_certificate.crt");
-    config.put("otel.exporter.otlp.client.key", "/tmp/otel_exporter_otlp_client_key.key");
-    config.put("otel.exporter.otlp.compression", "gzip");
-    config.put(
-        "otel.exporter.otlp.endpoint",
-        "https://configured.example.com/otel_exporter_otlp_endpoint");
-    config.put(OTEL_EXPORTER_OTLP_HEADERS_PROPERTY, "Authorization=abc,X-SF-TOKEN=token");
-    config.put(
-        "otel.exporter.otlp.logs.certificate", "/tmp/otel_exporter_otlp_logs_certificate.crt");
-    config.put(
-        "otel.exporter.otlp.logs.client.certificate",
-        "/tmp/otel_exporter_otlp_logs_client_certificate.crt");
-    config.put("otel.exporter.otlp.logs.client.key", "/tmp/otel_exporter_otlp_logs_client_key.key");
-    config.put("otel.exporter.otlp.logs.compression", "gzip");
-    config.put(
-        "otel.exporter.otlp.logs.endpoint",
-        "https://configured.example.com/otel_exporter_otlp_logs_endpoint");
-    config.put(OTEL_EXPORTER_OTLP_LOGS_HEADERS_PROPERTY, "logs-header=abc,X-SF-TOKEN=token");
-    config.put("otel.exporter.otlp.logs.protocol", "grpc");
-    config.put("otel.exporter.otlp.logs.timeout", "10001");
-    config.put(
-        "otel.exporter.otlp.metrics.certificate",
-        "/tmp/otel_exporter_otlp_metrics_certificate.crt");
-    config.put(
-        "otel.exporter.otlp.metrics.client.certificate",
-        "/tmp/otel_exporter_otlp_metrics_client_certificate.crt");
-    config.put(
-        "otel.exporter.otlp.metrics.client.key", "/tmp/otel_exporter_otlp_metrics_client_key.key");
-    config.put("otel.exporter.otlp.metrics.compression", "gzip");
-    config.put(
-        "otel.exporter.otlp.metrics.default.histogram.aggregation",
-        "BASE2_EXPONENTIAL_BUCKET_HISTOGRAM");
-    config.put(
-        "otel.exporter.otlp.metrics.endpoint",
-        "https://configured.example.com/otel_exporter_otlp_metrics_endpoint");
-    config.put(OTEL_EXPORTER_OTLP_METRICS_HEADERS_PROPERTY, "metrics-header=abc,X-SF-TOKEN=token");
-    config.put("otel.exporter.otlp.metrics.protocol", "grpc");
-    config.put("otel.exporter.otlp.metrics.temporality.preference", "DELTA");
-    config.put("otel.exporter.otlp.metrics.timeout", "10001");
-    config.put("otel.exporter.otlp.protocol", "grpc");
-    config.put("otel.exporter.otlp.timeout", "10001");
-    config.put(
-        "otel.exporter.otlp.traces.certificate", "/tmp/otel_exporter_otlp_traces_certificate.crt");
-    config.put(
-        "otel.exporter.otlp.traces.client.certificate",
-        "/tmp/otel_exporter_otlp_traces_client_certificate.crt");
-    config.put(
-        "otel.exporter.otlp.traces.client.key", "/tmp/otel_exporter_otlp_traces_client_key.key");
-    config.put("otel.exporter.otlp.traces.compression", "gzip");
-    config.put(
-        "otel.exporter.otlp.traces.endpoint",
-        "https://configured.example.com/otel_exporter_otlp_traces_endpoint");
-    config.put(OTEL_EXPORTER_OTLP_TRACES_HEADERS_PROPERTY, "traces-header=abc,X-SF-TOKEN=token");
-    config.put("otel.exporter.otlp.traces.protocol", "grpc");
-    config.put("otel.exporter.otlp.traces.timeout", "10001");
-    config.put("otel.exporter.prometheus.host", "127.0.0.1");
-    config.put("otel.exporter.prometheus.port", "9465");
-    config.put(
-        "otel.exporter.zipkin.endpoint",
-        "https://configured.example.com/otel_exporter_zipkin_endpoint");
-    config.put("otel.instrumentation.apache.elasticjob.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.apache.shenyu.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.aws.sdk.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.aws.sdk.experimental.use.propagator.for.messaging", "true");
-    config.put("otel.instrumentation.camel.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.common.db.statement.sanitizer.enabled", "false");
-    config.put("otel.instrumentation.common.default.enabled", "false");
-    config.put("otel.instrumentation.common.enduser.enabled", "true");
-    config.put("otel.instrumentation.common.enduser.id.enabled", "true");
-    config.put("otel.instrumentation.common.enduser.role.enabled", "true");
-    config.put("otel.instrumentation.common.enduser.scope.enabled", "true");
-    config.put("otel.instrumentation.common.experimental.controller.telemetry.enabled", "true");
-    config.put("otel.instrumentation.common.experimental.view.telemetry.enabled", "true");
-    config.put("otel.instrumentation.common.logging.span.id", "spanId");
-    config.put("otel.instrumentation.common.logging.trace.flags", "traceFlags");
-    config.put("otel.instrumentation.common.logging.trace.id", "traceId");
-    config.put(
-        "otel.instrumentation.common.mdc.resource.attributes", "service.name,service.version");
-    config.put("otel.instrumentation.common.peer.service.mapping", "db=orders-db");
-    config.put("otel.instrumentation.couchbase.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.elasticsearch.capture.search.query", "true");
-    config.put("otel.instrumentation.elasticsearch.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.experimental.span.suppression.strategy", "none");
-    config.put("otel.instrumentation.genai.capture.message.content", "true");
-    config.put("otel.instrumentation.graphql.add.operation.name.to.span.name.enabled", "true");
-    config.put("otel.instrumentation.graphql.capture.query", "false");
-    config.put("otel.instrumentation.graphql.data.fetcher.enabled", "true");
-    config.put("otel.instrumentation.graphql.query.sanitizer.enabled", "false");
-    config.put("otel.instrumentation.graphql.trivial.data.fetcher.enabled", "true");
-    config.put("otel.instrumentation.grpc.capture.metadata.client.request", "x-request-id");
-    config.put("otel.instrumentation.grpc.capture.metadata.server.request", "x-request-id");
-    config.put("otel.instrumentation.grpc.emit.message.events", "false");
-    config.put("otel.instrumentation.grpc.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.guava.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.hibernate.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.http.client.capture.request.headers", "x-request-id");
-    config.put("otel.instrumentation.http.client.capture.response.headers", "x-response-id");
-    config.put("otel.instrumentation.http.client.emit.experimental.telemetry", "true");
-    config.put("otel.instrumentation.http.client.experimental.redact.query.parameters", "false");
-    config.put("otel.instrumentation.http.known.methods", "GET, POST");
-    config.put("otel.instrumentation.http.server.capture.request.headers", "x-request-id");
-    config.put("otel.instrumentation.http.server.capture.response.headers", "x-response-id");
-    config.put("otel.instrumentation.http.server.emit.experimental.telemetry", "true");
-    config.put("otel.instrumentation.hystrix.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.java.util.logging.experimental.log.attributes", "true");
-    config.put("otel.instrumentation.jaxrs.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.jboss.logmanager.experimental.capture.event.name", "true");
-    config.put(
-        "otel.instrumentation.jboss.logmanager.experimental.capture.mdc.attributes", "mdc.key");
-    config.put("otel.instrumentation.jboss.logmanager.experimental.log.attributes", "true");
-    config.put("otel.instrumentation.jdbc.experimental.capture.query.parameters", "true");
-    config.put("otel.instrumentation.jdbc.experimental.sqlcommenter.enabled", "true");
-    config.put("otel.instrumentation.jdbc.experimental.transaction.enabled", "true");
-    config.put("otel.instrumentation.jdbc.statement.sanitizer.enabled", "false");
-    config.put("otel.instrumentation.jsp.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.kafka.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.kafka.producer.propagation.enabled", "false");
-    config.put("otel.instrumentation.kubernetes.client.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.lettuce.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.log4j.appender.experimental.capture.code.attributes", "true");
-    config.put("otel.instrumentation.log4j.appender.experimental.capture.event.name", "true");
-    config.put(
-        "otel.instrumentation.log4j.appender.experimental.capture.map.message.attributes", "true");
-    config.put("otel.instrumentation.log4j.appender.experimental.capture.marker.attribute", "true");
-    config.put(
-        "otel.instrumentation.log4j.appender.experimental.capture.mdc.attributes", "mdc.key");
-    config.put("otel.instrumentation.log4j.appender.experimental.log.attributes", "true");
-    config.put("otel.instrumentation.log4j.context.data.add.baggage", "true");
-    config.put("otel.instrumentation.logback.appender.experimental.capture.arguments", "true");
-    config.put(
-        "otel.instrumentation.logback.appender.experimental.capture.code.attributes", "true");
-    config.put("otel.instrumentation.logback.appender.experimental.capture.event.name", "true");
-    config.put(
-        "otel.instrumentation.logback.appender.experimental.capture.key.value.pair.attributes",
-        "true");
-    config.put(
-        "otel.instrumentation.logback.appender.experimental.capture.logger.context.attributes",
-        "true");
-    config.put(
-        "otel.instrumentation.logback.appender.experimental.capture.logstash.marker.attributes",
-        "true");
-    config.put(
-        "otel.instrumentation.logback.appender.experimental.capture.logstash.structured.arguments",
-        "true");
-    config.put(
-        "otel.instrumentation.logback.appender.experimental.capture.marker.attribute", "true");
-    config.put(
-        "otel.instrumentation.logback.appender.experimental.capture.mdc.attributes", "mdc.key");
-    config.put("otel.instrumentation.logback.appender.experimental.log.attributes", "true");
-    config.put("otel.instrumentation.logback.mdc.add.baggage", "true");
-    config.put("otel.instrumentation.messaging.experimental.receive.telemetry.enabled", "true");
-    config.put("otel.instrumentation.methods.include", "com.example.Foo[bar,baz]");
-    config.put("otel.instrumentation.micrometer.base.time.unit", "ms");
-    config.put("otel.instrumentation.micrometer.histogram.gauges.enabled", "true");
-    config.put("otel.instrumentation.micrometer.prometheus.mode.enabled", "true");
-    config.put("otel.instrumentation.mongo.statement.sanitizer.enabled", "false");
-    config.put("otel.instrumentation.netty.connection.telemetry.enabled", "true");
-    config.put("otel.instrumentation.netty.ssl.telemetry.enabled", "true");
-    config.put("otel.instrumentation.opensearch.capture.search.query", "false");
-    config.put("otel.instrumentation.opensearch.experimental.span.attributes", "true");
-    config.put(
-        "otel.instrumentation.opentelemetry.annotations.exclude.methods", "configured.value");
-    config.put(
-        "otel.instrumentation.opentelemetry.instrumentation.annotations.exclude.methods",
-        "configured.value");
-    config.put("otel.instrumentation.oshi.experimental.metrics.enabled", "true");
-    config.put("otel.instrumentation.powerjob.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.pulsar.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.quartz.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.r2dbc.statement.sanitizer.enabled", "false");
-    config.put("otel.instrumentation.rabbitmq.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.reactor.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.reactor.netty.connection.telemetry.enabled", "true");
-    config.put("otel.instrumentation.rocketmq.client.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.runtime.telemetry.emit.experimental.telemetry", "true");
-    config.put("otel.instrumentation.runtime.telemetry.java17.enabled", "true");
-    config.put("otel.instrumentation.runtime.telemetry.java17.enable.all", "true");
-    config.put("otel.instrumentation.runtime.telemetry.package.emitter.enabled", "true");
-    config.put("otel.instrumentation.runtime.telemetry.package.emitter.jars.per.second", "11");
-    config.put("otel.instrumentation.rxjava.experimental.span.attributes", "true");
-    config.put(
-        "otel.instrumentation.sanitization.url.experimental.sensitive.query.parameters",
-        "token,secret");
-    config.put(
-        "otel.instrumentation.servlet.experimental.capture.request.parameters", "configured.value");
-    config.put("otel.instrumentation.servlet.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.spring.batch.experimental.chunk.new.trace", "true");
-    config.put("otel.instrumentation.spring.batch.item.enabled", "true");
-    config.put("otel.instrumentation.spring.cloud.gateway.experimental.span.attributes", "true");
-    config.put(
-        "otel.instrumentation.spring.integration.global.channel.interceptor.patterns",
-        "orders*,payments*");
-    config.put("otel.instrumentation.spring.integration.producer.enabled", "true");
-    config.put("otel.instrumentation.spring.scheduling.experimental.span.attributes", "true");
-    config.put(
-        "otel.instrumentation.spring.security.enduser.role.granted.authority.prefix", "APP_");
-    config.put(
-        "otel.instrumentation.spring.security.enduser.scope.granted.authority.prefix", "PERM_");
-    config.put("otel.instrumentation.spring.webflux.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.spring.webmvc.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.spymemcached.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.twilio.experimental.span.attributes", "true");
-    config.put("otel.instrumentation.xxl.job.experimental.span.attributes", "true");
-    config.put("otel.javaagent.configuration.file", "/tmp/otel_javaagent_configuration_file");
-    config.put("otel.javaagent.debug", "true");
-    config.put("otel.javaagent.enabled", "false");
-    config.put("otel.javaagent.exclude.classes", "configured.value");
-    config.put("otel.javaagent.exclude.class.loaders", "configured.value");
-    config.put("otel.javaagent.experimental.security.manager.support.enabled", "true");
-    config.put("otel.javaagent.extensions", "/tmp/otel_javaagent_extensions.jar");
-    config.put("otel.javaagent.logging", "application");
-    config.put("otel.java.disabled.resource.providers", "configured.value");
-    config.put("otel.java.enabled.resource.providers", "configured.value");
-    config.put("otel.java.experimental.exporter.memory_mode", "reusable_data");
-    config.put("otel.java.exporter.otlp.retry.disabled", "false");
-    config.put("otel.java.metrics.cardinality.limit", "2001");
-    config.put("otel.logs.exporter", "none");
-    config.put("otel.metrics.exemplar.filter", "ALWAYS_OFF");
-    config.put("otel.metrics.exporter", "prometheus");
-    config.put("otel.metric.export.interval", "60001");
-    config.put("otel.propagators", "b3,baggage");
-    config.put("otel.resource.attributes", "service.name=checkout,service.version=1.2.3");
-    config.put("otel.resource.providers.aws.enabled", "true");
-    config.put("otel.resource.providers.gcp.enabled", "true");
-    config.put("otel.sdk.disabled", "true");
-    config.put("otel.service.name", "checkout");
-    config.put("otel.span.attribute.count.limit", "129");
-    config.put("otel.span.attribute.value.length.limit", "256");
-    config.put("otel.span.event.count.limit", "129");
-    config.put("otel.span.link.count.limit", "129");
-    config.put("otel.traces.exporter", "zipkin");
-    config.put("otel.traces.sampler", "traceidratio");
-    config.put("otel.traces.sampler.arg", "0.5");
-    config.put(METRICS_FULL_COMMAND_LINE, "true");
-    config.put("splunk.otel.instrumentation.nocode.yml.file", "/tmp/nocode.yml");
-    config.put("splunk.profiler.call.stack.interval", "1235ms");
-    config.put("splunk.profiler.directory", "/tmp/profiler");
-    config.put("splunk.profiler.enabled", "true");
-    config.put("splunk.profiler.include.agent.internals", "true");
-    config.put("splunk.profiler.include.internal.stacks", "true");
-    config.put("splunk.profiler.include.jvm.internals", "true");
-    config.put("splunk.profiler.keep.files", "true");
-    config.put("splunk.profiler.logs.endpoint", "https://configured.example.com/profiler/logs");
-    config.put("splunk.profiler.max.stack.depth", "1025");
-    config.put("splunk.profiler.memory.enabled", "true");
-    config.put("splunk.profiler.memory.event.rate", "321/s");
-    config.put("splunk.profiler.memory.event.rate.limit.enabled", "false");
-    config.put("splunk.profiler.memory.native.sampling", "true");
-    config.put("splunk.profiler.otlp.protocol", "grpc");
-    config.put("splunk.profiler.recording.duration", "15001ms");
-    config.put("splunk.profiler.tracing.stacks.only", "true");
-    config.put("splunk.realm", "us1");
-    config.put("splunk.trace.response.header.enabled", "false");
-    config.put("splunk.snapshot.profiler.enabled", "true");
-    config.put("splunk.snapshot.selection.probability", "0.25");
-    config.put("splunk.snapshot.profiler.max.stack.depth", "1025");
-    config.put("splunk.snapshot.sampling.interval", "26ms");
-    config.put("splunk.snapshot.profiler.export.interval", "43ms");
-    config.put("splunk.snapshot.profiler.staging.capacity", "2001");
-    config.put(SPLUNK_ACCESS_TOKEN, "token");
-
-    return config;
+    assertProperties(
+        fileContent,
+        Map.of(
+            "otel.exporter.otlp.traces.endpoint", "https://collector:4317",
+            "otel.exporter.otlp.metrics.endpoint", "https://collector:4317",
+            "otel.exporter.otlp.logs.endpoint", "https://collector:4317"));
   }
 
-  private static void assertReportedConfiguredValues(
-      Properties fileContent, Map<String, String> configuredValues) {
-    Properties expected = toProperties(configuredValues);
-    expected.setProperty(
-        OTEL_EXPORTER_OTLP_HEADERS_PROPERTY, "Authorization=abc,X-SF-TOKEN=" + REDACTION_MARKER);
-    expected.setProperty(
-        OTEL_EXPORTER_OTLP_LOGS_HEADERS_PROPERTY, "logs-header=abc,X-SF-TOKEN=" + REDACTION_MARKER);
-    expected.setProperty(
-        OTEL_EXPORTER_OTLP_METRICS_HEADERS_PROPERTY,
-        "metrics-header=abc,X-SF-TOKEN=" + REDACTION_MARKER);
-    expected.setProperty(
-        OTEL_EXPORTER_OTLP_TRACES_HEADERS_PROPERTY,
-        "traces-header=abc,X-SF-TOKEN=" + REDACTION_MARKER);
-    expected.setProperty(SPLUNK_ACCESS_TOKEN, REDACTION_MARKER);
+  @Test
+  void buildFileContent_usesSignalSpecificProtocolWhenResolvingEndpoints() throws IOException {
+    Properties fileContent =
+        loadProperties(
+            Map.of(
+                "otel.exporter.otlp.endpoint", "https://collector:4317",
+                "otel.exporter.otlp.traces.protocol", "grpc",
+                "otel.exporter.otlp.metrics.protocol", "grpc",
+                "otel.exporter.otlp.logs.protocol", "grpc"));
 
-    // See ProfilerEnvVarsConfiguration.getUseAllocationSampleEvent()
-    expected.setProperty(
-        "splunk.profiler.memory.native.sampling",
-        String.valueOf(ProfilerConfiguration.HAS_OBJECT_ALLOCATION_SAMPLE_EVENT));
-
-    assertProperties(fileContent, expected);
-  }
-
-  private static void assertReportedDefaultValues(Properties fileContent) {
-    Properties expected = new Properties();
-
-    expected.setProperty("otel.attribute.count.limit", "128");
-    expected.setProperty("otel.attribute.value.length.limit", "");
-    expected.setProperty("otel.blrp.export.timeout", "30000");
-    expected.setProperty("otel.blrp.max.export.batch.size", "512");
-    expected.setProperty("otel.blrp.max.queue.size", "2048");
-    expected.setProperty("otel.blrp.schedule.delay", "1000");
-    expected.setProperty("otel.bsp.export.timeout", "30000");
-    expected.setProperty("otel.bsp.max.export.batch.size", "512");
-    expected.setProperty("otel.bsp.max.queue.size", "2048");
-    expected.setProperty("otel.bsp.schedule.delay", "5000");
-    expected.setProperty("otel.config.file", "");
-    expected.setProperty("otel.experimental.javascript.snippet", "");
-    expected.setProperty("otel.experimental.resource.disabled.keys", "");
-    expected.setProperty("otel.exporter.otlp.certificate", "");
-    expected.setProperty("otel.exporter.otlp.client.certificate", "");
-    expected.setProperty("otel.exporter.otlp.client.key", "");
-    expected.setProperty("otel.exporter.otlp.compression", "");
-    expected.setProperty("otel.exporter.otlp.endpoint", "http://localhost:4318");
-    expected.setProperty(OTEL_EXPORTER_OTLP_HEADERS_PROPERTY, "");
-    expected.setProperty("otel.exporter.otlp.logs.certificate", "");
-    expected.setProperty("otel.exporter.otlp.logs.client.certificate", "");
-    expected.setProperty("otel.exporter.otlp.logs.client.key", "");
-    expected.setProperty("otel.exporter.otlp.logs.compression", "");
-    expected.setProperty("otel.exporter.otlp.logs.endpoint", "http://localhost:4318/v1/logs");
-    expected.setProperty(OTEL_EXPORTER_OTLP_LOGS_HEADERS_PROPERTY, "");
-    expected.setProperty("otel.exporter.otlp.logs.protocol", "http/protobuf");
-    expected.setProperty("otel.exporter.otlp.logs.timeout", "10000");
-    expected.setProperty("otel.exporter.otlp.metrics.certificate", "");
-    expected.setProperty("otel.exporter.otlp.metrics.client.certificate", "");
-    expected.setProperty("otel.exporter.otlp.metrics.client.key", "");
-    expected.setProperty("otel.exporter.otlp.metrics.compression", "");
-    expected.setProperty(
-        "otel.exporter.otlp.metrics.default.histogram.aggregation", "EXPLICIT_BUCKET_HISTOGRAM");
-    expected.setProperty("otel.exporter.otlp.metrics.endpoint", "http://localhost:4318/v1/metrics");
-    expected.setProperty(OTEL_EXPORTER_OTLP_METRICS_HEADERS_PROPERTY, "");
-    expected.setProperty("otel.exporter.otlp.metrics.protocol", "http/protobuf");
-    expected.setProperty("otel.exporter.otlp.metrics.temporality.preference", "CUMULATIVE");
-    expected.setProperty("otel.exporter.otlp.metrics.timeout", "10000");
-    expected.setProperty("otel.exporter.otlp.protocol", "http/protobuf");
-    expected.setProperty("otel.exporter.otlp.timeout", "10000");
-    expected.setProperty("otel.exporter.otlp.traces.certificate", "");
-    expected.setProperty("otel.exporter.otlp.traces.client.certificate", "");
-    expected.setProperty("otel.exporter.otlp.traces.client.key", "");
-    expected.setProperty("otel.exporter.otlp.traces.compression", "");
-    expected.setProperty("otel.exporter.otlp.traces.endpoint", "http://localhost:4318/v1/traces");
-    expected.setProperty(OTEL_EXPORTER_OTLP_TRACES_HEADERS_PROPERTY, "");
-    expected.setProperty("otel.exporter.otlp.traces.protocol", "http/protobuf");
-    expected.setProperty("otel.exporter.otlp.traces.timeout", "10000");
-    expected.setProperty("otel.exporter.prometheus.host", "0.0.0.0");
-    expected.setProperty("otel.exporter.prometheus.port", "9464");
-    expected.setProperty("otel.exporter.zipkin.endpoint", "http://localhost:9411/api/v2/spans");
-    expected.setProperty(
-        "otel.instrumentation.apache.elasticjob.experimental.span.attributes", "false");
-    expected.setProperty(
-        "otel.instrumentation.apache.shenyu.experimental.span.attributes", "false");
-    expected.setProperty("otel.instrumentation.aws.sdk.experimental.span.attributes", "false");
-    expected.setProperty(
-        "otel.instrumentation.aws.sdk.experimental.use.propagator.for.messaging", "false");
-    expected.setProperty("otel.instrumentation.camel.experimental.span.attributes", "false");
-    expected.setProperty("otel.instrumentation.common.db.statement.sanitizer.enabled", "true");
-    expected.setProperty("otel.instrumentation.common.default.enabled", "true");
-    expected.setProperty("otel.instrumentation.common.enduser.enabled", "false");
-    expected.setProperty("otel.instrumentation.common.enduser.id.enabled", "false");
-    expected.setProperty("otel.instrumentation.common.enduser.role.enabled", "false");
-    expected.setProperty("otel.instrumentation.common.enduser.scope.enabled", "false");
-    expected.setProperty(
-        "otel.instrumentation.common.experimental.controller.telemetry.enabled", "false");
-    expected.setProperty(
-        "otel.instrumentation.common.experimental.view.telemetry.enabled", "false");
-    expected.setProperty("otel.instrumentation.common.logging.span.id", "span_id");
-    expected.setProperty("otel.instrumentation.common.logging.trace.flags", "trace_flags");
-    expected.setProperty("otel.instrumentation.common.logging.trace.id", "trace_id");
-    expected.setProperty("otel.instrumentation.common.mdc.resource.attributes", "");
-    expected.setProperty("otel.instrumentation.common.peer.service.mapping", "");
-    expected.setProperty("otel.instrumentation.couchbase.experimental.span.attributes", "false");
-    expected.setProperty("otel.instrumentation.elasticsearch.capture.search.query", "false");
-    expected.setProperty(
-        "otel.instrumentation.elasticsearch.experimental.span.attributes", "false");
-    expected.setProperty("otel.instrumentation.experimental.span.suppression.strategy", "semconv");
-    expected.setProperty("otel.instrumentation.genai.capture.message.content", "false");
-    expected.setProperty(
-        "otel.instrumentation.graphql.add.operation.name.to.span.name.enabled", "false");
-    expected.setProperty("otel.instrumentation.graphql.capture.query", "true");
-    expected.setProperty("otel.instrumentation.graphql.data.fetcher.enabled", "false");
-    expected.setProperty("otel.instrumentation.graphql.query.sanitizer.enabled", "true");
-    expected.setProperty("otel.instrumentation.graphql.trivial.data.fetcher.enabled", "false");
-    expected.setProperty("otel.instrumentation.grpc.capture.metadata.client.request", "");
-    expected.setProperty("otel.instrumentation.grpc.capture.metadata.server.request", "");
-    expected.setProperty("otel.instrumentation.grpc.emit.message.events", "true");
-    expected.setProperty("otel.instrumentation.grpc.experimental.span.attributes", "false");
-    expected.setProperty("otel.instrumentation.guava.experimental.span.attributes", "false");
-    expected.setProperty("otel.instrumentation.hibernate.experimental.span.attributes", "false");
-    expected.setProperty("otel.instrumentation.http.client.capture.request.headers", "");
-    expected.setProperty("otel.instrumentation.http.client.capture.response.headers", "");
-    expected.setProperty("otel.instrumentation.http.client.emit.experimental.telemetry", "false");
-    expected.setProperty(
-        "otel.instrumentation.http.client.experimental.redact.query.parameters", "true");
-    expected.setProperty(
-        "otel.instrumentation.http.known.methods",
-        "CONNECT, DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT, TRACE");
-    expected.setProperty("otel.instrumentation.http.server.capture.request.headers", "");
-    expected.setProperty("otel.instrumentation.http.server.capture.response.headers", "");
-    expected.setProperty("otel.instrumentation.http.server.emit.experimental.telemetry", "false");
-    expected.setProperty("otel.instrumentation.hystrix.experimental.span.attributes", "false");
-    expected.setProperty(
-        "otel.instrumentation.java.util.logging.experimental.log.attributes", "false");
-    expected.setProperty("otel.instrumentation.jaxrs.experimental.span.attributes", "false");
-    expected.setProperty(
-        "otel.instrumentation.jboss.logmanager.experimental.capture.event.name", "false");
-    expected.setProperty(
-        "otel.instrumentation.jboss.logmanager.experimental.capture.mdc.attributes", "");
-    expected.setProperty(
-        "otel.instrumentation.jboss.logmanager.experimental.log.attributes", "false");
-    expected.setProperty(
-        "otel.instrumentation.jdbc.experimental.capture.query.parameters", "false");
-    expected.setProperty("otel.instrumentation.jdbc.experimental.sqlcommenter.enabled", "false");
-    expected.setProperty("otel.instrumentation.jdbc.experimental.transaction.enabled", "false");
-    expected.setProperty("otel.instrumentation.jdbc.statement.sanitizer.enabled", "true");
-    expected.setProperty("otel.instrumentation.jsp.experimental.span.attributes", "false");
-    expected.setProperty("otel.instrumentation.kafka.experimental.span.attributes", "false");
-    expected.setProperty("otel.instrumentation.kafka.producer.propagation.enabled", "true");
-    expected.setProperty(
-        "otel.instrumentation.kubernetes.client.experimental.span.attributes", "false");
-    expected.setProperty("otel.instrumentation.lettuce.experimental.span.attributes", "false");
-    expected.setProperty(
-        "otel.instrumentation.log4j.appender.experimental.capture.code.attributes", "false");
-    expected.setProperty(
-        "otel.instrumentation.log4j.appender.experimental.capture.event.name", "false");
-    expected.setProperty(
-        "otel.instrumentation.log4j.appender.experimental.capture.map.message.attributes", "false");
-    expected.setProperty(
-        "otel.instrumentation.log4j.appender.experimental.capture.marker.attribute", "false");
-    expected.setProperty(
-        "otel.instrumentation.log4j.appender.experimental.capture.mdc.attributes", "");
-    expected.setProperty(
-        "otel.instrumentation.log4j.appender.experimental.log.attributes", "false");
-    expected.setProperty("otel.instrumentation.log4j.context.data.add.baggage", "false");
-    expected.setProperty(
-        "otel.instrumentation.logback.appender.experimental.capture.arguments", "false");
-    expected.setProperty(
-        "otel.instrumentation.logback.appender.experimental.capture.code.attributes", "false");
-    expected.setProperty(
-        "otel.instrumentation.logback.appender.experimental.capture.event.name", "false");
-    expected.setProperty(
-        "otel.instrumentation.logback.appender.experimental.capture.key.value.pair.attributes",
-        "false");
-    expected.setProperty(
-        "otel.instrumentation.logback.appender.experimental.capture.logger.context.attributes",
-        "false");
-    expected.setProperty(
-        "otel.instrumentation.logback.appender.experimental.capture.logstash.marker.attributes",
-        "false");
-    expected.setProperty(
-        "otel.instrumentation.logback.appender.experimental.capture.logstash.structured.arguments",
-        "false");
-    expected.setProperty(
-        "otel.instrumentation.logback.appender.experimental.capture.marker.attribute", "false");
-    expected.setProperty(
-        "otel.instrumentation.logback.appender.experimental.capture.mdc.attributes", "");
-    expected.setProperty(
-        "otel.instrumentation.logback.appender.experimental.log.attributes", "false");
-    expected.setProperty("otel.instrumentation.logback.mdc.add.baggage", "false");
-    expected.setProperty(
-        "otel.instrumentation.messaging.experimental.receive.telemetry.enabled", "false");
-    expected.setProperty("otel.instrumentation.methods.include", "");
-    expected.setProperty("otel.instrumentation.micrometer.base.time.unit", "s");
-    expected.setProperty("otel.instrumentation.micrometer.histogram.gauges.enabled", "false");
-    expected.setProperty("otel.instrumentation.micrometer.prometheus.mode.enabled", "false");
-    expected.setProperty("otel.instrumentation.mongo.statement.sanitizer.enabled", "true");
-    expected.setProperty("otel.instrumentation.netty.connection.telemetry.enabled", "false");
-    expected.setProperty("otel.instrumentation.netty.ssl.telemetry.enabled", "false");
-    expected.setProperty("otel.instrumentation.opensearch.capture.search.query", "true");
-    expected.setProperty("otel.instrumentation.opensearch.experimental.span.attributes", "false");
-    expected.setProperty("otel.instrumentation.opentelemetry.annotations.exclude.methods", "");
-    expected.setProperty(
-        "otel.instrumentation.opentelemetry.instrumentation.annotations.exclude.methods", "");
-    expected.setProperty("otel.instrumentation.oshi.experimental.metrics.enabled", "false");
-    expected.setProperty("otel.instrumentation.powerjob.experimental.span.attributes", "false");
-    expected.setProperty("otel.instrumentation.pulsar.experimental.span.attributes", "false");
-    expected.setProperty("otel.instrumentation.quartz.experimental.span.attributes", "false");
-    expected.setProperty("otel.instrumentation.r2dbc.statement.sanitizer.enabled", "true");
-    expected.setProperty("otel.instrumentation.rabbitmq.experimental.span.attributes", "false");
-    expected.setProperty("otel.instrumentation.reactor.experimental.span.attributes", "false");
-    expected.setProperty(
-        "otel.instrumentation.reactor.netty.connection.telemetry.enabled", "false");
-    expected.setProperty(
-        "otel.instrumentation.rocketmq.client.experimental.span.attributes", "false");
-    expected.setProperty(
-        "otel.instrumentation.runtime.telemetry.emit.experimental.telemetry", "false");
-    expected.setProperty("otel.instrumentation.runtime.telemetry.java17.enabled", "false");
-    expected.setProperty("otel.instrumentation.runtime.telemetry.java17.enable.all", "false");
-    expected.setProperty("otel.instrumentation.runtime.telemetry.package.emitter.enabled", "false");
-    expected.setProperty(
-        "otel.instrumentation.runtime.telemetry.package.emitter.jars.per.second", "10");
-    expected.setProperty("otel.instrumentation.rxjava.experimental.span.attributes", "false");
-    expected.setProperty(
-        "otel.instrumentation.sanitization.url.experimental.sensitive.query.parameters",
-        "AWSAccessKeyId, Signature, sig, X-Goog-Signature");
-    expected.setProperty(
-        "otel.instrumentation.servlet.experimental.capture.request.parameters", "");
-    expected.setProperty("otel.instrumentation.servlet.experimental.span.attributes", "false");
-    expected.setProperty("otel.instrumentation.spring.batch.experimental.chunk.new.trace", "false");
-    expected.setProperty("otel.instrumentation.spring.batch.item.enabled", "false");
-    expected.setProperty(
-        "otel.instrumentation.spring.cloud.gateway.experimental.span.attributes", "false");
-    expected.setProperty(
-        "otel.instrumentation.spring.integration.global.channel.interceptor.patterns", "*");
-    expected.setProperty("otel.instrumentation.spring.integration.producer.enabled", "false");
-    expected.setProperty(
-        "otel.instrumentation.spring.scheduling.experimental.span.attributes", "false");
-    expected.setProperty(
-        "otel.instrumentation.spring.security.enduser.role.granted.authority.prefix", "ROLE_");
-    expected.setProperty(
-        "otel.instrumentation.spring.security.enduser.scope.granted.authority.prefix", "SCOPE_");
-    expected.setProperty(
-        "otel.instrumentation.spring.webflux.experimental.span.attributes", "false");
-    expected.setProperty(
-        "otel.instrumentation.spring.webmvc.experimental.span.attributes", "false");
-    expected.setProperty("otel.instrumentation.spymemcached.experimental.span.attributes", "false");
-    expected.setProperty("otel.instrumentation.twilio.experimental.span.attributes", "false");
-    expected.setProperty("otel.instrumentation.xxl.job.experimental.span.attributes", "false");
-    expected.setProperty("otel.javaagent.configuration.file", "");
-    expected.setProperty("otel.javaagent.debug", "false");
-    expected.setProperty("otel.javaagent.enabled", "true");
-    expected.setProperty("otel.javaagent.exclude.classes", "");
-    expected.setProperty("otel.javaagent.exclude.class.loaders", "");
-    expected.setProperty("otel.javaagent.experimental.security.manager.support.enabled", "false");
-    expected.setProperty("otel.javaagent.extensions", "");
-    expected.setProperty("otel.javaagent.logging", "simple");
-    expected.setProperty("otel.java.disabled.resource.providers", "");
-    expected.setProperty("otel.java.enabled.resource.providers", "");
-    expected.setProperty("otel.java.experimental.exporter.memory_mode", "immutable_data");
-    expected.setProperty("otel.java.exporter.otlp.retry.disabled", "true");
-    expected.setProperty("otel.java.metrics.cardinality.limit", "2000");
-    expected.setProperty("otel.logs.exporter", "otlp");
-    expected.setProperty("otel.metrics.exemplar.filter", "TRACE_BASED");
-    expected.setProperty("otel.metrics.exporter", "otlp");
-    expected.setProperty("otel.metric.export.interval", "60000");
-    expected.setProperty("otel.propagators", "tracecontext,baggage");
-    expected.setProperty("otel.resource.attributes", "");
-    expected.setProperty("otel.resource.providers.aws.enabled", "false");
-    expected.setProperty("otel.resource.providers.gcp.enabled", "false");
-    expected.setProperty("otel.sdk.disabled", "false");
-    expected.setProperty("otel.service.name", "");
-    expected.setProperty("otel.span.attribute.count.limit", "128");
-    expected.setProperty("otel.span.attribute.value.length.limit", "");
-    expected.setProperty("otel.span.event.count.limit", "128");
-    expected.setProperty("otel.span.link.count.limit", "128");
-    expected.setProperty("otel.traces.exporter", "otlp");
-    expected.setProperty("otel.traces.sampler", "always_on");
-    expected.setProperty("otel.traces.sampler.arg", "");
-    expected.setProperty(METRICS_FULL_COMMAND_LINE, "false");
-    expected.setProperty("splunk.otel.instrumentation.nocode.yml.file", "");
-    expected.setProperty("splunk.profiler.call.stack.interval", "10000ms");
-    expected.setProperty("splunk.profiler.directory", System.getProperty("java.io.tmpdir"));
-    expected.setProperty("splunk.profiler.enabled", "false");
-    expected.setProperty("splunk.profiler.include.agent.internals", "false");
-    expected.setProperty("splunk.profiler.include.internal.stacks", "false");
-    expected.setProperty("splunk.profiler.include.jvm.internals", "false");
-    expected.setProperty("splunk.profiler.keep.files", "false");
-    expected.setProperty("splunk.profiler.logs.endpoint", "http://localhost:4318/v1/logs");
-    expected.setProperty("splunk.profiler.max.stack.depth", "1024");
-    expected.setProperty("splunk.profiler.memory.enabled", "false");
-    expected.setProperty("splunk.profiler.memory.event.rate", "150/s");
-    expected.setProperty("splunk.profiler.memory.event.rate.limit.enabled", "true");
-    expected.setProperty("splunk.profiler.memory.native.sampling", "false");
-    expected.setProperty("splunk.profiler.otlp.protocol", "http/protobuf");
-    expected.setProperty("splunk.profiler.recording.duration", "20000ms");
-    expected.setProperty("splunk.profiler.tracing.stacks.only", "false");
-    expected.setProperty("splunk.realm", "none");
-    expected.setProperty("splunk.trace.response.header.enabled", "true");
-    expected.setProperty("splunk.snapshot.profiler.enabled", "false");
-    expected.setProperty("splunk.snapshot.selection.probability", "0.01");
-    expected.setProperty("splunk.snapshot.profiler.max.stack.depth", "1024");
-    expected.setProperty("splunk.snapshot.sampling.interval", "10ms");
-    expected.setProperty("splunk.snapshot.profiler.export.interval", "5000ms");
-    expected.setProperty("splunk.snapshot.profiler.staging.capacity", "2000");
-
-    assertProperties(fileContent, expected);
+    assertProperties(
+        fileContent,
+        Map.of(
+            "otel.exporter.otlp.traces.endpoint", "https://collector:4317",
+            "otel.exporter.otlp.metrics.endpoint", "https://collector:4317",
+            "otel.exporter.otlp.logs.endpoint", "https://collector:4317"));
   }
 
   private static String createFileContent(Map<String, String> configMap) {
@@ -668,23 +130,15 @@ class EnvVarsEffectiveConfigFileFactoryTest {
     return new EnvVarsEffectiveConfigFileFactory(config).buildFileContent();
   }
 
-  private static Properties loadProperties(String fileContent) throws IOException {
+  private static Properties loadProperties(Map<String, String> configMap) throws IOException {
     Properties properties = new Properties();
-    properties.load(new StringReader(fileContent));
+    properties.load(new StringReader(createFileContent(configMap)));
     return properties;
   }
 
-  private static Properties toProperties(Map<String, String> values) {
-    Properties properties = new Properties();
-    values.forEach(properties::setProperty);
-    return properties;
-  }
-
-  private static void assertProperties(Properties actual, Properties expected) {
-    assertThat(actual.size()).isEqualTo(expected.size());
-    for (String propertyName : expected.stringPropertyNames()) {
-      assertProperty(actual, propertyName, expected.getProperty(propertyName));
-    }
+  private static void assertProperties(Properties fileContent, Map<String, String> expectedValues) {
+    expectedValues.forEach(
+        (propertyName, expectedValue) -> assertProperty(fileContent, propertyName, expectedValue));
   }
 
   private static void assertProperty(


### PR DESCRIPTION
Previous implementation reported more env vars that it is needed.
Current set of desired env vars is described here: https://splunk.atlassian.net/browse/POR-21618

This PR is a cleanup of redundant env vars. Also a new one is added.