### PR TITLE
Avoid warning

### DIFF
--- a/agent-csa-bundle/build.gradle.kts
+++ b/agent-csa-bundle/build.gradle.kts
@@ -111,6 +111,10 @@ tasks {
     filesMatching("inst/META-INF/services/**") {
       duplicatesStrategy = DuplicatesStrategy.INCLUDE
     }
+    // avoid warning about duplicate kotlin module files being silently dropped
+    filesMatching("inst/META-INF/*.kotlin_module") {
+      duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
     from("build/ext-exploded/") {
       include("inst/META-INF/services/io.opentelemetry.javaagent.extension.AgentListener")
     }

--- a/agent/build.gradle.kts
+++ b/agent/build.gradle.kts
@@ -134,6 +134,10 @@ tasks {
     filesMatching("inst/META-INF/services/**") {
       duplicatesStrategy = DuplicatesStrategy.INCLUDE
     }
+    // avoid warning about duplicate kotlin module files being silently dropped
+    filesMatching("inst/META-INF/*.kotlin_module") {
+      duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
 
     manifest {
       attributes(

--- a/buildSrc/src/main/kotlin/splunk.shadow-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/splunk.shadow-conventions.gradle.kts
@@ -10,6 +10,10 @@ tasks.withType<ShadowJar>().configureEach {
   filesMatching("META-INF/services/**") {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
   }
+  // avoid warning about duplicate kotlin module files being silently dropped
+  filesMatching("inst/META-INF/*.kotlin_module") {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+  }
 
   exclude("**/module-info.class")
 

--- a/testing/agent-for-testing/build.gradle.kts
+++ b/testing/agent-for-testing/build.gradle.kts
@@ -49,6 +49,11 @@ tasks {
 
     archiveFileName.set("javaagentLibs-relocated.jar")
 
+    // avoid warning about duplicate kotlin module files being silently dropped
+    filesMatching("inst/META-INF/*.kotlin_module") {
+      duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
+
     // exclude known bootstrap dependencies - they can't appear in the inst/ directory
     dependencies {
       exclude(dependency("org.slf4j:slf4j-api"))
@@ -85,6 +90,10 @@ tasks {
     mergeServiceFiles("inst/META-INF/services")
     // mergeServiceFiles requires that duplicate strategy is set to include
     filesMatching("inst/META-INF/services/**") {
+      duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
+    // avoid warning about duplicate kotlin module files being silently dropped
+    filesMatching("inst/META-INF/*.kotlin_module") {
       duplicatesStrategy = DuplicatesStrategy.INCLUDE
     }
 


### PR DESCRIPTION
> Task :testing:agent-for-testing:shadowJar
'inst/META-INF/kotlin-stdlib-jdk7.shadow.kotlin_module' is matched by com.github.jengelman.gradle.plugins.shadow.transformers.KotlinModuleMetadataTransformer_Decorated but its DuplicatesStrategy is EXCLUDE — duplicates may be silently dropped before the transformer processes them.
Set it to INCLUDE or WARN to ensure all duplicates are processed by the transformer.
See https://gradleup.com/shadow/configuration/merging/#handling-duplicates-strategy for more details.