### PR TITLE
Exceptions and assertions fully reported in CI build log

### DIFF
--- a/buildSrc/src/main/kotlin/splunk.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.java-conventions.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+
 plugins {
   java
 }
@@ -41,6 +43,12 @@ dependencies {
 
 tasks.withType<Test>().configureEach {
   useJUnitPlatform()
+  testLogging {
+    exceptionFormat = TestExceptionFormat.FULL
+    showExceptions = true
+    showCauses = true
+    showStackTraces = true
+  }
   reports {
     junitXml.isOutputPerTestCase = true
   }


### PR DESCRIPTION
Until now a default short format was used by Gradle for exceptions reporting in build log.
Because of this assertion errors was mostly truncated and rather useless:
```
> Task :profiler:test

PeriodicStackTraceSamplerTest > finalSampleDurationIsLessThanSamplingPeriod() FAILED
    java.lang.AssertionError at PeriodicStackTraceSamplerTest.java:419


> Task :profiler:test FAILED
```

This PR configures exception reporting format, so now full assertion message is logged:
```
> Task :profiler:test

PeriodicStackTraceSamplerTest > finalSampleDurationIsLessThanSamplingPeriod() FAILED
    java.lang.AssertionError: 
    Expecting actual:
      0.025327725S
    to be less than:
      0.02S 
        at com.splunk.opentelemetry.profiler.snapshot.PeriodicStackTraceSamplerTest.finalSampleDurationIsLessThanSamplingPeriod(PeriodicStackTraceSamplerTest.java:419)


> Task :profiler:test FAILED
```

This is important for flaky tests investigations that are always passing on dev machine.