### PR TITLE
Fix metadata generator crash

### DIFF
--- a/metadata-generator/src/main/java/com/splunk/opentelemetry/tools/MetadataGenerator.java
+++ b/metadata-generator/src/main/java/com/splunk/opentelemetry/tools/MetadataGenerator.java
@@ -1394,9 +1394,13 @@ public class MetadataGenerator {
             (List<Map<String, Object>>) info.get("configurations");
         if (configurations != null) {
           for (Map<String, Object> configuration : configurations) {
+            Object propertyName = configuration.get("name");
+            if (propertyName == null) {
+              continue;
+            }
             builder.addSetting(
                 setting(
-                    configuration.get("name").toString(),
+                    propertyName.toString(),
                     configuration.get("description").toString(),
                     configuration.get("default").toString(),
                     toSettingType(configuration.get("type").toString()),


### PR DESCRIPTION
Upstream PR https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19150 added some metadata for configuration items that only exist in declarative config. We expect each config item to have a `name` field so that we can populate it in the docs table or whatever...but now that's inconsistent/broken.

I first tried falling back to the declarative name when name is missing, but that will end up fabricating false env vars in the docs, which I thought was bad.

So this seems like a minimally stupid way of preventing the metadata gen from crashing, at least until we can figure out how we think we want to generate docs for declarative config.