### PR TITLE
`APPLYING` status is set when processing of Remote Config starts

### DIFF
--- a/opamp/src/main/java/com/splunk/opentelemetry/opamp/RemoteConfigProcessorImpl.java
+++ b/opamp/src/main/java/com/splunk/opentelemetry/opamp/RemoteConfigProcessorImpl.java
@@ -74,6 +74,11 @@ public class RemoteConfigProcessorImpl implements RemoteConfigProcessor {
     }
 
     try {
+      reportRemoteConfigStatus(
+          remoteConfig.config_hash,
+          RemoteConfigStatuses.RemoteConfigStatuses_APPLYING,
+          opampClient);
+
       DeclarativeConfigProperties remoteConfigProperties =
           toDeclarativeConfigProperties(configFile);
       DeclarativeConfigProperties distributionRemoteConfigProperties =
@@ -89,18 +94,12 @@ public class RemoteConfigProcessorImpl implements RemoteConfigProcessor {
 
       // Confirm to the OpAMP Server that remote config has been applied.
       reportRemoteConfigStatus(
-          remoteConfig.config_hash,
-          RemoteConfigStatuses.RemoteConfigStatuses_APPLIED,
-          "",
-          opampClient);
+          remoteConfig.config_hash, RemoteConfigStatuses.RemoteConfigStatuses_APPLIED, opampClient);
 
     } catch (Exception e) {
       logger.log(Level.WARNING, "Remote configuration not applied due to exception.", e);
-      reportRemoteConfigStatus(
-          remoteConfig.config_hash,
-          RemoteConfigStatuses.RemoteConfigStatuses_FAILED,
-          "Exception occurred: " + e.getMessage(),
-          opampClient);
+      reportRemoteConfigFailure(
+          remoteConfig.config_hash, "Exception occurred: " + e.getMessage(), opampClient);
     }
 
     // TODO: Maybe should be postponed after profiler is enabled/disabled?
@@ -151,15 +150,21 @@ public class RemoteConfigProcessorImpl implements RemoteConfigProcessor {
   }
 
   private void reportRemoteConfigStatus(
-      ByteString configHash,
-      RemoteConfigStatuses status,
-      String errorMessage,
-      OpampClient opampClient) {
+      ByteString configHash, RemoteConfigStatuses status, OpampClient opampClient) {
+    opampClient.setRemoteConfigStatus(
+        new RemoteConfigStatus.Builder()
+            .last_remote_config_hash(configHash)
+            .status(status)
+            .build());
+  }
+
+  private void reportRemoteConfigFailure(
+      ByteString configHash, String errorMessage, OpampClient opampClient) {
     opampClient.setRemoteConfigStatus(
         new RemoteConfigStatus.Builder()
             .last_remote_config_hash(configHash)
             .error_message(errorMessage)
-            .status(status)
+            .status(RemoteConfigStatuses.RemoteConfigStatuses_FAILED)
             .build());
   }
 }

--- a/opamp/src/test/java/com/splunk/opentelemetry/opamp/RemoteConfigProcessorImplTest.java
+++ b/opamp/src/test/java/com/splunk/opentelemetry/opamp/RemoteConfigProcessorImplTest.java
@@ -18,6 +18,7 @@ package com.splunk.opentelemetry.opamp;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -28,6 +29,7 @@ import com.splunk.opentelemetry.profiler.ProfilingSupervisor;
 import com.splunk.opentelemetry.profiler.snapshot.SnapshotProfilingConfiguration;
 import com.splunk.opentelemetry.profiler.snapshot.SnapshotProfilingSupervisor;
 import io.opentelemetry.opamp.client.OpampClient;
+import java.util.List;
 import java.util.Map;
 import okio.ByteString;
 import opamp.proto.AgentConfigFile;
@@ -69,6 +71,22 @@ class RemoteConfigProcessorImplTest {
   }
 
   @Test
