### PR TITLE
Add nocode test coverage

### DIFF
--- a/instrumentation/nocode/src/test/config/nocode.yml
+++ b/instrumentation/nocode/src/test/config/nocode.yml
@@ -94,3 +94,7 @@
 - class: com.splunk.opentelemetry.instrumentation.nocode.NocodeInstrumentationTest$SampleClass
   method: currentThenRegular
   span_name: "'currentThenRegular.child'"
+
+- class: com.splunk.opentelemetry.instrumentation.nocode.NocodeInstrumentationTest$SampleClass
+  method:
+    name_regex: methodPrefix.*

--- a/instrumentation/nocode/src/test/java/com/splunk/opentelemetry/instrumentation/nocode/NocodeInstrumentationTest.java
+++ b/instrumentation/nocode/src/test/java/com/splunk/opentelemetry/instrumentation/nocode/NocodeInstrumentationTest.java
@@ -163,6 +163,18 @@ class NocodeInstrumentationTest {
                 span -> span.hasName("currentThenRegular.child").hasParent(trace.getSpan(0))));
   }
 
+  @Test
+  void testCanMatchMethodPrefixAndGenerateSeparateSpans() {
+    new SampleClass().methodPrefixFoo();
+    // foo calls bar, bar calls baz.
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("SampleClass.methodPrefixFoo"),
+                span -> span.hasName("SampleClass.methodPrefixBar"),
+                span -> span.hasName("SampleClass.methodPrefixBaz")));
+  }
+
   public static class SampleClass {
     public String getName() {
       return "name";
@@ -216,5 +228,15 @@ class NocodeInstrumentationTest {
     public void regularThenCurrent(String value) {}
 
     public void currentThenRegular(String value) {}
+
+    public void methodPrefixFoo() {
+      methodPrefixBar();
+    }
+
+    public void methodPrefixBar() {
+      methodPrefixBaz();
+    }
+
+    public void methodPrefixBaz() {}
   }
 }


### PR DESCRIPTION
This introduces a new tests case where multiple methods match a given glob/regex. This new test also demonstrates that the instrumentation will be invoked and that it will generate spans with different names that are based on the actual class and method name.