### PR TITLE
On windows start docker service if it is not running

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,6 +139,14 @@ jobs:
       - name: Free disk space
         run: .github/scripts/gha-free-disk-space.sh
 
+      - name: Docker issue workaround
+        if: startsWith(matrix.os, 'windows')
+        run: |
+          $dockerState = Get-Service -Name "docker"
+          if ($dockerState.Status -ne "Running") {
+            Start-Service -Name "docker"
+          }
+
       - name: Set up JDK 17 for running Gradle
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -133,6 +133,14 @@ jobs:
       - name: Free disk space
         run: .github/scripts/gha-free-disk-space.sh
 
+      - name: Docker issue workaround
+        if: startsWith(matrix.os, 'windows')
+        run: |
+          $dockerState = Get-Service -Name "docker"
+          if ($dockerState.Status -ne "Running") {
+            Start-Service -Name "docker"
+          }
+
       - name: Set up JDK 17 for running Gradle
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -143,6 +143,14 @@ jobs:
       - name: Free disk space
         run: .github/scripts/gha-free-disk-space.sh
 
+      - name: Docker issue workaround
+        if: startsWith(matrix.os, 'windows')
+        run: |
+          $dockerState = Get-Service -Name "docker"
+          if ($dockerState.Status -ne "Running") {
+            Start-Service -Name "docker"
+          }
+
       - name: Set up JDK 17 for running Gradle
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:


### PR DESCRIPTION
Suggested in https://github.com/actions/runner-images/issues/13729#issuecomment-4183956802 Hopefully will reduce the windows smoke test flakiness.