### PR TITLE
Prepare for 2.28.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ## Unreleased
 
+- OpenTelemetry Java SDK has been updated to version 1.62.0.
+- OpenTelemetry Instrumentation for Java has been updated to version 2.28.0.
+- Changes to experimental OpAMP identity fields [#2788](https://github.com/signalfx/splunk-otel-java/pull/2788)
+- Updates to experimental OpAMP effective config 
+  [#2796](https://github.com/signalfx/splunk-otel-java/pull/2796),
+  [#2799](https://github.com/signalfx/splunk-otel-java/pull/2799),
+  [#2799](https://github.com/signalfx/splunk-otel-java/pull/2806)
+- We now include CSA jars as build artifacts, and publish docker images that include CSA.
+  [#2804](https://github.com/signalfx/splunk-otel-java/pull/2804), 
+  [#2805](https://github.com/signalfx/splunk-otel-java/pull/2805)
+- Nocode instrumentation: Add ability to continue the current span instead of 
+  starting a new span. [#2726](https://github.com/signalfx/splunk-otel-java/pull/2726) 
+
+For the full set of changes from the upstream OpenTelemetry Java Instrumentation,
+including any breaking changes, please visit the release notes for
+[opentelemetry-java-instrumentation 2.28.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.28.0).
+
 ## v2.27.0 - 2026-04-22
 
 - OpenTelemetry Java SDK has been updated to version 1.61.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,22 +8,15 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ## Unreleased
 
+## v2.28.0 - 2026-05-22
+
 - OpenTelemetry Java SDK has been updated to version 1.62.0.
-- OpenTelemetry Instrumentation for Java has been updated to version 2.28.0.
-- Changes to experimental OpAMP identity fields [#2788](https://github.com/signalfx/splunk-otel-java/pull/2788)
-- Updates to experimental OpAMP effective config 
-  [#2796](https://github.com/signalfx/splunk-otel-java/pull/2796),
-  [#2799](https://github.com/signalfx/splunk-otel-java/pull/2799),
-  [#2799](https://github.com/signalfx/splunk-otel-java/pull/2806)
+- OpenTelemetry Instrumentation for Java has been updated to version 2.28.1.
 - We now include CSA jars as build artifacts, and publish docker images that include CSA.
   [#2804](https://github.com/signalfx/splunk-otel-java/pull/2804), 
   [#2805](https://github.com/signalfx/splunk-otel-java/pull/2805)
 - Nocode instrumentation: Add ability to continue the current span instead of 
   starting a new span. [#2726](https://github.com/signalfx/splunk-otel-java/pull/2726) 
-
-For the full set of changes from the upstream OpenTelemetry Java Instrumentation,
-including any breaking changes, please visit the release notes for
-[opentelemetry-java-instrumentation 2.28.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.28.0).
 
 ## v2.27.0 - 2026-04-22
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Splunk Distribution of OpenTelemetry Java
 
 ![Stable](https://img.shields.io/badge/status-stable-informational)
-[![OpenTelemetry Instrumentation for Java Version](https://img.shields.io/badge/otel-2.27.0-blueviolet)](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.27.0)
+[![OpenTelemetry Instrumentation for Java Version](https://img.shields.io/badge/otel-2.28.1-blueviolet)](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.28.1)
 [![Splunk GDI specification](https://img.shields.io/badge/GDI-1.9.0-blueviolet)](https://github.com/signalfx/gdi-specification/releases/tag/v1.9.0)
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/signalfx/splunk-otel-java?include_prereleases)](https://github.com/signalfx/splunk-otel-java/releases)
 [![Maven Central](https://img.shields.io/maven-central/v/com.splunk/splunk-otel-javaagent)](https://central.sonatype.com/artifact/com.splunk/splunk-otel-javaagent)
@@ -43,11 +43,6 @@ see [Migrate from the SignalFx Java Agent](https://help.splunk.com/en/splunk-obs
 
 <!-- Comments, spacing, empty and new lines in the section below are intentional, please do not modify them! -->
 <!--DEV_DOCS_WARNING-->
-<!--DEV_DOCS_WARNING_START-->
-The following documentation refers to the in-development version of `splunk-otel-java`. Docs for the latest version ([v2.27.0](https://github.com/signalfx/splunk-otel-java/releases/latest)) can be found [here](https://github.com/signalfx/splunk-otel-java/blob/v2.27.0/README.md).
-
----
-<!--DEV_DOCS_WARNING_END-->
 
 ## Requirements
 
@@ -79,11 +74,11 @@ To extend the instrumentation with the OpenTelemetry Instrumentation for Java,
 you have to use a compatible API version.
 
 <!-- IMPORTANT: do not change comments or break those lines below -->
-The Splunk Distribution of OpenTelemetry Java version <!--SPLUNK_VERSION-->2.27.0<!--SPLUNK_VERSION--> is compatible
+The Splunk Distribution of OpenTelemetry Java version <!--SPLUNK_VERSION-->2.28.0<!--SPLUNK_VERSION--> is compatible
 with:
 
-* OpenTelemetry API version <!--OTEL_VERSION-->1.61.0<!--OTEL_VERSION-->
-* OpenTelemetry Instrumentation for Java version <!--OTEL_INSTRUMENTATION_VERSION-->2.27.0<!--OTEL_INSTRUMENTATION_VERSION-->
+* OpenTelemetry API version <!--OTEL_VERSION-->1.62.0<!--OTEL_VERSION-->
+* OpenTelemetry Instrumentation for Java version <!--OTEL_INSTRUMENTATION_VERSION-->2.28.1<!--OTEL_INSTRUMENTATION_VERSION-->
 
 ## Snapshot builds
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
   implementation(gradleApi())
 
   implementation("com.diffplug.spotless:spotless-plugin-gradle:8.5.1")
-  implementation("io.opentelemetry.instrumentation:gradle-plugins:2.28.1-alpha")
+  implementation("io.opentelemetry.instrumentation:gradle-plugins:2.27.0-alpha")
 
   // keep these versions in sync with settings.gradle.kts
   implementation("com.gradleup.shadow:shadow-gradle-plugin:9.4.1")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
   implementation(gradleApi())
 
   implementation("com.diffplug.spotless:spotless-plugin-gradle:8.5.1")
-  implementation("io.opentelemetry.instrumentation:gradle-plugins:2.27.0-alpha")
+  implementation("io.opentelemetry.instrumentation:gradle-plugins:2.28.1-alpha")
 
   // keep these versions in sync with settings.gradle.kts
   implementation("com.gradleup.shadow:shadow-gradle-plugin:9.4.1")

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -4,9 +4,9 @@ plugins {
 
 val otelVersion = "1.62.0"
 val otelAlphaVersion = otelVersion.replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
-val otelInstrumentationVersion = "2.28.0"
+val otelInstrumentationVersion = "2.28.1"
 val otelInstrumentationAlphaVersion =  otelInstrumentationVersion.replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
-val otelContribAlphaVersion = "1.55.0-alpha"
+val otelContribAlphaVersion = "1.57.0-alpha"
 
 val autoValueVersion = "1.11.1"
 val dockerJavaVersion = "3.7.1"

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 val otelVersion = "1.62.0"
 val otelAlphaVersion = otelVersion.replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
-val otelInstrumentationVersion = "2.28.0-SNAPSHOT"
+val otelInstrumentationVersion = "2.28.0"
 val otelInstrumentationAlphaVersion =  otelInstrumentationVersion.replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
 val otelContribAlphaVersion = "1.55.0-alpha"
 

--- a/deployments/cloudfoundry/buildpack/README.md
+++ b/deployments/cloudfoundry/buildpack/README.md
@@ -40,7 +40,7 @@ If you want to use a specific version of the Java agent in your application, you
 environment variable before application deployment, either using `cf set-env` or the `manifest.yml` file:
 
 ```sh
-$ cf set-env SPLUNK_OTEL_JAVA_VERSION 2.27.0
+$ cf set-env SPLUNK_OTEL_JAVA_VERSION 2.28.0
 ```
 
 By default, the [latest](https://github.com/signalfx/splunk-otel-java/releases/latest) available agent version is used.

--- a/licenses/licenses.md
+++ b/licenses/licenses.md
@@ -1,7 +1,7 @@
 
 # splunk-otel-javaagent
 ## Dependency License Report
-_2026-05-20 08:03:08 EEST_
+_2026-05-20 15:39:03 PDT_
 ## Apache License, Version 2.0
 
 **1** **Group:** `com.squareup.okhttp3` **Name:** `okhttp` **Version:** `5.3.2` 
@@ -92,7 +92,7 @@ _2026-05-20 08:03:08 EEST_
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java-contrib](https://github.com/open-telemetry/opentelemetry-java-contrib)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**23** **Group:** `io.opentelemetry.instrumentation` **Name:** `opentelemetry-instrumentation-bom-alpha` **Version:** `2.28.0-alpha-SNAPSHOT` 
+**23** **Group:** `io.opentelemetry.instrumentation` **Name:** `opentelemetry-instrumentation-bom-alpha` **Version:** `2.28.0-alpha` 
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java-instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 

--- a/licenses/licenses.md
+++ b/licenses/licenses.md
@@ -1,7 +1,7 @@
 
 # splunk-otel-javaagent
 ## Dependency License Report
-_2026-05-20 15:39:03 PDT_
+_2026-05-21 10:06:10 EEST_
 ## Apache License, Version 2.0
 
 **1** **Group:** `com.squareup.okhttp3` **Name:** `okhttp` **Version:** `5.3.2` 
@@ -20,11 +20,11 @@ _2026-05-20 15:39:03 PDT_
 > - **POM Project URL**: [https://github.com/square/okio/](https://github.com/square/okio/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**5** **Group:** `com.squareup.wire` **Name:** `wire-runtime` **Version:** `6.2.0` 
+**5** **Group:** `com.squareup.wire` **Name:** `wire-runtime` **Version:** `6.4.0` 
 > - **POM Project URL**: [https://github.com/square/wire/](https://github.com/square/wire/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**6** **Group:** `com.squareup.wire` **Name:** `wire-runtime-jvm` **Version:** `6.2.0` 
+**6** **Group:** `com.squareup.wire` **Name:** `wire-runtime-jvm` **Version:** `6.4.0` 
 > - **POM Project URL**: [https://github.com/square/wire/](https://github.com/square/wire/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
@@ -80,19 +80,19 @@ _2026-05-20 15:39:03 PDT_
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**20** **Group:** `io.opentelemetry.contrib` **Name:** `opentelemetry-opamp-client` **Version:** `1.55.0-alpha` 
+**20** **Group:** `io.opentelemetry.contrib` **Name:** `opentelemetry-opamp-client` **Version:** `1.57.0-alpha` 
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java-contrib](https://github.com/open-telemetry/opentelemetry-java-contrib)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**21** **Group:** `io.opentelemetry.contrib` **Name:** `opentelemetry-resource-providers` **Version:** `1.55.0-alpha` 
+**21** **Group:** `io.opentelemetry.contrib` **Name:** `opentelemetry-resource-providers` **Version:** `1.57.0-alpha` 
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java-contrib](https://github.com/open-telemetry/opentelemetry-java-contrib)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**22** **Group:** `io.opentelemetry.contrib` **Name:** `opentelemetry-samplers` **Version:** `1.55.0-alpha` 
+**22** **Group:** `io.opentelemetry.contrib` **Name:** `opentelemetry-samplers` **Version:** `1.57.0-alpha` 
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java-contrib](https://github.com/open-telemetry/opentelemetry-java-contrib)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**23** **Group:** `io.opentelemetry.instrumentation` **Name:** `opentelemetry-instrumentation-bom-alpha` **Version:** `2.28.0-alpha` 
+**23** **Group:** `io.opentelemetry.instrumentation` **Name:** `opentelemetry-instrumentation-bom-alpha` **Version:** `2.28.1-alpha` 
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java-instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,5 +1,5 @@
 // do NOT update that variable manually - it is managed by the pre/post release scripts
-val distroVersion = "2.28.0-SNAPSHOT"
+val distroVersion = "2.28.0"
 
 allprojects {
   version = distroVersion


### PR DESCRIPTION
I don't normally like to lump the non-snapshot changeover into this, but I think it's fine this time.

I also acknowledge that the statement about and link to the upstream release notes is not typically part of our convention, but I think this might be a good thing to do, given that pull request 373 in gdi-specification (intentionally not linking to it 🤣 ) exists...