### PR TITLE
Help renovate find csa

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,8 +3,26 @@
   "extends": [
     "config:base"
   ],
+  "customDatasources": {
+    "csa-latest": {
+      "defaultRegistryUrlTemplate": "https://api.github.com/repos/signalfx/csa-releases/releases/latest",
+      "transformTemplates": [
+        "{\"releases\": $exists(assets[name = 'oss-agent-mtagent-extension-deployment.jar']) ? [{\"version\": tag_name, \"changelogUrl\": html_url}] : [], \"sourceUrl\": \"https://github.com/signalfx/csa-releases\"}"
+      ]
+    }
+  },
   "ignorePaths": ["instrumentation/**"],
   "packageRules": [
+    {
+      "description": "Update the bundled CSA release",
+      "matchManagers": ["gradle"],
+      "matchDatasources": ["maven"],
+      "matchPackageNames": ["signalfx:csa-releases"],
+      "matchFileNames": ["agent-csa-bundle/build.gradle.kts"],
+      "overrideDatasource": "custom.csa-latest",
+      "overridePackageName": "signalfx/csa-releases",
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)$"
+    },
     {
       "matchPackagePrefixes": ["com.diffplug.spotless"],
       "groupName": "spotless packages"

--- a/agent-csa-bundle/build.gradle.kts
+++ b/agent-csa-bundle/build.gradle.kts
@@ -6,8 +6,7 @@ plugins {
   id("com.gradleup.shadow")
 }
 
-// This should be updated for every CSA release, eventually in dependencyManagement?
-
+// Updated from the latest signalfx/csa-releases GitHub release by Renovate.
 val csaVersion = "26.8.0-1482"
 val otelInstrumentationVersion: String = rootProject.extra["otelInstrumentationVersion"] as String
 


### PR DESCRIPTION
Supersedes #3000.

Looks like renovate was already aware of our dependency on CSA, but it just failed to find the latest version because it was treating it like maven.

<img width="829" height="151" alt="image" src="https://github.com/user-attachments/assets/58309935-0dea-458e-bf12-b867fe784eb2" />

This should help it along.