### PR TITLE
[OpAMP] New opamp declarative config structure

### DIFF
--- a/opamp/src/main/java/com/splunk/opentelemetry/opamp/OpampClientConfigurationFactory.java
+++ b/opamp/src/main/java/com/splunk/opentelemetry/opamp/OpampClientConfigurationFactory.java
@@ -16,14 +16,11 @@
 
 package com.splunk.opentelemetry.opamp;
 
-import static io.opentelemetry.api.incubator.config.DeclarativeConfigProperties.empty;
 import static io.opentelemetry.opamp.client.internal.request.service.HttpRequestService.DEFAULT_DELAY_BETWEEN_REQUESTS;
 
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
-import io.opentelemetry.common.ComponentLoader;
 import io.opentelemetry.sdk.autoconfigure.AutoConfigureUtil;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
-import io.opentelemetry.sdk.autoconfigure.declarativeconfig.YamlDeclarativeConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.declarativeconfig.internal.model.OpenTelemetryConfigurationModel;
 import java.util.Objects;
@@ -39,27 +36,20 @@ public class OpampClientConfigurationFactory {
   }
 
   private static OpampClientConfiguration createConfigurationFromDeclarativeConfig() {
-    OpenTelemetryConfigurationModel configurationModel =
+    OpenTelemetryConfigurationModel config =
         Objects.requireNonNull(DeclarativeConfigurationInterceptor.getConfigurationModel());
 
-    OpampClientConfiguration.Builder builder = OpampClientConfiguration.builder();
-    DeclarativeConfigProperties properties =
-        YamlDeclarativeConfigProperties.create(
-            configurationModel.getAdditionalProperties(),
-            ComponentLoader.forClassLoader(DeclarativeConfigProperties.class.getClassLoader()));
+    DeclarativeConfigProperties opampProperties =
+        AutoConfigureUtil.getDistributionConfig(config).getStructured("opamp/development");
 
-    DeclarativeConfigProperties opampProperties = properties.getStructured("opamp/development");
+    OpampClientConfiguration.Builder builder = OpampClientConfiguration.builder();
     if (opampProperties != null) {
       builder.withEnabled(true);
-      DeclarativeConfigProperties connection = opampProperties.getStructured("transport", empty());
-      DeclarativeConfigProperties http = connection.getStructured("http");
-      if (http != null) {
-        builder
-            .withEndpoint(http.getString("endpoint"))
-            .withPollingInterval(
-                http.getLong(
-                    "polling_interval", DEFAULT_DELAY_BETWEEN_REQUESTS.getNextDelay().toMillis()));
-      }
+      builder
+          .withEndpoint(opampProperties.getString("endpoint"))
+          .withPollingInterval(
+              opampProperties.getLong(
+                  "polling_interval", DEFAULT_DELAY_BETWEEN_REQUESTS.getNextDelay().toMillis()));
     }
 
     return builder.build();

--- a/opamp/src/test/java/com/splunk/opentelemetry/opamp/OpampClientConfigurationFactoryTest.java
+++ b/opamp/src/test/java/com/splunk/opentelemetry/opamp/OpampClientConfigurationFactoryTest.java
@@ -64,10 +64,10 @@ class OpampClientConfigurationFactoryTest {
     String yaml =
         """
             file_format: "1.0"
-            opamp/development:
-              transport:
-                http:
-                  endpoint: https://opamp.example.com
+            distribution:
+              splunk:
+                opamp/development:
+                  endpoint: http://some.opamp-host.com:3420/v1/opamp
                   polling_interval: 4567
             """;
     AutoConfiguredOpenTelemetrySdk sdk =
@@ -79,7 +79,7 @@ class OpampClientConfigurationFactoryTest {
 
     // then
     assertThat(configuration.isEnabled()).isTrue();
-    assertThat(configuration.getEndpoint()).isEqualTo("https://opamp.example.com");
+    assertThat(configuration.getEndpoint()).isEqualTo("http://some.opamp-host.com:3420/v1/opamp");
     assertThat(configuration.getPollingInterval()).isEqualTo(4567);
   }
 


### PR DESCRIPTION
Use OpAMP client declarative config structure defined in [GDI spec](https://github.com/signalfx/gdi-specification/blob/main/specification/configuration.md#opamp-declarative-yaml)

There is no support for `features.remote_config` in this PR