### PR TITLE
Export thread lock and monitor info as profiling labels

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/ProfilingSemanticAttributes.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/ProfilingSemanticAttributes.java
@@ -49,6 +49,9 @@ public class ProfilingSemanticAttributes {
   public static final AttributeKey<String> THREAD_STATE = stringKey("thread.state");
   public static final AttributeKey<Boolean> THREAD_STACK_TRUNCATED =
       booleanKey("thread.stack.truncated");
+  public static final String LOCK_WAITING_ON = "lock.waiting_on";
+  public static final String LOCK_OWNER_THREAD = "lock.owner_thread";
+  public static final String LOCK_HELD_PREFIX = "lock.held.";
 
   public static final AttributeKey<String> TRACE_ID = stringKey("trace_id");
   public static final AttributeKey<String> SPAN_ID = stringKey("span_id");

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/CpuEventExporter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/CpuEventExporter.java
@@ -17,12 +17,16 @@
 package com.splunk.opentelemetry.profiler.exporter;
 
 import com.splunk.opentelemetry.profiler.context.StackToSpanLinkage;
+import java.lang.management.ThreadInfo;
 import java.time.Duration;
 import java.time.Instant;
 
 public interface CpuEventExporter {
 
   void export(StackToSpanLinkage stackToSpanLinkage);
+
+  default void export(
+      ThreadInfo threadInfo, Instant eventTime, String traceId, String spanId, Duration duration) {}
 
   default void export(
       long threadId,

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/PprofCpuEventExporter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/PprofCpuEventExporter.java
@@ -16,6 +16,9 @@
 
 package com.splunk.opentelemetry.profiler.exporter;
 
+import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.LOCK_HELD_PREFIX;
+import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.LOCK_OWNER_THREAD;
+import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.LOCK_WAITING_ON;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SOURCE_EVENT_NAME;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SOURCE_EVENT_PERIOD;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SOURCE_EVENT_TIME;
@@ -36,6 +39,9 @@ import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.TraceId;
+import java.lang.management.LockInfo;
+import java.lang.management.MonitorInfo;
+import java.lang.management.ThreadInfo;
 import java.time.Duration;
 import java.time.Instant;
 
@@ -96,6 +102,16 @@ public class PprofCpuEventExporter implements CpuEventExporter {
 
   @Override
   public void export(
+      ThreadInfo threadInfo, Instant eventTime, String traceId, String spanId, Duration duration) {
+    Sample.Builder sample = Sample.newBuilder();
+    addThreadInfo(
+        sample, threadInfo.getThreadId(), threadInfo.getThreadName(), threadInfo.getThreadState());
+    addLockInfo(sample, threadInfo);
+    addSample(sample, threadInfo.getStackTrace(), eventTime, traceId, spanId, duration);
+  }
+
+  @Override
+  public void export(
       long threadId,
       String threadName,
       Thread.State threadState,
@@ -105,11 +121,24 @@ public class PprofCpuEventExporter implements CpuEventExporter {
       String spanId,
       Duration duration) {
     Sample.Builder sample = Sample.newBuilder();
+    addThreadInfo(sample, threadId, threadName, threadState);
+    addSample(sample, stackTrace, eventTime, traceId, spanId, duration);
+  }
 
+  private void addThreadInfo(
+      Sample.Builder sample, long threadId, String threadName, Thread.State threadState) {
     pprof.addLabel(sample, THREAD_ID, threadId);
     pprof.addLabel(sample, THREAD_NAME, threadName);
     pprof.addLabel(sample, THREAD_STATE, threadState.name());
+  }
 
+  private void addSample(
+      Sample.Builder sample,
+      StackTraceElement[] stackTrace,
+      Instant eventTime,
+      String traceId,
+      String spanId,
+      Duration duration) {
     if (stackTrace.length > stackDepth) {
       pprof.addLabel(sample, THREAD_STACK_TRUNCATED, true);
     }
@@ -139,6 +168,26 @@ public class PprofCpuEventExporter implements CpuEventExporter {
     }
 
     pprof.getProfileBuilder().addSample(sample);
+  }
+
+  private void addLockInfo(Sample.Builder sample, ThreadInfo threadInfo) {
+    LockInfo waitingOn = threadInfo.getLockInfo();
+    if (waitingOn != null) {
+      pprof.addLabel(sample, LOCK_WAITING_ON, formatLock(waitingOn));
+    }
+    pprof.addLabel(sample, LOCK_OWNER_THREAD, threadInfo.getLockOwnerName());
+
+    int heldLockIndex = 0;
+    for (MonitorInfo monitor : threadInfo.getLockedMonitors()) {
+      pprof.addLabel(sample, LOCK_HELD_PREFIX + heldLockIndex++, formatLock(monitor));
+    }
+    for (LockInfo synchronizer : threadInfo.getLockedSynchronizers()) {
+      pprof.addLabel(sample, LOCK_HELD_PREFIX + heldLockIndex++, formatLock(synchronizer));
+    }
+  }
+
+  private static String formatLock(LockInfo lockInfo) {
+    return lockInfo.getClassName() + '@' + Integer.toHexString(lockInfo.getIdentityHashCode());
   }
 
   private static Pprof createPprof() {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/AsyncStackTraceExporter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/AsyncStackTraceExporter.java
@@ -76,10 +76,7 @@ class AsyncStackTraceExporter implements StackTraceExporter {
 
         for (StackTrace stackTrace : stackTraces) {
           cpuEventExporter.export(
-              stackTrace.getThreadId(),
-              stackTrace.getThreadName(),
-              stackTrace.getThreadState(),
-              stackTrace.getStackFrames(),
+              stackTrace.getThreadInfo(),
               stackTrace.getTimestamp(),
               stackTrace.getTraceId(),
               stackTrace.getSpanId(),

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/StackTrace.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/StackTrace.java
@@ -29,24 +29,12 @@ class StackTrace {
       String traceId,
       String spanId,
       long recordingThreadId) {
-    return new StackTrace(
-        timestamp,
-        duration,
-        thread.getThreadId(),
-        thread.getThreadName(),
-        thread.getThreadState(),
-        thread.getStackTrace(),
-        traceId,
-        spanId,
-        recordingThreadId);
+    return new StackTrace(timestamp, duration, thread, traceId, spanId, recordingThreadId);
   }
 
   private final Instant timestamp;
   private final Duration duration;
-  private final long threadId;
-  private final String threadName;
-  private final Thread.State threadState;
-  private final StackTraceElement[] stackFrames;
+  private final ThreadInfo threadInfo;
   private final String traceId;
   private final String spanId;
   private final long recordingThreadId;
@@ -55,19 +43,13 @@ class StackTrace {
   StackTrace(
       Instant timestamp,
       Duration duration,
-      long threadId,
-      String threadName,
-      Thread.State threadState,
-      StackTraceElement[] stackFrames,
+      ThreadInfo threadInfo,
       String traceId,
       String spanId,
       long recordingThreadId) {
     this.timestamp = timestamp;
     this.duration = duration;
-    this.threadId = threadId;
-    this.threadName = threadName;
-    this.threadState = threadState;
-    this.stackFrames = stackFrames;
+    this.threadInfo = threadInfo;
     this.traceId = traceId;
     this.spanId = spanId;
     this.recordingThreadId = recordingThreadId;
@@ -82,19 +64,23 @@ class StackTrace {
   }
 
   long getThreadId() {
-    return threadId;
+    return threadInfo.getThreadId();
   }
 
   String getThreadName() {
-    return threadName;
+    return threadInfo.getThreadName();
   }
 
   Thread.State getThreadState() {
-    return threadState;
+    return threadInfo.getThreadState();
   }
 
   StackTraceElement[] getStackFrames() {
-    return stackFrames;
+    return threadInfo.getStackTrace();
+  }
+
+  ThreadInfo getThreadInfo() {
+    return threadInfo;
   }
 
   String getTraceId() {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/ThreadInfoCollector.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/ThreadInfoCollector.java
@@ -16,6 +16,7 @@
 
 package com.splunk.opentelemetry.profiler.snapshot;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
@@ -30,11 +31,21 @@ import java.util.logging.Logger;
 class ThreadInfoCollector {
   private static final Logger logger = Logger.getLogger(ThreadInfoCollector.class.getName());
 
-  private final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+  private final ThreadMXBean threadMXBean;
+
+  ThreadInfoCollector() {
+    this(ManagementFactory.getThreadMXBean());
+  }
+
+  @VisibleForTesting
+  ThreadInfoCollector(ThreadMXBean threadMXBean) {
+    this.threadMXBean = threadMXBean;
+  }
 
   ThreadInfo getThreadInfo(long threadId) {
     try {
-      return threadMXBean.getThreadInfo(threadId, Integer.MAX_VALUE);
+      ThreadInfo[] threadInfos = collectThreadInfo(new long[] {threadId});
+      return threadInfos.length == 0 ? null : threadInfos[0];
     } catch (Exception e) {
       logger.log(Level.SEVERE, e, () -> "Error taking callstack sample for thread id " + threadId);
     }
@@ -44,7 +55,7 @@ class ThreadInfoCollector {
   ThreadInfo[] getThreadInfo(Collection<Long> threadIds) {
     try {
       long[] threadIdArray = threadIds.stream().mapToLong(Long::longValue).toArray();
-      return threadMXBean.getThreadInfo(threadIdArray, Integer.MAX_VALUE);
+      return collectThreadInfo(threadIdArray);
     } catch (Exception e) {
       logger.log(
           Level.SEVERE,
@@ -52,5 +63,12 @@ class ThreadInfoCollector {
           () -> "Error taking callstack samples for thread ids [" + threadIds + "]");
     }
     return new ThreadInfo[0];
+  }
+
+  private ThreadInfo[] collectThreadInfo(long[] threadIds) {
+    return threadMXBean.getThreadInfo(
+        threadIds,
+        threadMXBean.isObjectMonitorUsageSupported(),
+        threadMXBean.isSynchronizerUsageSupported());
   }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/exporter/PprofCpuEventExporterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/exporter/PprofCpuEventExporterTest.java
@@ -20,6 +20,8 @@ import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.FRAM
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.perftools.profiles.ProfileProto.Location;
 import com.google.perftools.profiles.ProfileProto.Profile;
@@ -30,6 +32,9 @@ import com.splunk.opentelemetry.profiler.pprof.PprofUtils;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.trace.IdGenerator;
 import java.io.IOException;
+import java.lang.management.LockInfo;
+import java.lang.management.MonitorInfo;
+import java.lang.management.ThreadInfo;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -331,6 +336,36 @@ class PprofCpuEventExporterTest {
     assertThat(labels).contains(entry(ProfilingSemanticAttributes.THREAD_ID, threadId));
     assertThat(labels).contains(entry(ProfilingSemanticAttributes.THREAD_NAME, threadName));
     assertThat(labels).contains(entry(ProfilingSemanticAttributes.THREAD_STATE, state.toString()));
+  }
+
+  @Test
+  void includeThreadLockInformationInSamples() throws Exception {
+    var frame = new StackTraceElement("example.Worker", "run", "Worker.java", 42);
+    ThreadInfo threadInfo = mock(ThreadInfo.class);
+    when(threadInfo.getThreadId()).thenReturn(17L);
+    when(threadInfo.getThreadName()).thenReturn("worker-17");
+    when(threadInfo.getThreadState()).thenReturn(Thread.State.BLOCKED);
+    when(threadInfo.getStackTrace()).thenReturn(new StackTraceElement[] {frame});
+    when(threadInfo.getLockInfo()).thenReturn(new LockInfo("example.WaitingLock", 0x12ab));
+    when(threadInfo.getLockOwnerName()).thenReturn("lock-owner");
+    when(threadInfo.getLockedMonitors())
+        .thenReturn(new MonitorInfo[] {new MonitorInfo("example.Monitor", 0x23bc, 0, frame)});
+    when(threadInfo.getLockedSynchronizers())
+        .thenReturn(new LockInfo[] {new LockInfo("example.Synchronizer", 0x34cd)});
+
+    exporter.export(threadInfo, Instant.now(), "", "", Duration.ZERO);
+    exporter.flush();
+
+    var logRecord = logger.records().get(0);
+    var profile = Profile.parseFrom(PprofUtils.deserialize(logRecord));
+    var labels = PprofUtils.toLabelString(profile.getSample(0), profile);
+
+    assertThat(labels)
+        .containsEntry(ProfilingSemanticAttributes.LOCK_WAITING_ON, "example.WaitingLock@12ab")
+        .containsEntry(ProfilingSemanticAttributes.LOCK_OWNER_THREAD, "lock-owner")
+        .containsEntry(ProfilingSemanticAttributes.LOCK_HELD_PREFIX + "0", "example.Monitor@23bc")
+        .containsEntry(
+            ProfilingSemanticAttributes.LOCK_HELD_PREFIX + "1", "example.Synchronizer@34cd");
   }
 
   @Test

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/exporter/PprofCpuEventExporterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/exporter/PprofCpuEventExporterTest.java
@@ -17,6 +17,9 @@
 package com.splunk.opentelemetry.profiler.exporter;
 
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.FRAME_COUNT;
+import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.LOCK_HELD_PREFIX;
+import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.LOCK_OWNER_THREAD;
+import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.LOCK_WAITING_ON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -361,11 +364,10 @@ class PprofCpuEventExporterTest {
     var labels = PprofUtils.toLabelString(profile.getSample(0), profile);
 
     assertThat(labels)
-        .containsEntry(ProfilingSemanticAttributes.LOCK_WAITING_ON, "example.WaitingLock@12ab")
-        .containsEntry(ProfilingSemanticAttributes.LOCK_OWNER_THREAD, "lock-owner")
-        .containsEntry(ProfilingSemanticAttributes.LOCK_HELD_PREFIX + "0", "example.Monitor@23bc")
-        .containsEntry(
-            ProfilingSemanticAttributes.LOCK_HELD_PREFIX + "1", "example.Synchronizer@34cd");
+        .containsEntry(LOCK_WAITING_ON, "example.WaitingLock@12ab")
+        .containsEntry(LOCK_OWNER_THREAD, "lock-owner")
+        .containsEntry(LOCK_HELD_PREFIX + "0", "example.Monitor@23bc")
+        .containsEntry(LOCK_HELD_PREFIX + "1", "example.Synchronizer@34cd");
   }
 
   @Test

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/AsyncStackTraceExporterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/AsyncStackTraceExporterTest.java
@@ -20,6 +20,9 @@ import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.DATA
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.DATA_TYPE;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.FRAME_COUNT;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.INSTRUMENTATION_SOURCE;
+import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.LOCK_HELD_PREFIX;
+import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.LOCK_OWNER_THREAD;
+import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.LOCK_WAITING_ON;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SOURCE_EVENT_TIME;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SOURCE_TYPE;
 import static com.splunk.opentelemetry.profiler.ProfilingSemanticAttributes.SPAN_ID;
@@ -28,11 +31,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.perftools.profiles.ProfileProto.Profile;
 import com.splunk.opentelemetry.profiler.exporter.InMemoryOtelLogger;
 import com.splunk.opentelemetry.profiler.pprof.PprofUtils;
 import java.io.ByteArrayInputStream;
+import java.lang.management.LockInfo;
+import java.lang.management.MonitorInfo;
+import java.lang.management.ThreadInfo;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
@@ -201,6 +209,34 @@ class AsyncStackTraceExporterTest {
 
     var labels = PprofUtils.toLabelString(sample, profile);
     assertThat(labels).containsEntry(SPAN_ID.getKey(), stackTrace.getSpanId());
+  }
+
+  @Test
+  void includeThreadLockInformationInSamples() throws Exception {
+    var frame = new StackTraceElement("example.Worker", "run", "Worker.java", 42);
+    ThreadInfo threadInfo = mock(ThreadInfo.class);
+    when(threadInfo.getThreadId()).thenReturn(17L);
+    when(threadInfo.getThreadName()).thenReturn("worker-17");
+    when(threadInfo.getThreadState()).thenReturn(Thread.State.BLOCKED);
+    when(threadInfo.getStackTrace()).thenReturn(new StackTraceElement[] {frame});
+    when(threadInfo.getLockInfo()).thenReturn(new LockInfo("example.WaitingLock", 0x12ab));
+    when(threadInfo.getLockOwnerName()).thenReturn("lock-owner");
+    when(threadInfo.getLockedMonitors())
+        .thenReturn(new MonitorInfo[] {new MonitorInfo("example.Monitor", 0x23bc, 0, frame)});
+    when(threadInfo.getLockedSynchronizers())
+        .thenReturn(new LockInfo[] {new LockInfo("example.Synchronizer", 0x34cd)});
+    var stackTrace = Snapshotting.stackTrace().with(threadInfo).build();
+
+    exporter.export(List.of(stackTrace));
+    await().until(() -> !logger.records().isEmpty());
+
+    var profile = Profile.parseFrom(PprofUtils.deserialize(logger.records().get(0)));
+    var labels = PprofUtils.toLabelString(profile.getSample(0), profile);
+    assertThat(labels)
+        .containsEntry(LOCK_WAITING_ON, "example.WaitingLock@12ab")
+        .containsEntry(LOCK_OWNER_THREAD, "lock-owner")
+        .containsEntry(LOCK_HELD_PREFIX + "0", "example.Monitor@23bc")
+        .containsEntry(LOCK_HELD_PREFIX + "1", "example.Synchronizer@34cd");
   }
 
   @Test

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/StackTraceBuilder.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/StackTraceBuilder.java
@@ -16,6 +16,12 @@
 
 package com.splunk.opentelemetry.profiler.snapshot;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.management.LockInfo;
+import java.lang.management.MonitorInfo;
+import java.lang.management.ThreadInfo;
 import java.time.Duration;
 import java.time.Instant;
 
@@ -26,6 +32,7 @@ class StackTraceBuilder {
   private String threadName;
   private Thread.State state;
   private Exception exception;
+  private ThreadInfo threadInfo;
   private Snapshotting.SpanContextBuilder spanContextBuilder = Snapshotting.spanContext();
 
   public StackTraceBuilder with(Instant timestamp) {
@@ -58,6 +65,11 @@ class StackTraceBuilder {
     return this;
   }
 
+  public StackTraceBuilder with(ThreadInfo threadInfo) {
+    this.threadInfo = threadInfo;
+    return this;
+  }
+
   public StackTraceBuilder withTraceId(String traceId) {
     spanContextBuilder = spanContextBuilder.withTraceId(traceId);
     return this;
@@ -71,14 +83,20 @@ class StackTraceBuilder {
   StackTrace build() {
     var spanContext = spanContextBuilder.build();
     return new StackTrace(
-        timestamp,
-        duration,
-        threadId,
-        threadName,
-        state,
-        exception.getStackTrace(),
-        spanContext.getTraceId(),
-        spanContext.getSpanId(),
-        0);
+        timestamp, duration, threadInfo(), spanContext.getTraceId(), spanContext.getSpanId(), 0);
+  }
+
+  private ThreadInfo threadInfo() {
+    if (threadInfo != null) {
+      return threadInfo;
+    }
+    ThreadInfo result = mock(ThreadInfo.class);
+    when(result.getThreadId()).thenReturn(threadId);
+    when(result.getThreadName()).thenReturn(threadName);
+    when(result.getThreadState()).thenReturn(state);
+    when(result.getStackTrace()).thenReturn(exception.getStackTrace());
+    when(result.getLockedMonitors()).thenReturn(new MonitorInfo[0]);
+    when(result.getLockedSynchronizers()).thenReturn(new LockInfo[0]);
+    return result;
   }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/ThreadInfoCollectorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/ThreadInfoCollectorTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.profiler.snapshot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class ThreadInfoCollectorTest {
+
+  @Test
+  void requestsLockInformationForCollectedThreads() {
+    ThreadMXBean threadMXBean = mock(ThreadMXBean.class);
+    ThreadInfo threadInfo = mock(ThreadInfo.class);
+    when(threadMXBean.isObjectMonitorUsageSupported()).thenReturn(true);
+    when(threadMXBean.isSynchronizerUsageSupported()).thenReturn(true);
+    when(threadMXBean.getThreadInfo(any(long[].class), eq(true), eq(true)))
+        .thenReturn(new ThreadInfo[] {threadInfo});
+    ThreadInfoCollector collector = new ThreadInfoCollector(threadMXBean);
+
+    ThreadInfo[] result = collector.getThreadInfo(List.of(17L));
+
+    ArgumentCaptor<long[]> threadIds = ArgumentCaptor.forClass(long[].class);
+    verify(threadMXBean).getThreadInfo(threadIds.capture(), eq(true), eq(true));
+    assertThat(threadIds.getValue()).containsExactly(17L);
+    assertThat(result).containsExactly(threadInfo);
+  }
+}


### PR DESCRIPTION
This borrows some of the art from the opamp thread dump command and just ands the thread lock/monitor info as a standard part of the profiling signal. These labels aren't yet understood by the backend and are expected to be quietly dropped until then.