### PR TITLE
Support the new upstream metadata format

### DIFF
--- a/metadata-generator/build.gradle.kts
+++ b/metadata-generator/build.gradle.kts
@@ -1,4 +1,5 @@
 dependencies {
+  compileOnly("com.google.auto.service:auto-service")
   implementation("org.yaml:snakeyaml:2.6")
 }
 

--- a/metadata-generator/src/main/java/com/splunk/opentelemetry/tools/MetadataGenerator.java
+++ b/metadata-generator/src/main/java/com/splunk/opentelemetry/tools/MetadataGenerator.java
@@ -1349,27 +1349,45 @@ public class MetadataGenerator {
     return parseInstrumentations(new URL(url));
   }
 
-  private static List<Map<String, Object>> parseInstrumentations(URL url) throws IOException {
+  static List<Map<String, Object>> parseInstrumentations(URL url) throws IOException {
     Yaml yaml = new Yaml();
     Map<String, Object> metadata;
     try (InputStream inputStream = url.openStream()) {
       metadata = yaml.load(inputStream);
     }
 
-    if (!"0.5".equals(metadata.get("file_format").toString())) {
+    if (!"0.6".equals(metadata.get("file_format").toString())) {
       throw new IllegalStateException(
           "unexpected file format version: " + metadata.get("file_format"));
     }
+
+    Map<String, Object> definitions = (Map<String, Object>) metadata.get("definitions");
+    Map<String, Map<String, Object>> configurationDefinitions =
+        (Map<String, Map<String, Object>>) definitions.get("configurations");
+    Map<String, Map<String, Object>> metricDefinitions =
+        (Map<String, Map<String, Object>>) definitions.get("metrics");
+
     List<Map<String, Object>> result = new ArrayList<>();
 
-    handle(result, (List<Map<String, Object>>) metadata.get("libraries"));
-    handle(result, (List<Map<String, Object>>) metadata.get("custom"));
+    handle(
+        result,
+        (List<Map<String, Object>>) metadata.get("libraries"),
+        configurationDefinitions,
+        metricDefinitions);
+    handle(
+        result,
+        (List<Map<String, Object>>) metadata.get("custom"),
+        configurationDefinitions,
+        metricDefinitions);
 
     return result;
   }
 
   private static void handle(
-      List<Map<String, Object>> instrumentations, List<Map<String, Object>> infos) {
+      List<Map<String, Object>> instrumentations,
+      List<Map<String, Object>> infos,
+      Map<String, Map<String, Object>> configurationDefinitions,
+      Map<String, Map<String, Object>> metricDefinitions) {
     for (Map<String, Object> info : infos) {
       // only javaagent instrumentations
       if (Boolean.TRUE.equals(info.get("has_javaagent"))) {
@@ -1391,21 +1409,20 @@ public class MetadataGenerator {
         }
 
         List<Map<String, Object>> configurations =
-            (List<Map<String, Object>>) info.get("configurations");
-        if (configurations != null) {
-          for (Map<String, Object> configuration : configurations) {
-            Object propertyName = configuration.get("name");
-            if (propertyName == null) {
-              continue;
-            }
-            builder.addSetting(
-                setting(
-                    propertyName.toString(),
-                    configuration.get("description").toString(),
-                    configuration.get("default").toString(),
-                    toSettingType(configuration.get("type").toString()),
-                    MetadataGenerator.SettingCategory.INSTRUMENTATION));
+            resolveDefinitions(
+                info, "configurations", "configuration_refs", configurationDefinitions);
+        for (Map<String, Object> configuration : configurations) {
+          Object propertyName = configuration.get("name");
+          if (propertyName == null) {
+            continue;
           }
+          builder.addSetting(
+              setting(
+                  propertyName.toString(),
+                  configuration.get("description").toString(),
+                  configuration.get("default").toString(),
+                  toSettingType(configuration.get("type").toString()),
+                  MetadataGenerator.SettingCategory.INSTRUMENTATION));
         }
 
         List<Map<String, Object>> telemetry = (List<Map<String, Object>>) info.get("telemetry");
@@ -1419,7 +1436,8 @@ public class MetadataGenerator {
             String configuration = telemetryConfiguration.get("when").toString();
             boolean isDefault = "default".equals(configuration);
             List<Map<String, Object>> metrics =
-                (List<Map<String, Object>>) telemetryConfiguration.get("metrics");
+                resolveDefinitions(
+                    telemetryConfiguration, "metrics", "metric_refs", metricDefinitions);
 
             if (isDefault) {
               defaultSeen = true;
@@ -1473,6 +1491,32 @@ public class MetadataGenerator {
         instrumentations.add(builder.build());
       }
     }
+  }
+
+  private static List<Map<String, Object>> resolveDefinitions(
+      Map<String, Object> source,
+      String inlineKey,
+      String referenceKey,
+      Map<String, Map<String, Object>> definitions) {
+    List<Map<String, Object>> result = new ArrayList<>();
+
+    List<Map<String, Object>> inlineValues = (List<Map<String, Object>>) source.get(inlineKey);
+    if (inlineValues != null) {
+      result.addAll(inlineValues);
+    }
+
+    List<String> references = (List<String>) source.get(referenceKey);
+    if (references != null) {
+      for (String reference : references) {
+        Map<String, Object> definition = definitions.get(reference);
+        if (definition == null) {
+          throw new IllegalStateException("missing " + inlineKey + " definition: " + reference);
+        }
+        result.add(definition);
+      }
+    }
+
+    return result;
   }
 
   private static Map<String, Object> dependency(

--- a/metadata-generator/src/main/java/com/splunk/opentelemetry/tools/MetadataGenerator.java
+++ b/metadata-generator/src/main/java/com/splunk/opentelemetry/tools/MetadataGenerator.java
@@ -16,6 +16,7 @@
 
 package com.splunk.opentelemetry.tools;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -1349,6 +1350,7 @@ public class MetadataGenerator {
     return parseInstrumentations(new URL(url));
   }
 
+  @VisibleForTesting
   static List<Map<String, Object>> parseInstrumentations(URL url) throws IOException {
     Yaml yaml = new Yaml();
     Map<String, Object> metadata;
@@ -1362,23 +1364,10 @@ public class MetadataGenerator {
     }
 
     Map<String, Object> definitions = (Map<String, Object>) metadata.get("definitions");
-    Map<String, Map<String, Object>> configurationDefinitions =
-        (Map<String, Map<String, Object>>) definitions.get("configurations");
-    Map<String, Map<String, Object>> metricDefinitions =
-        (Map<String, Map<String, Object>>) definitions.get("metrics");
-
     List<Map<String, Object>> result = new ArrayList<>();
 
-    handle(
-        result,
-        (List<Map<String, Object>>) metadata.get("libraries"),
-        configurationDefinitions,
-        metricDefinitions);
-    handle(
-        result,
-        (List<Map<String, Object>>) metadata.get("custom"),
-        configurationDefinitions,
-        metricDefinitions);
+    handle(result, (List<Map<String, Object>>) metadata.get("libraries"), definitions);
+    handle(result, (List<Map<String, Object>>) metadata.get("custom"), definitions);
 
     return result;
   }
@@ -1386,8 +1375,12 @@ public class MetadataGenerator {
   private static void handle(
       List<Map<String, Object>> instrumentations,
       List<Map<String, Object>> infos,
-      Map<String, Map<String, Object>> configurationDefinitions,
-      Map<String, Map<String, Object>> metricDefinitions) {
+      Map<String, Object> definitions) {
+    Map<String, Map<String, Object>> configurationDefinitions =
+        (Map<String, Map<String, Object>>) definitions.get("configurations");
+    Map<String, Map<String, Object>> metricDefinitions =
+        (Map<String, Map<String, Object>>) definitions.get("metrics");
+
     for (Map<String, Object> info : infos) {
       // only javaagent instrumentations
       if (Boolean.TRUE.equals(info.get("has_javaagent"))) {

--- a/metadata-generator/src/main/java/com/splunk/opentelemetry/tools/MetadataGenerator.java
+++ b/metadata-generator/src/main/java/com/splunk/opentelemetry/tools/MetadataGenerator.java
@@ -1506,14 +1506,15 @@ public class MetadataGenerator {
     }
 
     List<String> references = (List<String>) source.get(referenceKey);
-    if (references != null) {
-      for (String reference : references) {
-        Map<String, Object> definition = definitions.get(reference);
-        if (definition == null) {
-          throw new IllegalStateException("missing " + inlineKey + " definition: " + reference);
-        }
-        result.add(definition);
+    if (references == null) {
+      return result;
+    }
+    for (String reference : references) {
+      Map<String, Object> definition = definitions.get(reference);
+      if (definition == null) {
+        throw new IllegalStateException("missing " + inlineKey + " definition: " + reference);
       }
+      result.add(definition);
     }
 
     return result;

--- a/metadata-generator/src/test/java/com/splunk/opentelemetry/tools/MetadataGeneratorTest.java
+++ b/metadata-generator/src/test/java/com/splunk/opentelemetry/tools/MetadataGeneratorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MetadataGeneratorTest {
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void supportsReferencedDefinitionsInFileFormat06() throws IOException {
+    List<Map<String, Object>> instrumentations =
+        parseInstrumentations("instrumentation-list-0.6.yaml");
+
+    assertThat(instrumentations)
+        .singleElement()
+        .satisfies(
+            instrumentation -> {
+              List<Map<String, Object>> settings =
+                  (List<Map<String, Object>>) instrumentation.get("settings");
+              assertThat(settings)
+                  .extracting(setting -> setting.get("property"))
+                  .containsExactly("otel.instrumentation.test.enabled");
+
+              List<Map<String, Object>> signals =
+                  (List<Map<String, Object>>) instrumentation.get("signals");
+              List<Map<String, Object>> metrics =
+                  (List<Map<String, Object>>) signals.get(0).get("metrics");
+              assertThat(metrics)
+                  .extracting(metric -> metric.get("metric_name"))
+                  .containsExactly("test.requests");
+            });
+  }
+
+  private static List<Map<String, Object>> parseInstrumentations(String resourceName)
+      throws IOException {
+    URL resource = MetadataGeneratorTest.class.getResource("/" + resourceName);
+    assertThat(resource).isNotNull();
+    return MetadataGenerator.parseInstrumentations(resource);
+  }
+}

--- a/metadata-generator/src/test/resources/instrumentation-list-0.6.yaml
+++ b/metadata-generator/src/test/resources/instrumentation-list-0.6.yaml
@@ -1,0 +1,29 @@
+file_format: 0.6
+
+definitions:
+  configurations:
+    test.enabled:
+      name: otel.instrumentation.test.enabled
+      description: Enables test instrumentation.
+      type: boolean
+      default: true
+  metrics:
+    test.requests-abcd1234:
+      name: test.requests
+      description: Number of test requests.
+      instrument: counter
+
+libraries:
+- name: test-library
+  display_name: Test Library
+  description: Test instrumentation.
+  has_javaagent: true
+  javaagent_target_versions: 1.0+
+  configuration_refs:
+  - test.enabled
+  telemetry:
+  - when: default
+    metric_refs:
+    - test.requests-abcd1234
+
+custom: []


### PR DESCRIPTION
This gets us past the failing metadata generator. I haven't been following upstream closely enough to know if this is a great approach, I just let codex take the reins mostly. Seems to be doing ok. 