### PR TITLE
Add ability for the opamp client to use the x-sf-token header

### DIFF
--- a/opamp/build.gradle.kts
+++ b/opamp/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api")
   compileOnly("org.snakeyaml:snakeyaml-engine")
+  compileOnly("com.squareup.okhttp3:okhttp")
 
   annotationProcessor("com.google.auto.service:auto-service")
   compileOnly("com.google.auto.service:auto-service")

--- a/opamp/src/main/java/com/splunk/opentelemetry/opamp/OpampActivator.java
+++ b/opamp/src/main/java/com/splunk/opentelemetry/opamp/OpampActivator.java
@@ -38,8 +38,12 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.logging.Logger;
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
 import opamp.proto.ComponentHealth;
 import opamp.proto.ServerErrorResponse;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @AutoService(AgentListener.class)
@@ -125,10 +129,10 @@ public class OpampActivator implements AgentListener {
     if (endpoint != null) {
       PeriodicDelay pollingDelay =
           PeriodicDelay.ofFixedDuration(Duration.ofMillis(pollingDurationMillis));
-      OkHttpSender okhttp = OkHttpSender.create(endpoint);
-      HttpRequestService httpSender =
+      OkHttpSender okhttp = buildOkHttpSender(opampClientConfiguration);
+      HttpRequestService httpRequestService =
           HttpRequestService.create(okhttp, pollingDelay, DEFAULT_DELAY_BETWEEN_RETRIES);
-      builder.setRequestService(httpSender);
+      builder.setRequestService(httpRequestService);
     }
 
     OpampAgentAttributes agentAttributes = new OpampAgentAttributes(resource);
@@ -139,6 +143,22 @@ public class OpampActivator implements AgentListener {
     builder.enableHealthReporting(createInitialHealthReport());
 
     return builder.build(callbacks);
+  }
+
+  @NotNull
+  private static OkHttpSender buildOkHttpSender(OpampClientConfiguration config) {
+    String token = config.getAccessToken();
+    if (token == null) {
+      return OkHttpSender.create(config.getEndpoint());
+    }
+    Interceptor tokenFlinger =
+        chain -> {
+          Request.Builder requestBuilder = chain.request().newBuilder();
+          requestBuilder.addHeader("X-SF-TOKEN", token);
+          return chain.proceed(requestBuilder.build());
+        };
+    OkHttpClient okhttpClient = new OkHttpClient.Builder().addInterceptor(tokenFlinger).build();
+    return OkHttpSender.create(config.getEndpoint(), okhttpClient);
   }
 
   private static ComponentHealth createInitialHealthReport() {

--- a/opamp/src/main/java/com/splunk/opentelemetry/opamp/OpampClientConfiguration.java
+++ b/opamp/src/main/java/com/splunk/opentelemetry/opamp/OpampClientConfiguration.java
@@ -19,6 +19,7 @@ package com.splunk.opentelemetry.opamp;
 public class OpampClientConfiguration {
   private boolean enabled;
   private String endpoint;
+  private String accessToken = null;
   private long pollingInterval;
 
   private OpampClientConfiguration() {}
@@ -39,6 +40,10 @@ public class OpampClientConfiguration {
     return pollingInterval;
   }
 
+  public String getAccessToken() {
+    return accessToken;
+  }
+
   @Override
   public String toString() {
     return "OpampClientConfiguration{"
@@ -47,6 +52,9 @@ public class OpampClientConfiguration {
         + '\''
         + ", endpoint='"
         + endpoint
+        + '\''
+        + ", accessToken='"
+        + (accessToken == null ? "<null>" : "***redacted***")
         + '\''
         + ", pollingInterval="
         + pollingInterval
@@ -70,6 +78,11 @@ public class OpampClientConfiguration {
 
     public Builder withPollingInterval(long pollingInterval) {
       configuredInstance.pollingInterval = pollingInterval;
+      return this;
+    }
+
+    public Builder withAccessToken(String accessToken) {
+      configuredInstance.accessToken = accessToken;
       return this;
     }
 

--- a/opamp/src/main/java/com/splunk/opentelemetry/opamp/OpampClientConfiguration.java
+++ b/opamp/src/main/java/com/splunk/opentelemetry/opamp/OpampClientConfiguration.java
@@ -19,7 +19,7 @@ package com.splunk.opentelemetry.opamp;
 public class OpampClientConfiguration {
   private boolean enabled;
   private String endpoint;
-  private String accessToken = null;
+  private String accessToken;
   private long pollingInterval;
 
   private OpampClientConfiguration() {}

--- a/opamp/src/main/java/com/splunk/opentelemetry/opamp/OpampClientConfigurationFactory.java
+++ b/opamp/src/main/java/com/splunk/opentelemetry/opamp/OpampClientConfigurationFactory.java
@@ -16,6 +16,7 @@
 
 package com.splunk.opentelemetry.opamp;
 
+import static com.splunk.opentelemetry.SplunkConfigurationCustomizer.SPLUNK_ACCESS_TOKEN;
 import static io.opentelemetry.opamp.client.internal.request.service.HttpRequestService.DEFAULT_DELAY_BETWEEN_REQUESTS;
 
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
@@ -47,6 +48,7 @@ public class OpampClientConfigurationFactory {
       builder.withEnabled(true);
       builder
           .withEndpoint(opampProperties.getString("endpoint"))
+          .withAccessToken(opampProperties.getString("access_token"))
           .withPollingInterval(
               opampProperties.getLong(
                   "polling_interval", DEFAULT_DELAY_BETWEEN_REQUESTS.getNextDelay().toMillis()));
@@ -59,6 +61,7 @@ public class OpampClientConfigurationFactory {
     return OpampClientConfiguration.builder()
         .withEnabled(config.getBoolean("splunk.opamp.enabled", false))
         .withEndpoint(config.getString("splunk.opamp.endpoint"))
+        .withAccessToken(config.getString(SPLUNK_ACCESS_TOKEN))
         .withPollingInterval(
             config.getLong(
                 "splunk.opamp.polling.interval",

--- a/opamp/src/test/java/com/splunk/opentelemetry/opamp/OpampActivatorTest.java
+++ b/opamp/src/test/java/com/splunk/opentelemetry/opamp/OpampActivatorTest.java
@@ -138,6 +138,7 @@ class OpampActivatorTest {
         OpampClientConfiguration.builder()
             .withEnabled(true)
             .withEndpoint(server.httpUri().toString())
+            .withAccessToken("test-access-token")
             .withPollingInterval(500)
             .build();
     OpampClient client =
@@ -177,6 +178,8 @@ class OpampActivatorTest {
     assertThat(remoteConfig.config.config_map.get("test-key").body.utf8()).isEqualTo("test-value");
 
     RecordedRequest recordedRequest = server.takeRequest();
+    assertThat(recordedRequest.request().headers().get("X-SF-TOKEN"))
+        .isEqualTo("test-access-token");
     byte[] body = recordedRequest.request().content().array();
     AgentToServer agentToServer = AgentToServer.ADAPTER.decode(body);
 

--- a/opamp/src/test/java/com/splunk/opentelemetry/opamp/OpampClientConfigurationFactoryTest.java
+++ b/opamp/src/test/java/com/splunk/opentelemetry/opamp/OpampClientConfigurationFactoryTest.java
@@ -46,6 +46,7 @@ class OpampClientConfigurationFactoryTest {
             Map.of(
                 "splunk.opamp.enabled", "true",
                 "splunk.opamp.endpoint", "https://opamp.example.com",
+                "splunk.access.token", "env-token",
                 "splunk.opamp.polling.interval", "3210"));
 
     // when
@@ -55,6 +56,7 @@ class OpampClientConfigurationFactoryTest {
     // then
     assertThat(configuration.isEnabled()).isTrue();
     assertThat(configuration.getEndpoint()).isEqualTo("https://opamp.example.com");
+    assertThat(configuration.getAccessToken()).isEqualTo("env-token");
     assertThat(configuration.getPollingInterval()).isEqualTo(3210);
   }
 
@@ -68,6 +70,7 @@ class OpampClientConfigurationFactoryTest {
               splunk:
                 opamp/development:
                   endpoint: http://some.opamp-host.com:3420/v1/opamp
+                  access_token: declarative-token
                   polling_interval: 4567
             """;
     AutoConfiguredOpenTelemetrySdk sdk =
@@ -80,6 +83,7 @@ class OpampClientConfigurationFactoryTest {
     // then
     assertThat(configuration.isEnabled()).isTrue();
     assertThat(configuration.getEndpoint()).isEqualTo("http://some.opamp-host.com:3420/v1/opamp");
+    assertThat(configuration.getAccessToken()).isEqualTo("declarative-token");
     assertThat(configuration.getPollingInterval()).isEqualTo(4567);
   }
 
@@ -95,6 +99,7 @@ class OpampClientConfigurationFactoryTest {
     // then
     assertThat(configuration.isEnabled()).isFalse();
     assertThat(configuration.getEndpoint()).isNull();
+    assertThat(configuration.getAccessToken()).isNull();
     assertThat(configuration.getPollingInterval())
         .isEqualTo(DEFAULT_DELAY_BETWEEN_REQUESTS.getNextDelay().toMillis());
   }

--- a/opamp/src/test/java/com/splunk/opentelemetry/opamp/OpampClientConfigurationTest.java
+++ b/opamp/src/test/java/com/splunk/opentelemetry/opamp/OpampClientConfigurationTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.opamp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class OpampClientConfigurationTest {
+
+  @Test
+  void shouldConfigureAccessToken() {
+    OpampClientConfiguration configuration =
+        OpampClientConfiguration.builder().withAccessToken("secret-token").build();
+
+    assertThat(configuration.getAccessToken()).isEqualTo("secret-token");
+    assertThat(configuration.toString())
+        .contains("accessToken='***redacted***'")
+        .doesNotContain("secret-token");
+  }
+
+  @Test
+  void shouldDefaultAccessTokenToNull() {
+    OpampClientConfiguration configuration = OpampClientConfiguration.builder().build();
+
+    assertThat(configuration.getAccessToken()).isNull();
+    assertThat(configuration.toString()).contains("accessToken='<null>'");
+  }
+}


### PR DESCRIPTION
If the opamp client is to be used without a collector, then it will need the ability to set the token header.