### PR TITLE
add csa jar to build artifacts

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -47,6 +47,8 @@ build_project() {
   ./gradlew assemble :metadata-generator:generateMetadata publishToSonatype closeAndReleaseSonatypeStagingRepository --no-daemon --stacktrace
   mv "agent/build/libs/splunk-otel-javaagent-${release_version}.jar" dist/splunk-otel-javaagent.jar
   mv "agent/build/libs/splunk-otel-javaagent-${release_version}.jar.asc" dist/splunk-otel-javaagent.jar.asc
+  mv "agent-csa-bundle/build/libs/splunk-otel-javaagent-csa-${release_version}.jar" dist/splunk-otel-javaagent-csa.jar
+  mv "agent-csa-bundle/build/libs/splunk-otel-javaagent-csa-${release_version}.jar.asc" dist/splunk-otel-javaagent-csa.jar.asc
   mv "metadata-generator/build/splunk-otel-java-metadata.yaml" dist/splunk-otel-java-metadata.yaml
 
   echo ">>> Building the cloudfoundry buildpack ..."


### PR DESCRIPTION
We are being asked to also publish docker images for the csa jar. Some of these docker builds source the agent jar from the build artifacts just after the release is complete. To be more consistent with the way the vanilla splunk-otel-javaagent process works, let's add the csa jar to the build artifacts.

This comes with the downside, of course, of being more confusing to users who download from the releases page.