### PR TITLE
renovate - fix issue with datasources

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,14 +3,6 @@
   "extends": [
     "config:base"
   ],
-  "customDatasources": {
-    "csa-latest": {
-      "defaultRegistryUrlTemplate": "https://api.github.com/repos/signalfx/csa-releases/releases/latest",
-      "transformTemplates": [
-        "{\"releases\": $exists(assets[name = 'oss-agent-mtagent-extension-deployment.jar']) ? [{\"version\": tag_name, \"changelogUrl\": html_url}] : [], \"sourceUrl\": \"https://github.com/signalfx/csa-releases\"}"
-      ]
-    }
-  },
   "ignorePaths": ["instrumentation/**"],
   "packageRules": [
     {
@@ -19,8 +11,9 @@
       "matchDatasources": ["maven"],
       "matchPackageNames": ["signalfx:csa-releases"],
       "matchFileNames": ["agent-csa-bundle/build.gradle.kts"],
-      "overrideDatasource": "custom.csa-latest",
+      "overrideDatasource": "github-releases",
       "overridePackageName": "signalfx/csa-releases",
+      "registryUrls": ["https://github.com"],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)$"
     },
     {


### PR DESCRIPTION
The dashboard showed that the last fix in #3001 didn't work as intended.

<img width="836" height="314" alt="image" src="https://github.com/user-attachments/assets/68697cd1-70a2-419a-903b-0e6fd855d052" />

I guess we can just use the built-in renovate github releases.