### PR TITLE
Create and publish CSA javaagent images.

### DIFF
--- a/.github/workflows/publish-docker-image-ghcr.yml
+++ b/.github/workflows/publish-docker-image-ghcr.yml
@@ -54,3 +54,16 @@ jobs:
             ghcr.io/signalfx/splunk-otel-java/splunk-otel-java:${{ env.MAJOR_VERSION }}
             ghcr.io/signalfx/splunk-otel-java/splunk-otel-java:${{ env.RELEASE_VERSION }}
 
+      - name: build and publish CSA container
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          push: true
+          file: Dockerfile-ghcr
+          platforms: linux/amd64,linux/arm64,linux/ppc64le
+          build-args: |
+            RELEASE_VER=${{ env.RELEASE_VERSION }}
+            JAR_FILE=splunk-otel-javaagent-csa.jar
+          tags: |
+            ghcr.io/signalfx/splunk-otel-java/splunk-otel-java-csa:latest
+            ghcr.io/signalfx/splunk-otel-java/splunk-otel-java-csa:${{ env.MAJOR_VERSION }}
+            ghcr.io/signalfx/splunk-otel-java/splunk-otel-java-csa:${{ env.RELEASE_VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
-FROM busybox 
+FROM busybox
 
-ADD dist/splunk-otel-javaagent.jar /
+ARG JAR_FILE=splunk-otel-javaagent.jar
+
+ADD dist/${JAR_FILE} /

--- a/Dockerfile-ghcr
+++ b/Dockerfile-ghcr
@@ -1,6 +1,6 @@
 # To build an auto-instrumentation image for Java, please:
-#  - Grant the necessary access to the jar. `chmod 644  /splunk-otel-javaagent.jar`
-#  - Symlink '/splunk-otel-javaagent.jar' to `/javaagent.jar` to support compatability with the
+#  - Grant the necessary access to the jar.
+#  - Symlink the jar to `/javaagent.jar` to support compatability with the
 #    https://github.com/open-telemetry/opentelemetry-operator project.
 #  - For this docker image to be used for auto-instrumentation by container injection, we use the
 #    busybox image because it contains the Linux command cp which must be available.
@@ -10,8 +10,9 @@ LABEL org.opencontainers.image.source="https://github.com/signalfx/splunk-otel-j
 LABEL org.opencontainers.image.description="Splunk Distribution of OpenTelemetry Java Instrumentation"
 
 ARG RELEASE_VER
+ARG JAR_FILE=splunk-otel-javaagent.jar
 ENV RELEASE_VER=$RELEASE_VER
 
-ADD https://github.com/signalfx/splunk-otel-java/releases/download/${RELEASE_VER}/splunk-otel-javaagent.jar /
-RUN chmod 644 /splunk-otel-javaagent.jar
-RUN ln -s /splunk-otel-javaagent.jar /javaagent.jar
+ADD https://github.com/signalfx/splunk-otel-java/releases/download/${RELEASE_VER}/${JAR_FILE} /
+RUN chmod 644 "/${JAR_FILE}"
+RUN ln -s "/${JAR_FILE}" /javaagent.jar

--- a/scripts/publish-docker-image.sh
+++ b/scripts/publish-docker-image.sh
@@ -28,11 +28,14 @@ fi
 release_tag="$1"
 
 build_docker_image() {
-  echo ">>> Building the operator docker image ..."
-  docker build -t splunk-otel-instrumentation-java .
-  docker tag splunk-otel-instrumentation-java quay.io/signalfx/splunk-otel-instrumentation-java:latest
-  docker tag splunk-otel-instrumentation-java "quay.io/signalfx/splunk-otel-instrumentation-java:v$(get_major_version "$release_tag")"
-  docker tag splunk-otel-instrumentation-java "quay.io/signalfx/splunk-otel-instrumentation-java:$release_tag"
+  local image_name="$1"
+  local jar_file="$2"
+
+  echo ">>> Building operator docker image ${image_name} ..."
+  docker build --build-arg "JAR_FILE=${jar_file}" -t "${image_name}" .
+  docker tag "${image_name}" "quay.io/signalfx/${image_name}:latest"
+  docker tag "${image_name}" "quay.io/signalfx/${image_name}:v$(get_major_version "$release_tag")"
+  docker tag "${image_name}" "quay.io/signalfx/${image_name}:$release_tag"
 }
 
 login_to_quay_io() {
@@ -41,18 +44,27 @@ login_to_quay_io() {
 }
 
 publish_docker_image() {
-  echo ">>> Publishing the operator docker image ..."
-  docker push quay.io/signalfx/splunk-otel-instrumentation-java:latest
-  docker push "quay.io/signalfx/splunk-otel-instrumentation-java:v$(get_major_version "$release_tag")"
-  docker push "quay.io/signalfx/splunk-otel-instrumentation-java:$release_tag"
+  local image_name="$1"
+
+  echo ">>> Publishing the operator docker image ${image_name} ..."
+  docker push "quay.io/signalfx/${image_name}:latest"
+  docker push "quay.io/signalfx/${image_name}:v$(get_major_version "$release_tag")"
+  docker push "quay.io/signalfx/${image_name}:$release_tag"
 }
 
 sign_published_docker_image() {
-  echo ">>> Signing the published operator docker image ..."
-  artifact-ci sign docker "quay.io/signalfx/splunk-otel-instrumentation-java:$release_tag"
+  local image_name="$1"
+
+  echo ">>> Signing the published operator docker image ${image_name} ..."
+  artifact-ci sign docker "quay.io/signalfx/${image_name}:$release_tag"
 }
 
-build_docker_image
 login_to_quay_io
-publish_docker_image
-sign_published_docker_image
+
+build_docker_image splunk-otel-instrumentation-java splunk-otel-javaagent.jar
+publish_docker_image splunk-otel-instrumentation-java
+sign_published_docker_image splunk-otel-instrumentation-java
+
+build_docker_image splunk-otel-instrumentation-java-csa splunk-otel-javaagent-csa.jar
+publish_docker_image splunk-otel-instrumentation-java-csa
+sign_published_docker_image splunk-otel-instrumentation-java-csa

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -47,6 +47,8 @@ build_project() {
   ./gradlew assemble :metadata-generator:generateMetadata publishToSonatype closeAndReleaseSonatypeStagingRepository --no-daemon --stacktrace
   mv "agent/build/libs/splunk-otel-javaagent-${release_version}.jar" dist/splunk-otel-javaagent.jar
   mv "agent/build/libs/splunk-otel-javaagent-${release_version}.jar.asc" dist/splunk-otel-javaagent.jar.asc
+  mv "agent-csa-bundle/build/libs/splunk-otel-javaagent-csa-${release_version}.jar" dist/splunk-otel-javaagent-csa.jar
+  mv "agent-csa-bundle/build/libs/splunk-otel-javaagent-csa-${release_version}.jar.asc" dist/splunk-otel-javaagent-csa.jar.asc
   mv "metadata-generator/build/splunk-otel-java-metadata.yaml" dist/splunk-otel-java-metadata.yaml
 
   echo ">>> Building the cloudfoundry buildpack ..."


### PR DESCRIPTION
* Publishes to quay.io from gitlab during release time.
* Publishes to ghcr from the `publish-docker-image-ghcr.yml` workflow, triggered on release published.

This depends on #2804 to ensure that the csa artifact is part of the release assets in the release page.