### PR TITLE
Config setting for snapshot thread monitor/lock info

### DIFF
--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/PprofCpuEventExporter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/exporter/PprofCpuEventExporter.java
@@ -48,12 +48,14 @@ import java.time.Instant;
 public class PprofCpuEventExporter implements CpuEventExporter {
   private final Duration period;
   private final int stackDepth;
+  private final boolean locksEnabled;
   private final PprofLogDataExporter pprofLogDataExporter;
   private Pprof pprof = createPprof();
 
   private PprofCpuEventExporter(Builder builder) {
     this.period = builder.period;
     this.stackDepth = builder.stackDepth;
+    this.locksEnabled = builder.locksEnabled;
     this.pprofLogDataExporter =
         new PprofLogDataExporter(
             builder.otelLogger, ProfilingDataType.CPU, builder.instrumentationSource);
@@ -106,7 +108,9 @@ public class PprofCpuEventExporter implements CpuEventExporter {
     Sample.Builder sample = Sample.newBuilder();
     addThreadInfo(
         sample, threadInfo.getThreadId(), threadInfo.getThreadName(), threadInfo.getThreadState());
-    addLockInfo(sample, threadInfo);
+    if (locksEnabled) {
+      addLockInfo(sample, threadInfo);
+    }
     addSample(sample, threadInfo.getStackTrace(), eventTime, traceId, spanId, duration);
   }
 
@@ -219,6 +223,7 @@ public class PprofCpuEventExporter implements CpuEventExporter {
     private Logger otelLogger;
     private Duration period;
     private int stackDepth;
+    private boolean locksEnabled;
     private InstrumentationSource instrumentationSource = InstrumentationSource.CONTINUOUS;
 
     public PprofCpuEventExporter build() {
@@ -237,6 +242,11 @@ public class PprofCpuEventExporter implements CpuEventExporter {
 
     public Builder stackDepth(int stackDepth) {
       this.stackDepth = stackDepth;
+      return this;
+    }
+
+    public Builder locksEnabled(boolean locksEnabled) {
+      this.locksEnabled = locksEnabled;
       return this;
     }
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/AsyncStackTraceExporter.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/AsyncStackTraceExporter.java
@@ -34,11 +34,17 @@ class AsyncStackTraceExporter implements StackTraceExporter {
       HelpfulExecutors.newSingleThreadExecutor("async-stack-trace-exporter");
   private final Logger otelLogger;
   private final int maxDepth;
+  private final boolean locksEnabled;
   private volatile boolean closed = false;
 
   AsyncStackTraceExporter(Logger logger, int maxDepth) {
+    this(logger, maxDepth, false);
+  }
+
+  AsyncStackTraceExporter(Logger logger, int maxDepth, boolean locksEnabled) {
     this.otelLogger = logger;
     this.maxDepth = maxDepth;
+    this.locksEnabled = locksEnabled;
   }
 
   @Override
@@ -71,6 +77,7 @@ class AsyncStackTraceExporter implements StackTraceExporter {
             PprofCpuEventExporter.builder()
                 .otelLogger(otelLogger)
                 .stackDepth(maxDepth)
+                .locksEnabled(locksEnabled)
                 .instrumentationSource(InstrumentationSource.SNAPSHOT)
                 .build();
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/PeriodicStackTraceSampler.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/PeriodicStackTraceSampler.java
@@ -44,7 +44,20 @@ class PeriodicStackTraceSampler implements StackTraceSampler {
 
   public PeriodicStackTraceSampler(
       Supplier<StagingArea> staging, Supplier<SpanTracker> spanTracker, Duration samplingPeriod) {
-    this(staging, spanTracker, new ThreadInfoCollector(), samplingPeriod, Clock.getDefault());
+    this(staging, spanTracker, samplingPeriod, false);
+  }
+
+  public PeriodicStackTraceSampler(
+      Supplier<StagingArea> staging,
+      Supplier<SpanTracker> spanTracker,
+      Duration samplingPeriod,
+      boolean locksEnabled) {
+    this(
+        staging,
+        spanTracker,
+        new ThreadInfoCollector(locksEnabled),
+        samplingPeriod,
+        Clock.getDefault());
   }
 
   @VisibleForTesting

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/PeriodicStackTraceSampler.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/PeriodicStackTraceSampler.java
@@ -43,11 +43,6 @@ class PeriodicStackTraceSampler implements StackTraceSampler {
   private volatile boolean closed;
 
   public PeriodicStackTraceSampler(
-      Supplier<StagingArea> staging, Supplier<SpanTracker> spanTracker, Duration samplingPeriod) {
-    this(staging, spanTracker, samplingPeriod, false);
-  }
-
-  public PeriodicStackTraceSampler(
       Supplier<StagingArea> staging,
       Supplier<SpanTracker> spanTracker,
       Duration samplingPeriod,

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingConfiguration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingConfiguration.java
@@ -82,7 +82,6 @@ public class SnapshotProfilingConfiguration {
     log("SamplingInterval", getSamplingInterval().toMillis() + "ms");
     log("ExportInterval", getExportInterval().toMillis() + "ms");
     log("StagingCapacity", getStagingCapacity());
-    log("LocksEnabled", getLocksEnabled());
 
     logger.info("--------------------------------");
   }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingConfiguration.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingConfiguration.java
@@ -42,6 +42,7 @@ public class SnapshotProfilingConfiguration {
   private final Duration samplingInterval;
   private final Duration exportInterval;
   private final int stagingCapacity;
+  private final boolean locksEnabled;
   @Nullable private final Object configProperties;
 
   private SnapshotProfilingConfiguration(Builder builder) {
@@ -51,6 +52,7 @@ public class SnapshotProfilingConfiguration {
     samplingInterval = builder.samplingInterval;
     exportInterval = builder.exportInterval;
     stagingCapacity = builder.stagingCapacity;
+    locksEnabled = builder.locksEnabled;
     configProperties = builder.configProperties;
   }
 
@@ -66,6 +68,7 @@ public class SnapshotProfilingConfiguration {
         .setSamplingInterval(samplingInterval)
         .setExportInterval(exportInterval)
         .setStagingCapacity(stagingCapacity)
+        .setLocksEnabled(locksEnabled)
         .setConfigProperties(configProperties);
   }
 
@@ -79,6 +82,7 @@ public class SnapshotProfilingConfiguration {
     log("SamplingInterval", getSamplingInterval().toMillis() + "ms");
     log("ExportInterval", getExportInterval().toMillis() + "ms");
     log("StagingCapacity", getStagingCapacity());
+    log("LocksEnabled", getLocksEnabled());
 
     logger.info("--------------------------------");
   }
@@ -107,6 +111,10 @@ public class SnapshotProfilingConfiguration {
     return stagingCapacity;
   }
 
+  public boolean getLocksEnabled() {
+    return locksEnabled;
+  }
+
   @Nullable
   public Object getConfigProperties() {
     return configProperties;
@@ -125,6 +133,7 @@ public class SnapshotProfilingConfiguration {
         && Double.compare(that.snapshotSelectionProbability, snapshotSelectionProbability) == 0
         && stackDepth == that.stackDepth
         && stagingCapacity == that.stagingCapacity
+        && locksEnabled == that.locksEnabled
         && Objects.equals(samplingInterval, that.samplingInterval)
         && Objects.equals(exportInterval, that.exportInterval)
         && Objects.equals(configProperties, that.configProperties);
@@ -139,6 +148,7 @@ public class SnapshotProfilingConfiguration {
         samplingInterval,
         exportInterval,
         stagingCapacity,
+        locksEnabled,
         configProperties);
   }
 
@@ -174,6 +184,7 @@ public class SnapshotProfilingConfiguration {
     private Duration samplingInterval = Duration.ofMillis(DEFAULT_SAMPLING_INTERVAL);
     private Duration exportInterval = Duration.ofMillis(DEFAULT_EXPORT_INTERVAL);
     private int stagingCapacity = DEFAULT_STAGING_CAPACITY;
+    private boolean locksEnabled;
     @Nullable private Object configProperties;
 
     private Builder() {}
@@ -209,6 +220,11 @@ public class SnapshotProfilingConfiguration {
 
     public Builder setStagingCapacity(int stagingCapacity) {
       this.stagingCapacity = stagingCapacity;
+      return this;
+    }
+
+    public Builder setLocksEnabled(boolean locksEnabled) {
+      this.locksEnabled = locksEnabled;
       return this;
     }
 

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingDeclarativeConfigurationFactory.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingDeclarativeConfigurationFactory.java
@@ -52,7 +52,7 @@ public final class SnapshotProfilingDeclarativeConfigurationFactory {
         .setStagingCapacity(
             configRoot.getInt(
                 "staging_capacity", SnapshotProfilingConfiguration.DEFAULT_STAGING_CAPACITY))
-        .setLocksEnabled(configRoot.getStructured("locks", empty()).getBoolean("enabled", false))
+        .setLocksEnabled(configRoot.getBoolean("report_locks", false))
         .setConfigProperties(config)
         .build();
   }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingDeclarativeConfigurationFactory.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingDeclarativeConfigurationFactory.java
@@ -52,6 +52,7 @@ public final class SnapshotProfilingDeclarativeConfigurationFactory {
         .setStagingCapacity(
             configRoot.getInt(
                 "staging_capacity", SnapshotProfilingConfiguration.DEFAULT_STAGING_CAPACITY))
+        .setLocksEnabled(configRoot.getStructured("locks", empty()).getBoolean("enabled", false))
         .setConfigProperties(config)
         .build();
   }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingEnvVarsConfigurationFactory.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingEnvVarsConfigurationFactory.java
@@ -31,6 +31,7 @@ public final class SnapshotProfilingEnvVarsConfigurationFactory {
   static final String SAMPLING_INTERVAL_KEY = "splunk.snapshot.sampling.interval";
   static final String EXPORT_INTERVAL_KEY = "splunk.snapshot.profiler.export.interval";
   static final String STAGING_CAPACITY_KEY = "splunk.snapshot.profiler.staging.capacity";
+  static final String LOCKS_ENABLED_KEY = "splunk.profiler.locks.enabled";
 
   private SnapshotProfilingEnvVarsConfigurationFactory() {}
 
@@ -51,6 +52,7 @@ public final class SnapshotProfilingEnvVarsConfigurationFactory {
         .setStagingCapacity(
             properties.getInt(
                 STAGING_CAPACITY_KEY, SnapshotProfilingConfiguration.DEFAULT_STAGING_CAPACITY))
+        .setLocksEnabled(properties.getBoolean(LOCKS_ENABLED_KEY, false))
         .setConfigProperties(properties)
         .build();
   }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSupervisor.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSupervisor.java
@@ -215,7 +215,8 @@ public class SnapshotProfilingSupervisor {
 
   StackTraceSampler createStackTraceSampler(SnapshotProfilingConfiguration configuration) {
     Duration samplingPeriod = configuration.getSamplingInterval();
-    return new PeriodicStackTraceSampler(stagingAreaSupplier, spanTrackerSupplier, samplingPeriod);
+    return new PeriodicStackTraceSampler(
+        stagingAreaSupplier, spanTrackerSupplier, samplingPeriod, configuration.getLocksEnabled());
   }
 
   StackTraceExporter createStackTraceExporter(SnapshotProfilingConfiguration configuration) {
@@ -223,7 +224,8 @@ public class SnapshotProfilingSupervisor {
     io.opentelemetry.api.logs.Logger otelLogger =
         buildLogger(otelLoggerFactory, resource, configuration.getConfigProperties());
 
-    return new AsyncStackTraceExporter(otelLogger, configuration.getStackDepth());
+    return new AsyncStackTraceExporter(
+        otelLogger, configuration.getStackDepth(), configuration.getLocksEnabled());
   }
 
   private io.opentelemetry.api.logs.Logger buildLogger(

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/ThreadInfoCollector.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/ThreadInfoCollector.java
@@ -34,10 +34,6 @@ class ThreadInfoCollector {
   private final ThreadMXBean threadMXBean;
   private final boolean locksEnabled;
 
-  ThreadInfoCollector() {
-    this(ManagementFactory.getThreadMXBean(), false);
-  }
-
   ThreadInfoCollector(boolean locksEnabled) {
     this(ManagementFactory.getThreadMXBean(), locksEnabled);
   }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/ThreadInfoCollector.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/ThreadInfoCollector.java
@@ -32,14 +32,25 @@ class ThreadInfoCollector {
   private static final Logger logger = Logger.getLogger(ThreadInfoCollector.class.getName());
 
   private final ThreadMXBean threadMXBean;
+  private final boolean locksEnabled;
 
   ThreadInfoCollector() {
-    this(ManagementFactory.getThreadMXBean());
+    this(ManagementFactory.getThreadMXBean(), false);
+  }
+
+  ThreadInfoCollector(boolean locksEnabled) {
+    this(ManagementFactory.getThreadMXBean(), locksEnabled);
   }
 
   @VisibleForTesting
   ThreadInfoCollector(ThreadMXBean threadMXBean) {
+    this(threadMXBean, false);
+  }
+
+  @VisibleForTesting
+  ThreadInfoCollector(ThreadMXBean threadMXBean, boolean locksEnabled) {
     this.threadMXBean = threadMXBean;
+    this.locksEnabled = locksEnabled;
   }
 
   ThreadInfo getThreadInfo(long threadId) {
@@ -68,7 +79,7 @@ class ThreadInfoCollector {
   private ThreadInfo[] collectThreadInfo(long[] threadIds) {
     return threadMXBean.getThreadInfo(
         threadIds,
-        threadMXBean.isObjectMonitorUsageSupported(),
-        threadMXBean.isSynchronizerUsageSupported());
+        locksEnabled && threadMXBean.isObjectMonitorUsageSupported(),
+        locksEnabled && threadMXBean.isSynchronizerUsageSupported());
   }
 }

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/exporter/PprofCpuEventExporterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/exporter/PprofCpuEventExporterTest.java
@@ -343,6 +343,14 @@ class PprofCpuEventExporterTest {
 
   @Test
   void includeThreadLockInformationInSamples() throws Exception {
+    var locksEnabledExporter =
+        PprofCpuEventExporter.builder()
+            .otelLogger(logger)
+            .period(Duration.ofMillis(20))
+            .stackDepth(1024)
+            .locksEnabled(true)
+            .instrumentationSource(InstrumentationSource.SNAPSHOT)
+            .build();
     var frame = new StackTraceElement("example.Worker", "run", "Worker.java", 42);
     ThreadInfo threadInfo = mock(ThreadInfo.class);
     when(threadInfo.getThreadId()).thenReturn(17L);
@@ -356,8 +364,8 @@ class PprofCpuEventExporterTest {
     when(threadInfo.getLockedSynchronizers())
         .thenReturn(new LockInfo[] {new LockInfo("example.Synchronizer", 0x34cd)});
 
-    exporter.export(threadInfo, Instant.now(), "", "", Duration.ZERO);
-    exporter.flush();
+    locksEnabledExporter.export(threadInfo, Instant.now(), "", "", Duration.ZERO);
+    locksEnabledExporter.flush();
 
     var logRecord = logger.records().get(0);
     var profile = Profile.parseFrom(PprofUtils.deserialize(logRecord));
@@ -368,6 +376,25 @@ class PprofCpuEventExporterTest {
         .containsEntry(LOCK_OWNER_THREAD, "lock-owner")
         .containsEntry(LOCK_HELD_PREFIX + "0", "example.Monitor@23bc")
         .containsEntry(LOCK_HELD_PREFIX + "1", "example.Synchronizer@34cd");
+  }
+
+  @Test
+  void doesNotIncludeThreadLockInformationByDefault() throws Exception {
+    ThreadInfo threadInfo = mock(ThreadInfo.class);
+    when(threadInfo.getThreadId()).thenReturn(17L);
+    when(threadInfo.getThreadName()).thenReturn("worker-17");
+    when(threadInfo.getThreadState()).thenReturn(Thread.State.BLOCKED);
+    when(threadInfo.getStackTrace()).thenReturn(new StackTraceElement[0]);
+
+    exporter.export(threadInfo, Instant.now(), "", "", Duration.ZERO);
+    exporter.flush();
+
+    var logRecord = logger.records().get(0);
+    var profile = Profile.parseFrom(PprofUtils.deserialize(logRecord));
+    var labels = PprofUtils.toLabelString(profile.getSample(0), profile);
+
+    assertThat(labels)
+        .doesNotContainKeys(LOCK_WAITING_ON, LOCK_OWNER_THREAD, LOCK_HELD_PREFIX + "0");
   }
 
   @Test

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/AsyncStackTraceExporterTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/AsyncStackTraceExporterTest.java
@@ -213,6 +213,7 @@ class AsyncStackTraceExporterTest {
 
   @Test
   void includeThreadLockInformationInSamples() throws Exception {
+    var locksEnabledExporter = new AsyncStackTraceExporter(logger, 200, true);
     var frame = new StackTraceElement("example.Worker", "run", "Worker.java", 42);
     ThreadInfo threadInfo = mock(ThreadInfo.class);
     when(threadInfo.getThreadId()).thenReturn(17L);
@@ -227,7 +228,7 @@ class AsyncStackTraceExporterTest {
         .thenReturn(new LockInfo[] {new LockInfo("example.Synchronizer", 0x34cd)});
     var stackTrace = Snapshotting.stackTrace().with(threadInfo).build();
 
-    exporter.export(List.of(stackTrace));
+    locksEnabledExporter.export(List.of(stackTrace));
     await().until(() -> !logger.records().isEmpty());
 
     var profile = Profile.parseFrom(PprofUtils.deserialize(logger.records().get(0)));
@@ -237,6 +238,7 @@ class AsyncStackTraceExporterTest {
         .containsEntry(LOCK_OWNER_THREAD, "lock-owner")
         .containsEntry(LOCK_HELD_PREFIX + "0", "example.Monitor@23bc")
         .containsEntry(LOCK_HELD_PREFIX + "1", "example.Synchronizer@34cd");
+    locksEnabledExporter.close();
   }
 
   @Test

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/ConcurrentServiceEntrySamplingTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/ConcurrentServiceEntrySamplingTest.java
@@ -51,7 +51,7 @@ class ConcurrentServiceEntrySamplingTest {
     var stagingAreaSupplier = StagingArea.SUPPLIER;
     stagingAreaSupplier.configure(staging);
     return new PeriodicStackTraceSampler(
-        stagingAreaSupplier, SpanTracker.SUPPLIER, Duration.ofMillis(20));
+        stagingAreaSupplier, SpanTracker.SUPPLIER, Duration.ofMillis(20), false);
   }
 
   private final SnapshotProfilingSdkCustomizer downstreamCustomizer =

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/ContextStorageWrapperTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/ContextStorageWrapperTest.java
@@ -86,7 +86,7 @@ class ContextStorageWrapperTest {
 
     var sampler =
         new PeriodicStackTraceSampler(
-            StagingArea.SUPPLIER, SpanTracker.SUPPLIER, Duration.ofMinutes(1));
+            StagingArea.SUPPLIER, SpanTracker.SUPPLIER, Duration.ofMinutes(1), false);
     StackTraceSampler.SUPPLIER.configure(sampler);
 
     wrapper.wrapContextStorage(registry);

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/PeriodicStackTraceSamplerTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/PeriodicStackTraceSamplerTest.java
@@ -202,7 +202,7 @@ class PeriodicStackTraceSamplerTest {
   void calculateSamplingPeriodAfterFirstRecordedStackTraces() {
     var clock = TestClock.create();
     var initialSampleCollector =
-        new ThreadInfoCollector() {
+        new ThreadInfoCollector(false) {
           @Override
           ThreadInfo getThreadInfo(long threadId) {
             var threadInfo = super.getThreadInfo(threadId);
@@ -542,6 +542,10 @@ class PeriodicStackTraceSamplerTest {
       this.delay = delay;
     }
 
+    DelayedThreadInfoCollector() {
+      super(false);
+    }
+
     @Override
     ThreadInfo getThreadInfo(long threadId) {
       try {
@@ -568,6 +572,7 @@ class PeriodicStackTraceSamplerTest {
     private final CountDownLatch latch;
 
     private CoordinatingThreadInfoCollector(CountDownLatch latch) {
+      super(false);
       this.latch = latch;
     }
 

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingDeclarativeConfigurationFactoryTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingDeclarativeConfigurationFactoryTest.java
@@ -42,8 +42,7 @@ class SnapshotProfilingDeclarativeConfigurationFactoryTest {
                     selection_probability: 0.0123 # SPLUNK_SNAPSHOT_SELECTION_PROBABILITY
                     stack_depth: 200              # SPLUNK_SNAPSHOT_STACK_DEPTH
                     staging_capacity: 7           # SPLUNK_SNAPSHOT_STAGING_CAPACITY
-                    locks:
-                      enabled: true
+                    report_locks: true
             """);
 
     DeclarativeConfigProperties profilingConfig = getProfilingConfig(model);

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingDeclarativeConfigurationFactoryTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingDeclarativeConfigurationFactoryTest.java
@@ -42,6 +42,8 @@ class SnapshotProfilingDeclarativeConfigurationFactoryTest {
                     selection_probability: 0.0123 # SPLUNK_SNAPSHOT_SELECTION_PROBABILITY
                     stack_depth: 200              # SPLUNK_SNAPSHOT_STACK_DEPTH
                     staging_capacity: 7           # SPLUNK_SNAPSHOT_STAGING_CAPACITY
+                    locks:
+                      enabled: true
             """);
 
     DeclarativeConfigProperties profilingConfig = getProfilingConfig(model);
@@ -57,6 +59,7 @@ class SnapshotProfilingDeclarativeConfigurationFactoryTest {
     assertThat(config.getSamplingInterval()).isEqualTo(Duration.ofMillis(10));
     assertThat(config.getExportInterval()).isEqualTo(Duration.ofMillis(20));
     assertThat(config.getStagingCapacity()).isEqualTo(7);
+    assertThat(config.getLocksEnabled()).isTrue();
   }
 
   @Test
@@ -85,6 +88,7 @@ class SnapshotProfilingDeclarativeConfigurationFactoryTest {
     assertThat(config.getSamplingInterval()).isEqualTo(Duration.ofMillis(10));
     assertThat(config.getExportInterval()).isEqualTo(Duration.ofSeconds(5));
     assertThat(config.getStagingCapacity()).isEqualTo(2000);
+    assertThat(config.getLocksEnabled()).isFalse();
   }
 
   @Test

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingEnvVarsConfigurationFactoryTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingEnvVarsConfigurationFactoryTest.java
@@ -52,6 +52,21 @@ class SnapshotProfilingEnvVarsConfigurationFactoryTest {
   }
 
   @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void shouldMapLocksEnabled(boolean enabled) {
+    var properties =
+        DefaultConfigProperties.create(
+            Map.of(
+                SnapshotProfilingEnvVarsConfigurationFactory.LOCKS_ENABLED_KEY,
+                String.valueOf(enabled)),
+            COMPONENT_LOADER);
+
+    var configuration = SnapshotProfilingEnvVarsConfigurationFactory.create(properties);
+
+    assertThat(configuration.getLocksEnabled()).isEqualTo(enabled);
+  }
+
+  @ParameterizedTest
   @ValueSource(doubles = {0.10, 0.05, 0.00001})
   void shouldReturnValidSelectionProbability(double selectionRate) {
     // given

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSdkCustomizerBuilder.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSdkCustomizerBuilder.java
@@ -33,7 +33,8 @@ class SnapshotProfilingSdkCustomizerBuilder {
 
   SnapshotProfilingSdkCustomizerBuilder withRealStackTraceSampler(Duration samplingPeriod) {
     return with(
-        new PeriodicStackTraceSampler(StagingArea.SUPPLIER, SpanTracker.SUPPLIER, samplingPeriod, false));
+        new PeriodicStackTraceSampler(
+            StagingArea.SUPPLIER, SpanTracker.SUPPLIER, samplingPeriod, false));
   }
 
   SnapshotProfilingSdkCustomizerBuilder with(StackTraceSampler sampler) {

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSdkCustomizerBuilder.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSdkCustomizerBuilder.java
@@ -33,7 +33,7 @@ class SnapshotProfilingSdkCustomizerBuilder {
 
   SnapshotProfilingSdkCustomizerBuilder withRealStackTraceSampler(Duration samplingPeriod) {
     return with(
-        new PeriodicStackTraceSampler(StagingArea.SUPPLIER, SpanTracker.SUPPLIER, samplingPeriod));
+        new PeriodicStackTraceSampler(StagingArea.SUPPLIER, SpanTracker.SUPPLIER, samplingPeriod, false));
   }
 
   SnapshotProfilingSdkCustomizerBuilder with(StackTraceSampler sampler) {

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/ThreadInfoCollectorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/ThreadInfoCollectorTest.java
@@ -32,14 +32,30 @@ import org.mockito.ArgumentCaptor;
 class ThreadInfoCollectorTest {
 
   @Test
-  void requestsLockInformationForCollectedThreads() {
+  void doesNotRequestLockInformationByDefault() {
+    ThreadMXBean threadMXBean = mock(ThreadMXBean.class);
+    ThreadInfo threadInfo = mock(ThreadInfo.class);
+    when(threadMXBean.getThreadInfo(any(long[].class), eq(false), eq(false)))
+        .thenReturn(new ThreadInfo[] {threadInfo});
+    ThreadInfoCollector collector = new ThreadInfoCollector(threadMXBean);
+
+    ThreadInfo[] result = collector.getThreadInfo(List.of(17L));
+
+    ArgumentCaptor<long[]> threadIds = ArgumentCaptor.forClass(long[].class);
+    verify(threadMXBean).getThreadInfo(threadIds.capture(), eq(false), eq(false));
+    assertThat(threadIds.getValue()).containsExactly(17L);
+    assertThat(result).containsExactly(threadInfo);
+  }
+
+  @Test
+  void requestsLockInformationWhenEnabled() {
     ThreadMXBean threadMXBean = mock(ThreadMXBean.class);
     ThreadInfo threadInfo = mock(ThreadInfo.class);
     when(threadMXBean.isObjectMonitorUsageSupported()).thenReturn(true);
     when(threadMXBean.isSynchronizerUsageSupported()).thenReturn(true);
     when(threadMXBean.getThreadInfo(any(long[].class), eq(true), eq(true)))
         .thenReturn(new ThreadInfo[] {threadInfo});
-    ThreadInfoCollector collector = new ThreadInfoCollector(threadMXBean);
+    ThreadInfoCollector collector = new ThreadInfoCollector(threadMXBean, true);
 
     ThreadInfo[] result = collector.getThreadInfo(List.of(17L));
 


### PR DESCRIPTION
This introduces a new config setting called `splunk.profiler.locks.enabled` which defaults to false. This effectively rolls back #2952 unless the user opts in with the new config setting.

(used codex)