### PR TITLE
[OpAMP] Agent now returns value of telemetry.distro.version in identifying attrs

### DIFF
--- a/opamp/build.gradle.kts
+++ b/opamp/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api")
+  compileOnly("io.opentelemetry.semconv:opentelemetry-semconv")
 
   annotationProcessor("com.google.auto.service:auto-service")
   compileOnly("com.google.auto.service:auto-service")

--- a/opamp/src/main/java/com/splunk/opentelemetry/opamp/OpampAgentAttributes.java
+++ b/opamp/src/main/java/com/splunk/opentelemetry/opamp/OpampAgentAttributes.java
@@ -27,16 +27,13 @@ import io.opentelemetry.api.common.AttributeType;
 import io.opentelemetry.opamp.client.OpampClientBuilder;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
 class OpampAgentAttributes {
-  private static final List<AttributeKey<?>> IDENTIFYING_ATTRIBUTES =
-      Arrays.asList(SERVICE_NAME, SERVICE_NAMESPACE, SERVICE_INSTANCE_ID);
   private static final List<AttributeKey<?>> SKIPPED_NONIDENTIFYING_ATTRIBUTES =
-      Collections.singletonList(TELEMETRY_DISTRO_VERSION);
+      Arrays.asList(SERVICE_NAME, SERVICE_NAMESPACE, SERVICE_INSTANCE_ID, TELEMETRY_DISTRO_VERSION);
 
   private final Resource resource;
 
@@ -45,59 +42,58 @@ class OpampAgentAttributes {
   }
 
   void addIdentifyingAttributes(OpampClientBuilder builder) {
-    IDENTIFYING_ATTRIBUTES.forEach(
-        (key) -> {
-          putIdentifyingAttribute(builder, key);
-        });
-
+    putIdentifyingAttribute(builder, SERVICE_NAME);
+    putIdentifyingAttribute(builder, SERVICE_NAMESPACE);
+    putIdentifyingAttribute(builder, SERVICE_INSTANCE_ID);
     // An agent version must be reported as a service version in identifying attributes
-    String distroVersion = resource.getAttribute(TELEMETRY_DISTRO_VERSION);
-    if (distroVersion != null) {
-      builder.putIdentifyingAttribute(SERVICE_VERSION.getKey(), distroVersion);
-    }
+    putIdentifyingAttribute(builder, TELEMETRY_DISTRO_VERSION, SERVICE_VERSION.getKey());
   }
 
   void addNonIdentifyingAttributes(OpampClientBuilder builder) {
     resource.getAttributes().asMap().entrySet().stream()
-        .filter(entry -> !IDENTIFYING_ATTRIBUTES.contains(entry.getKey()))
         .filter(entry -> !SKIPPED_NONIDENTIFYING_ATTRIBUTES.contains(entry.getKey()))
         .forEach(putNonIdentifyingAttribute(builder));
   }
 
-  private void putIdentifyingAttribute(OpampClientBuilder builder, AttributeKey<?> key) {
-    Object value = resource.getAttribute(key);
+  private void putIdentifyingAttribute(OpampClientBuilder builder, AttributeKey<?> attributeKey) {
+    putIdentifyingAttribute(builder, attributeKey, attributeKey.getKey());
+  }
+
+  private void putIdentifyingAttribute(
+      OpampClientBuilder builder, AttributeKey<?> sourceAttributeKey, String targetAttributeName) {
+    Object value = resource.getAttribute(sourceAttributeKey);
     if (value == null) {
       return;
     }
-    AttributeType type = key.getType();
+    AttributeType type = sourceAttributeKey.getType();
 
     switch (type) {
       case VALUE:
-        builder.putIdentifyingAttribute(key.getKey(), value.toString());
+        builder.putIdentifyingAttribute(targetAttributeName, value.toString());
         break;
       case STRING:
-        builder.putIdentifyingAttribute(key.getKey(), (String) value);
+        builder.putIdentifyingAttribute(targetAttributeName, (String) value);
         break;
       case LONG:
-        builder.putIdentifyingAttribute(key.getKey(), (long) value);
+        builder.putIdentifyingAttribute(targetAttributeName, (long) value);
         break;
       case DOUBLE:
-        builder.putIdentifyingAttribute(key.getKey(), (double) value);
+        builder.putIdentifyingAttribute(targetAttributeName, (double) value);
         break;
       case BOOLEAN:
-        builder.putIdentifyingAttribute(key.getKey(), (boolean) value);
+        builder.putIdentifyingAttribute(targetAttributeName, (boolean) value);
         break;
       case STRING_ARRAY:
-        builder.putIdentifyingAttribute(key.getKey(), toStringArray((List<?>) value));
+        builder.putIdentifyingAttribute(targetAttributeName, toStringArray((List<?>) value));
         break;
       case LONG_ARRAY:
-        builder.putIdentifyingAttribute(key.getKey(), toLongArray((List<?>) value));
+        builder.putIdentifyingAttribute(targetAttributeName, toLongArray((List<?>) value));
         break;
       case DOUBLE_ARRAY:
-        builder.putIdentifyingAttribute(key.getKey(), toDoubleArray((List<?>) value));
+        builder.putIdentifyingAttribute(targetAttributeName, toDoubleArray((List<?>) value));
         break;
       case BOOLEAN_ARRAY:
-        builder.putIdentifyingAttribute(key.getKey(), toBooleanArray((List<?>) value));
+        builder.putIdentifyingAttribute(targetAttributeName, toBooleanArray((List<?>) value));
         break;
     }
   }

--- a/opamp/src/main/java/com/splunk/opentelemetry/opamp/OpampAgentAttributes.java
+++ b/opamp/src/main/java/com/splunk/opentelemetry/opamp/OpampAgentAttributes.java
@@ -60,40 +60,40 @@ class OpampAgentAttributes {
   }
 
   private void putIdentifyingAttribute(
-      OpampClientBuilder builder, AttributeKey<?> sourceAttributeKey, String targetAttributeName) {
-    Object value = resource.getAttribute(sourceAttributeKey);
+      OpampClientBuilder builder, AttributeKey<?> resourceAttributeKey, String agentAttributeName) {
+    Object value = resource.getAttribute(resourceAttributeKey);
     if (value == null) {
       return;
     }
-    AttributeType type = sourceAttributeKey.getType();
+    AttributeType type = resourceAttributeKey.getType();
 
     switch (type) {
       case VALUE:
-        builder.putIdentifyingAttribute(targetAttributeName, value.toString());
+        builder.putIdentifyingAttribute(agentAttributeName, value.toString());
         break;
       case STRING:
-        builder.putIdentifyingAttribute(targetAttributeName, (String) value);
+        builder.putIdentifyingAttribute(agentAttributeName, (String) value);
         break;
       case LONG:
-        builder.putIdentifyingAttribute(targetAttributeName, (long) value);
+        builder.putIdentifyingAttribute(agentAttributeName, (long) value);
         break;
       case DOUBLE:
-        builder.putIdentifyingAttribute(targetAttributeName, (double) value);
+        builder.putIdentifyingAttribute(agentAttributeName, (double) value);
         break;
       case BOOLEAN:
-        builder.putIdentifyingAttribute(targetAttributeName, (boolean) value);
+        builder.putIdentifyingAttribute(agentAttributeName, (boolean) value);
         break;
       case STRING_ARRAY:
-        builder.putIdentifyingAttribute(targetAttributeName, toStringArray((List<?>) value));
+        builder.putIdentifyingAttribute(agentAttributeName, toStringArray((List<?>) value));
         break;
       case LONG_ARRAY:
-        builder.putIdentifyingAttribute(targetAttributeName, toLongArray((List<?>) value));
+        builder.putIdentifyingAttribute(agentAttributeName, toLongArray((List<?>) value));
         break;
       case DOUBLE_ARRAY:
-        builder.putIdentifyingAttribute(targetAttributeName, toDoubleArray((List<?>) value));
+        builder.putIdentifyingAttribute(agentAttributeName, toDoubleArray((List<?>) value));
         break;
       case BOOLEAN_ARRAY:
-        builder.putIdentifyingAttribute(targetAttributeName, toBooleanArray((List<?>) value));
+        builder.putIdentifyingAttribute(agentAttributeName, toBooleanArray((List<?>) value));
         break;
     }
   }

--- a/opamp/src/main/java/com/splunk/opentelemetry/opamp/OpampAgentAttributes.java
+++ b/opamp/src/main/java/com/splunk/opentelemetry/opamp/OpampAgentAttributes.java
@@ -16,18 +16,27 @@
 
 package com.splunk.opentelemetry.opamp;
 
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_INSTANCE_ID;
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAMESPACE;
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_VERSION;
+import static io.opentelemetry.semconv.TelemetryAttributes.TELEMETRY_DISTRO_VERSION;
+
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributeType;
 import io.opentelemetry.opamp.client.OpampClientBuilder;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
 class OpampAgentAttributes {
-  private static final List<String> IDENTIFYING_ATTRIBUTES =
-      Arrays.asList("service.name", "service.namespace", "service.instance.id");
+  private static final List<AttributeKey<?>> IDENTIFYING_ATTRIBUTES =
+      Arrays.asList(SERVICE_NAME, SERVICE_NAMESPACE, SERVICE_INSTANCE_ID);
+  private static final List<AttributeKey<?>> SKIPPED_NONIDENTIFYING_ATTRIBUTES =
+      Collections.singletonList(TELEMETRY_DISTRO_VERSION);
 
   private final Resource resource;
 
@@ -36,57 +45,61 @@ class OpampAgentAttributes {
   }
 
   void addIdentifyingAttributes(OpampClientBuilder builder) {
-    resource.getAttributes().asMap().entrySet().stream()
-        .filter(entry -> IDENTIFYING_ATTRIBUTES.contains(entry.getKey().getKey()))
-        .forEach(putIdentifyingAttribute(builder));
+    IDENTIFYING_ATTRIBUTES.forEach(
+        (key) -> {
+          putIdentifyingAttribute(builder, key);
+        });
+
+    // An agent version must be reported as a service version in identifying attributes
+    String distroVersion = resource.getAttribute(TELEMETRY_DISTRO_VERSION);
+    if (distroVersion != null) {
+      builder.putIdentifyingAttribute(SERVICE_VERSION.getKey(), distroVersion);
+    }
   }
 
   void addNonIdentifyingAttributes(OpampClientBuilder builder) {
     resource.getAttributes().asMap().entrySet().stream()
-        .filter(entry -> !IDENTIFYING_ATTRIBUTES.contains(entry.getKey().getKey()))
+        .filter(entry -> !IDENTIFYING_ATTRIBUTES.contains(entry.getKey()))
+        .filter(entry -> !SKIPPED_NONIDENTIFYING_ATTRIBUTES.contains(entry.getKey()))
         .forEach(putNonIdentifyingAttribute(builder));
   }
 
-  private Consumer<? super Map.Entry<AttributeKey<?>, Object>> putIdentifyingAttribute(
-      OpampClientBuilder builder) {
-    return entry -> {
-      AttributeKey<?> key = entry.getKey();
-      Object value = entry.getValue();
-      if (value == null) {
-        return;
-      }
-      AttributeType type = key.getType();
+  private void putIdentifyingAttribute(OpampClientBuilder builder, AttributeKey<?> key) {
+    Object value = resource.getAttribute(key);
+    if (value == null) {
+      return;
+    }
+    AttributeType type = key.getType();
 
-      switch (type) {
-        case VALUE:
-          builder.putIdentifyingAttribute(key.getKey(), value.toString());
-          break;
-        case STRING:
-          builder.putIdentifyingAttribute(key.getKey(), (String) value);
-          break;
-        case LONG:
-          builder.putIdentifyingAttribute(key.getKey(), (long) value);
-          break;
-        case DOUBLE:
-          builder.putIdentifyingAttribute(key.getKey(), (double) value);
-          break;
-        case BOOLEAN:
-          builder.putIdentifyingAttribute(key.getKey(), (boolean) value);
-          break;
-        case STRING_ARRAY:
-          builder.putIdentifyingAttribute(key.getKey(), toStringArray((List<?>) value));
-          break;
-        case LONG_ARRAY:
-          builder.putIdentifyingAttribute(key.getKey(), toLongArray((List<?>) value));
-          break;
-        case DOUBLE_ARRAY:
-          builder.putIdentifyingAttribute(key.getKey(), toDoubleArray((List<?>) value));
-          break;
-        case BOOLEAN_ARRAY:
-          builder.putIdentifyingAttribute(key.getKey(), toBooleanArray((List<?>) value));
-          break;
-      }
-    };
+    switch (type) {
+      case VALUE:
+        builder.putIdentifyingAttribute(key.getKey(), value.toString());
+        break;
+      case STRING:
+        builder.putIdentifyingAttribute(key.getKey(), (String) value);
+        break;
+      case LONG:
+        builder.putIdentifyingAttribute(key.getKey(), (long) value);
+        break;
+      case DOUBLE:
+        builder.putIdentifyingAttribute(key.getKey(), (double) value);
+        break;
+      case BOOLEAN:
+        builder.putIdentifyingAttribute(key.getKey(), (boolean) value);
+        break;
+      case STRING_ARRAY:
+        builder.putIdentifyingAttribute(key.getKey(), toStringArray((List<?>) value));
+        break;
+      case LONG_ARRAY:
+        builder.putIdentifyingAttribute(key.getKey(), toLongArray((List<?>) value));
+        break;
+      case DOUBLE_ARRAY:
+        builder.putIdentifyingAttribute(key.getKey(), toDoubleArray((List<?>) value));
+        break;
+      case BOOLEAN_ARRAY:
+        builder.putIdentifyingAttribute(key.getKey(), toBooleanArray((List<?>) value));
+        break;
+    }
   }
 
   private Consumer<? super Map.Entry<AttributeKey<?>, Object>> putNonIdentifyingAttribute(

--- a/opamp/src/test/java/com/splunk/opentelemetry/opamp/OpampAgentAttributesTest.java
+++ b/opamp/src/test/java/com/splunk/opentelemetry/opamp/OpampAgentAttributesTest.java
@@ -24,6 +24,7 @@ import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_INSTANCE_ID;
 import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
 import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAMESPACE;
 import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_VERSION;
+import static io.opentelemetry.semconv.TelemetryAttributes.TELEMETRY_DISTRO_VERSION;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -46,6 +47,8 @@ class OpampAgentAttributesTest {
               "test-namespace",
               SERVICE_INSTANCE_ID,
               "test-instance",
+              TELEMETRY_DISTRO_VERSION,
+              "1.2.3",
               SERVICE_VERSION,
               "test-version")
           .toBuilder()
@@ -73,6 +76,7 @@ class OpampAgentAttributesTest {
 
     verify(builder).putIdentifyingAttribute(SERVICE_NAME.getKey(), "test-service");
     verify(builder).putIdentifyingAttribute(SERVICE_NAMESPACE.getKey(), "test-namespace");
+    verify(builder).putIdentifyingAttribute(SERVICE_VERSION.getKey(), "1.2.3");
     verify(builder).putIdentifyingAttribute(SERVICE_INSTANCE_ID.getKey(), "test-instance");
     verifyNoMoreInteractions(builder);
   }
@@ -84,8 +88,9 @@ class OpampAgentAttributesTest {
     OpampAgentAttributes testClass = new OpampAgentAttributes(resource);
 
     testClass.addNonIdentifyingAttributes(builder);
+    // Make sure original service name is reported in nonidentifying attributes
+    verify(builder).putNonIdentifyingAttribute("service.version", "test-version");
 
-    verify(builder).putNonIdentifyingAttribute(SERVICE_VERSION.getKey(), "test-version");
     verify(builder).putNonIdentifyingAttribute("long", 12L);
     verify(builder).putNonIdentifyingAttribute("double", 99.0);
     verify(builder).putNonIdentifyingAttribute("bool", true);


### PR DESCRIPTION
According to the documentation https://splunk.atlassian.net/wiki/spaces/PROD/pages/1079695409595/Server+-+Client+communication+RFC#5.2.1.-Required-Attribute-Set, agent's identifying attributes should contain service.version attribute with value copied from `telemetry.distro.version`