+  void shouldMarkRemoteConfigAsApplyingWhenProcessingStarts() {
+    // given
+    ByteString configHash = ByteString.encodeUtf8("test-config-hash");
+    AgentRemoteConfig remoteConfig = createRemoteConfig(configHash, "test-config:");
+
+    // when
+    handler.applyConfig(remoteConfig, opampClient);
+
+    // then
+    RemoteConfigStatus status = getInitialReportedRemoteConfigStatus();
+    assertThat(status.last_remote_config_hash).isEqualTo(configHash);
+    assertThat(status.status).isEqualTo(RemoteConfigStatuses.RemoteConfigStatuses_APPLYING);
+    assertThat(status.error_message).isEmpty();
+  }
+
+  @Test
   void shouldMarkRemoteConfigAsAppliedWhenProfilingConfigIsNotProvided() {
     // given
     String remoteConfigYaml = "test-config:";
@@ -86,7 +104,7 @@ class RemoteConfigProcessorImplTest {
     handler.applyConfig(remoteConfig, opampClient);
 
     // then
-    RemoteConfigStatus status = getReportedRemoteConfigStatus();
+    RemoteConfigStatus status = getFinalReportedRemoteConfigStatus();
     assertThat(status.last_remote_config_hash).isEqualTo(configHash);
     assertThat(status.status).isEqualTo(RemoteConfigStatuses.RemoteConfigStatuses_APPLIED);
     assertThat(status.error_message).isEmpty();
@@ -112,7 +130,7 @@ class RemoteConfigProcessorImplTest {
     handler.applyConfig(remoteConfig, opampClient);
 
     // then
-    RemoteConfigStatus status = getReportedRemoteConfigStatus();
+    RemoteConfigStatus status = getFinalReportedRemoteConfigStatus();
     assertThat(status.last_remote_config_hash).isEqualTo(configHash);
     assertThat(status.status).isEqualTo(RemoteConfigStatuses.RemoteConfigStatuses_FAILED);
     assertThat(status.error_message).startsWith("Exception occurred:");
@@ -162,7 +180,7 @@ class RemoteConfigProcessorImplTest {
       handler.applyConfig(remoteConfig, opampClient);
 
       // then
-      RemoteConfigStatus status = getReportedRemoteConfigStatus();
+      RemoteConfigStatus status = getFinalReportedRemoteConfigStatus();
       assertThat(status.last_remote_config_hash).isEqualTo(configHash);
       assertThat(status.status).isEqualTo(RemoteConfigStatuses.RemoteConfigStatuses_APPLIED);
       assertThat(status.error_message).isEmpty();
@@ -224,7 +242,7 @@ class RemoteConfigProcessorImplTest {
       handler.applyConfig(remoteConfig, opampClient);
 
       // then
-      RemoteConfigStatus status = getReportedRemoteConfigStatus();
+      RemoteConfigStatus status = getFinalReportedRemoteConfigStatus();
       assertThat(status.last_remote_config_hash).isEqualTo(configHash);
       assertThat(status.status).isEqualTo(RemoteConfigStatuses.RemoteConfigStatuses_APPLIED);
       assertThat(status.error_message).isEmpty();
@@ -255,7 +273,7 @@ class RemoteConfigProcessorImplTest {
       handler.applyConfig(remoteConfig, opampClient);
 
       // then
-      RemoteConfigStatus status = getReportedRemoteConfigStatus();
+      RemoteConfigStatus status = getFinalReportedRemoteConfigStatus();
       assertThat(status.last_remote_config_hash).isEqualTo(configHash);
       assertThat(status.status).isEqualTo(RemoteConfigStatuses.RemoteConfigStatuses_APPLIED);
       assertThat(status.error_message).isEmpty();
@@ -308,7 +326,7 @@ class RemoteConfigProcessorImplTest {
       handler.applyConfig(remoteConfig, opampClient);
 
       // then
-      RemoteConfigStatus status = getReportedRemoteConfigStatus();
+      RemoteConfigStatus status = getFinalReportedRemoteConfigStatus();
       assertThat(status.last_remote_config_hash).isEqualTo(configHash);
       assertThat(status.status).isEqualTo(RemoteConfigStatuses.RemoteConfigStatuses_APPLIED);
       assertThat(status.error_message).isEmpty();
@@ -320,11 +338,19 @@ class RemoteConfigProcessorImplTest {
     }
   }
 
-  private RemoteConfigStatus getReportedRemoteConfigStatus() {
+  private RemoteConfigStatus getInitialReportedRemoteConfigStatus() {
+    return getReportedRemoteConfigStatuses().get(0);
+  }
+
+  private RemoteConfigStatus getFinalReportedRemoteConfigStatus() {
+    return getReportedRemoteConfigStatuses().get(1);
+  }
+
+  private List<RemoteConfigStatus> getReportedRemoteConfigStatuses() {
     ArgumentCaptor<RemoteConfigStatus> statusCaptor =
         ArgumentCaptor.forClass(RemoteConfigStatus.class);
-    verify(opampClient).setRemoteConfigStatus(statusCaptor.capture());
-    return statusCaptor.getValue();
+    verify(opampClient, times(2)).setRemoteConfigStatus(statusCaptor.capture());
+    return statusCaptor.getAllValues();
   }
 
   private static AgentRemoteConfig createRemoteConfig(ByteString configHash, String config) {


### PR DESCRIPTION
So far RemoteConfigStatus was set only at the end of remote config processing to `APPLIED` or `FAILED`.
According to the [SPEC](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#remoteconfigstatus-message) it can also be set to `APPLYING` at the beginning of remote config application.
Usually server will get final remote config status, but in case of some bug that prevents remote config application to finish the server should get the `APPLYING` status.