### PR TITLE
[OpAMP] Snapshot profiling remote config

### DIFF
--- a/opamp/src/main/java/com/splunk/opentelemetry/opamp/RemoteConfigProcessorImpl.java
+++ b/opamp/src/main/java/com/splunk/opentelemetry/opamp/RemoteConfigProcessorImpl.java
@@ -135,7 +135,12 @@ public class RemoteConfigProcessorImpl implements RemoteConfigProcessor {
     SnapshotProfilingConfiguration currentConfiguration =
         SnapshotProfilingConfiguration.SUPPLIER.get();
     SnapshotProfilingConfiguration updatedConfiguration =
-        currentConfiguration.toBuilder().setEnabled(receivedConfiguration.isEnabled()).build();
+        currentConfiguration.toBuilder()
+            .setEnabled(receivedConfiguration.isEnabled())
+            .setSamplingInterval(receivedConfiguration.getSamplingInterval())
+            .setSnapshotSelectionProbability(
+                receivedConfiguration.getSnapshotSelectionProbability())
+            .build();
 
     if (!currentConfiguration.equals(updatedConfiguration)) {
       SnapshotProfilingConfiguration.SUPPLIER.configure(updatedConfiguration);

--- a/opamp/src/main/java/com/splunk/opentelemetry/opamp/effectiveconfig/DeclarativeEffectiveConfigFileFactory.java
+++ b/opamp/src/main/java/com/splunk/opentelemetry/opamp/effectiveconfig/DeclarativeEffectiveConfigFileFactory.java
@@ -113,6 +113,8 @@ class DeclarativeEffectiveConfigFileFactory implements EffectiveConfigFactory {
     if (snapshotConfiguration.isEnabled()) {
       profiling.addNestedNode(
           "callgraphs.sampling_interval", snapshotConfiguration.getSamplingInterval().toMillis());
+      profiling.addNestedNode(
+          "callgraphs.selection_probability", snapshotConfiguration.getSnapshotSelectionProbability());
     }
   }
 

--- a/opamp/src/main/java/com/splunk/opentelemetry/opamp/effectiveconfig/DeclarativeEffectiveConfigFileFactory.java
+++ b/opamp/src/main/java/com/splunk/opentelemetry/opamp/effectiveconfig/DeclarativeEffectiveConfigFileFactory.java
@@ -111,17 +111,21 @@ class DeclarativeEffectiveConfigFileFactory implements EffectiveConfigFactory {
   private static void addCallgraphsNode(
       SnapshotProfilingConfiguration snapshotConfiguration, YamlNodeBuilder profiling) {
     if (snapshotConfiguration.isEnabled()) {
-      profiling.addNestedNode(
-          "callgraphs.sampling_interval", snapshotConfiguration.getSamplingInterval().toMillis());
-      profiling.addNestedNode(
-          "callgraphs.selection_probability", snapshotConfiguration.getSnapshotSelectionProbability());
+      profiling.addNode(
+          "callgraphs",
+          callgraphs -> {
+            callgraphs.addNode(
+                "sampling_interval", snapshotConfiguration.getSamplingInterval().toMillis());
+            callgraphs.addNode(
+                "selection_probability", snapshotConfiguration.getSnapshotSelectionProbability());
+          });
     }
   }
 
   private static void addAlwaysOnProfilerNode(
       ProfilerConfiguration profilerConfiguration, YamlNodeBuilder profiling) {
     if (profilerConfiguration.isEnabled()) {
-      profiling.addNestedNode(
+      profiling.addNode(
           "always_on",
           alwaysOn -> {
             alwaysOn.addNestedNode(

--- a/opamp/src/main/java/com/splunk/opentelemetry/opamp/effectiveconfig/EnvVarsEffectiveConfigFileFactory.java
+++ b/opamp/src/main/java/com/splunk/opentelemetry/opamp/effectiveconfig/EnvVarsEffectiveConfigFileFactory.java
@@ -53,13 +53,15 @@ class EnvVarsEffectiveConfigFileFactory implements EffectiveConfigFactory {
 
     builder
         .add("SPLUNK_PROFILER_ENABLED", profilerConfiguration.isEnabled())
+        .add("SPLUNK_PROFILER_CALL_STACK_INTERVAL", profilerConfiguration.getCallStackInterval())
         .add("SPLUNK_PROFILER_MEMORY_ENABLED", profilerConfiguration.getMemoryEnabled())
         .add("SPLUNK_SNAPSHOT_PROFILER_ENABLED", snapshotConfiguration.isEnabled())
         .add(
             "SPLUNK_SNAPSHOT_PROFILER_SAMPLING_INTERVAL",
             snapshotConfiguration.getSamplingInterval())
-        .add("SPLUNK_SNAPSHOT_SELECTION_PROBABILITY", snapshotConfiguration.getSnapshotSelectionProbability())
-        .add("SPLUNK_PROFILER_CALL_STACK_INTERVAL", profilerConfiguration.getCallStackInterval());
+        .add(
+            "SPLUNK_SNAPSHOT_SELECTION_PROBABILITY",
+            snapshotConfiguration.getSnapshotSelectionProbability());
   }
 
   private void addOtelEnvVars(EffectiveConfigBuilder builder) {

--- a/opamp/src/main/java/com/splunk/opentelemetry/opamp/effectiveconfig/EnvVarsEffectiveConfigFileFactory.java
+++ b/opamp/src/main/java/com/splunk/opentelemetry/opamp/effectiveconfig/EnvVarsEffectiveConfigFileFactory.java
@@ -58,6 +58,7 @@ class EnvVarsEffectiveConfigFileFactory implements EffectiveConfigFactory {
         .add(
             "SPLUNK_SNAPSHOT_PROFILER_SAMPLING_INTERVAL",
             snapshotConfiguration.getSamplingInterval())
+        .add("SPLUNK_SNAPSHOT_SELECTION_PROBABILITY", snapshotConfiguration.getSnapshotSelectionProbability())
         .add("SPLUNK_PROFILER_CALL_STACK_INTERVAL", profilerConfiguration.getCallStackInterval());
   }
 

--- a/opamp/src/test/java/com/splunk/opentelemetry/opamp/OpampClientConfigurationFactoryTest.java
+++ b/opamp/src/test/java/com/splunk/opentelemetry/opamp/OpampClientConfigurationFactoryTest.java
@@ -92,7 +92,7 @@ class OpampClientConfigurationFactoryTest {
     // given
     String yaml =
         """
-            file_format: "1.0"
+            file_format: "1.1"
             distribution:
               splunk:
                 opamp/development:

--- a/opamp/src/test/java/com/splunk/opentelemetry/opamp/RemoteConfigProcessorImplTest.java
+++ b/opamp/src/test/java/com/splunk/opentelemetry/opamp/RemoteConfigProcessorImplTest.java
@@ -29,6 +29,7 @@ import com.splunk.opentelemetry.profiler.ProfilingSupervisor;
 import com.splunk.opentelemetry.profiler.snapshot.SnapshotProfilingConfiguration;
 import com.splunk.opentelemetry.profiler.snapshot.SnapshotProfilingSupervisor;
 import io.opentelemetry.opamp.client.OpampClient;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import okio.ByteString;
@@ -306,6 +307,33 @@ class RemoteConfigProcessorImplTest {
       assertThat(SnapshotProfilingConfiguration.SUPPLIER.get().isEnabled()).isTrue();
       verifyNoInteractions(profilingSupervisor, snapshotProfilingSupervisor);
       verify(effectiveConfigReporter).reportEffectiveConfigIfChanged();
+    }
+
+    @Test
+    void shouldUpdateCallgraphsSettingsFromRemoteConfig() {
+      SnapshotProfilingConfiguration.SUPPLIER.configure(
+          SnapshotProfilingConfiguration.builder().setEnabled(true).build());
+      String remoteConfigYaml =
+          """
+          distribution:
+            splunk:
+              profiling:
+                callgraphs:
+                  selection_probability: 0.5
+                  sampling_interval: 123
+          """;
+      AgentRemoteConfig remoteConfig =
+          createRemoteConfig(ByteString.encodeUtf8("test-config-hash"), remoteConfigYaml);
+
+      handler.applyConfig(remoteConfig, opampClient);
+
+      assertThat(SnapshotProfilingConfiguration.SUPPLIER.get().getSnapshotSelectionProbability())
+          .isEqualTo(0.5);
+      assertThat(SnapshotProfilingConfiguration.SUPPLIER.get().getSamplingInterval())
+          .isEqualTo(Duration.ofMillis(123));
+      verify(snapshotProfilingSupervisor).requestReinitializeProfiling();
+      verifyNoMoreInteractions(snapshotProfilingSupervisor);
+      verifyNoInteractions(profilingSupervisor);
     }
 
     @Test

--- a/opamp/src/test/java/com/splunk/opentelemetry/opamp/effectiveconfig/DeclarativeEffectiveConfigFileFactoryTest.java
+++ b/opamp/src/test/java/com/splunk/opentelemetry/opamp/effectiveconfig/DeclarativeEffectiveConfigFileFactoryTest.java
@@ -109,6 +109,7 @@ class DeclarativeEffectiveConfigFileFactoryTest {
                 memory_profiler:
               callgraphs:
                 sampling_interval: 10
+                selection_probability: 0.1507
         """;
 
     // when
@@ -131,6 +132,7 @@ class DeclarativeEffectiveConfigFileFactoryTest {
                     memory_profiler:
                   callgraphs:
                     sampling_interval: 10
+                    selection_probability: 0.1507
             """);
   }
 
@@ -365,8 +367,6 @@ class DeclarativeEffectiveConfigFileFactoryTest {
     when(mockProfilerConfiguration.isEnabled()).thenReturn(true);
     when(mockProfilerConfiguration.getCallStackInterval()).thenReturn(Duration.ofMillis(1410));
     when(mockProfilerConfiguration.getMemoryEnabled()).thenReturn(true);
-    when(mockSnapshotConfiguration.isEnabled()).thenReturn(true);
-    when(mockSnapshotConfiguration.getSamplingInterval()).thenReturn(Duration.ofMillis(10));
 
     String yaml =
         new DeclarativeEffectiveConfigFileFactory()
@@ -384,8 +384,31 @@ class DeclarativeEffectiveConfigFileFactoryTest {
                     cpu_profiler:
                       sampling_interval: 1410
                     memory_profiler:
+            """);
+  }
+
+  @Test
+  void supportsSnapshotProfiler() throws Exception {
+    OpenTelemetryConfigurationModel model = parseModel("file_format: 1.1");
+    when(mockSnapshotConfiguration.isEnabled()).thenReturn(true);
+    when(mockSnapshotConfiguration.getSamplingInterval()).thenReturn(Duration.ofMillis(10));
+    when(mockSnapshotConfiguration.getSnapshotSelectionProbability()).thenReturn(0.0123);
+
+    String yaml =
+        new DeclarativeEffectiveConfigFileFactory()
+            .processModel(model, mockProfilerConfiguration, mockSnapshotConfiguration);
+
+    assertThat(yaml)
+        .isEqualTo(
+            """
+            otel_config_file: null
+            otel_experimental_config_file: null
+            distribution:
+              splunk:
+                profiling:
                   callgraphs:
                     sampling_interval: 10
+                    selection_probability: 0.0123
             """);
   }
 

--- a/opamp/src/test/java/com/splunk/opentelemetry/opamp/effectiveconfig/EnvVarsEffectiveConfigFileFactoryTest.java
+++ b/opamp/src/test/java/com/splunk/opentelemetry/opamp/effectiveconfig/EnvVarsEffectiveConfigFileFactoryTest.java
@@ -40,7 +40,7 @@ class EnvVarsEffectiveConfigFileFactoryTest {
 
   @Test
   void createFile_reportsCorrectContentType() {
-    DefaultConfigProperties config = DefaultConfigProperties.createFromMap(Map.of());
+    DefaultConfigProperties config = DefaultConfigProperties.createFromMap(Map.ofEntries());
     String contentType = new EnvVarsEffectiveConfigFileFactory(config).getContentType();
 
     assertThat(contentType).isEqualTo("text/plain; format=properties; vendor=splunk; v=1.0.0");
@@ -50,117 +50,121 @@ class EnvVarsEffectiveConfigFileFactoryTest {
   void buildFileContent_reportsConfiguredValues() throws IOException {
     Properties fileContent =
         createFileContent(
-            Map.of(
-                "splunk.profiler.enabled", "true",
-                "splunk.profiler.memory.enabled", "true",
-                "splunk.snapshot.profiler.enabled", "true",
-                "splunk.snapshot.sampling.interval", "26ms",
-                "splunk.profiler.call.stack.interval", "1235ms",
-                "otel.exporter.otlp.endpoint", "https://base.example.com",
-                "otel.exporter.otlp.traces.endpoint", "https://traces.example.com",
-                "otel.exporter.otlp.metrics.endpoint", "https://metrics.example.com",
-                "otel.exporter.otlp.logs.endpoint", "https://logs.example.com",
-                "otel.service.name", "checkout"));
+            Map.ofEntries(
+                Map.entry("splunk.profiler.enabled", "true"),
+                Map.entry("splunk.profiler.memory.enabled", "true"),
+                Map.entry("splunk.snapshot.profiler.enabled", "true"),
+                Map.entry("splunk.snapshot.sampling.interval", "26ms"),
+                Map.entry("splunk.snapshot.selection.probability", "0.0123"),
+                Map.entry("splunk.profiler.call.stack.interval", "1235ms"),
+                Map.entry("otel.exporter.otlp.endpoint", "https://base.example.com"),
+                Map.entry("otel.exporter.otlp.traces.endpoint", "https://traces.example.com"),
+                Map.entry("otel.exporter.otlp.metrics.endpoint", "https://metrics.example.com"),
+                Map.entry("otel.exporter.otlp.logs.endpoint", "https://logs.example.com"),
+                Map.entry("otel.service.name", "checkout")));
 
     assertProperties(
         fileContent,
-        Map.of(
-            "SPLUNK_PROFILER_ENABLED", "true",
-            "SPLUNK_PROFILER_MEMORY_ENABLED", "true",
-            "SPLUNK_SNAPSHOT_PROFILER_ENABLED", "true",
-            "SPLUNK_SNAPSHOT_PROFILER_SAMPLING_INTERVAL", "26ms",
-            "SPLUNK_PROFILER_CALL_STACK_INTERVAL", "1235ms",
-            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "https://traces.example.com",
-            "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "https://metrics.example.com",
-            "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "https://logs.example.com",
-            "OTEL_CONFIG_FILE", "null",
-            "OTEL_EXPERIMENTAL_CONFIG_FILE", "null"));
-    assertThat(fileContent.size()).isEqualTo(10);
+        Map.ofEntries(
+            Map.entry("SPLUNK_PROFILER_ENABLED", "true"),
+            Map.entry("SPLUNK_PROFILER_MEMORY_ENABLED", "true"),
+            Map.entry("SPLUNK_SNAPSHOT_PROFILER_ENABLED", "true"),
+            Map.entry("SPLUNK_SNAPSHOT_PROFILER_SAMPLING_INTERVAL", "26ms"),
+            Map.entry("SPLUNK_SNAPSHOT_SELECTION_PROBABILITY", "0.0123"),
+            Map.entry("SPLUNK_PROFILER_CALL_STACK_INTERVAL", "1235ms"),
+            Map.entry("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "https://traces.example.com"),
+            Map.entry("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "https://metrics.example.com"),
+            Map.entry("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "https://logs.example.com"),
+            Map.entry("OTEL_CONFIG_FILE", "null"),
+            Map.entry("OTEL_EXPERIMENTAL_CONFIG_FILE", "null")));
+    assertThat(fileContent.size()).isEqualTo(11);
   }
 
   @Test
   void buildFileContent_reportsDefaultValuesWhenNotConfigured() throws IOException {
-    Properties fileContent = createFileContent(Map.of());
+    Properties fileContent = createFileContent(Map.ofEntries());
 
     assertProperties(
         fileContent,
-        Map.of(
-            "SPLUNK_PROFILER_ENABLED", "false",
-            "SPLUNK_PROFILER_MEMORY_ENABLED", "false",
-            "SPLUNK_SNAPSHOT_PROFILER_ENABLED", "false",
-            "SPLUNK_SNAPSHOT_PROFILER_SAMPLING_INTERVAL", "10ms",
-            "SPLUNK_PROFILER_CALL_STACK_INTERVAL", "10000ms",
-            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://localhost:4318/v1/traces",
-            "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://localhost:4318/v1/metrics",
-            "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "http://localhost:4318/v1/logs",
-            "OTEL_CONFIG_FILE", "null",
-            "OTEL_EXPERIMENTAL_CONFIG_FILE", "null"));
-    assertThat(fileContent.size()).isEqualTo(10);
+        Map.ofEntries(
+            Map.entry("SPLUNK_PROFILER_ENABLED", "false"),
+            Map.entry("SPLUNK_PROFILER_MEMORY_ENABLED", "false"),
+            Map.entry("SPLUNK_SNAPSHOT_PROFILER_ENABLED", "false"),
+            Map.entry("SPLUNK_SNAPSHOT_PROFILER_SAMPLING_INTERVAL", "10ms"),
+            Map.entry("SPLUNK_SNAPSHOT_SELECTION_PROBABILITY", "0.01"),
+            Map.entry("SPLUNK_PROFILER_CALL_STACK_INTERVAL", "10000ms"),
+            Map.entry("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://localhost:4318/v1/traces"),
+            Map.entry("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://localhost:4318/v1/metrics"),
+            Map.entry("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "http://localhost:4318/v1/logs"),
+            Map.entry("OTEL_CONFIG_FILE", "null"),
+            Map.entry("OTEL_EXPERIMENTAL_CONFIG_FILE", "null")));
+    assertThat(fileContent.size()).isEqualTo(11);
   }
 
   @Test
   void buildFileContent_appendsSignalPathsToBaseHttpProtobufEndpoint() throws IOException {
     Properties fileContent =
-        createFileContent(Map.of("otel.exporter.otlp.endpoint", "https://collector:4318"));
+        createFileContent(
+            Map.ofEntries(Map.entry("otel.exporter.otlp.endpoint", "https://collector:4318")));
 
     assertProperties(
         fileContent,
-        Map.of(
-            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "https://collector:4318/v1/traces",
-            "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "https://collector:4318/v1/metrics",
-            "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "https://collector:4318/v1/logs"));
+        Map.ofEntries(
+            Map.entry("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "https://collector:4318/v1/traces"),
+            Map.entry("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "https://collector:4318/v1/metrics"),
+            Map.entry("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "https://collector:4318/v1/logs")));
   }
 
   @Test
   void buildFileContent_reportsEmptySignalEndpointsWhenExportersAreNotOtlp() throws IOException {
     Properties fileContent =
         createFileContent(
-            Map.of(
-                "otel.exporter.otlp.endpoint", "https://collector:4318",
-                "otel.traces.exporter", "custom",
-                "otel.metrics.exporter", "console",
-                "otel.logs.exporter", "none"));
+            Map.ofEntries(
+                Map.entry("otel.exporter.otlp.endpoint", "https://collector:4318"),
+                Map.entry("otel.traces.exporter", "custom"),
+                Map.entry("otel.metrics.exporter", "console"),
+                Map.entry("otel.logs.exporter", "none")));
 
     assertProperties(
         fileContent,
-        Map.of(
-            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "",
-            "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "",
-            "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", ""));
+        Map.ofEntries(
+            Map.entry("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", ""),
+            Map.entry("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", ""),
+            Map.entry("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "")));
   }
 
   @Test
   void buildFileContent_usesBaseGrpcEndpointForAllSignals() throws IOException {
     Properties fileContent =
         createFileContent(
-            Map.of(
-                "otel.exporter.otlp.endpoint", "https://collector:4317",
-                "otel.exporter.otlp.protocol", "grpc"));
+            Map.ofEntries(
+                Map.entry("otel.exporter.otlp.endpoint", "https://collector:4317"),
+                Map.entry("otel.exporter.otlp.protocol", "grpc")));
 
     assertProperties(
         fileContent,
-        Map.of(
-            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "https://collector:4317",
-            "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "https://collector:4317",
-            "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "https://collector:4317"));
+        Map.ofEntries(
+            Map.entry("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "https://collector:4317"),
+            Map.entry("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "https://collector:4317"),
+            Map.entry("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "https://collector:4317")));
   }
 
   @Test
   void buildFileContent_usesSignalSpecificProtocolWhenResolvingEndpoints() throws IOException {
     Properties fileContent =
         createFileContent(
-            Map.of(
-                "otel.exporter.otlp.endpoint", "https://collector:4317",
-                "otel.exporter.otlp.traces.protocol", "grpc",
-                "otel.exporter.otlp.metrics.protocol", "grpc",
-                "otel.exporter.otlp.logs.protocol", "grpc"));
+            Map.ofEntries(
+                Map.entry("otel.exporter.otlp.endpoint", "https://collector:4317"),
+                Map.entry("otel.exporter.otlp.traces.protocol", "grpc"),
+                Map.entry("otel.exporter.otlp.metrics.protocol", "grpc"),
+                Map.entry("otel.exporter.otlp.logs.protocol", "grpc")));
 
     assertProperties(
         fileContent,
-        Map.of(
-            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "https://collector:4317",
-            "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "https://collector:4317",
-            "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "https://collector:4317"));
+        Map.ofEntries(
+            Map.entry("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "https://collector:4317"),
+            Map.entry("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "https://collector:4317"),
+            Map.entry("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "https://collector:4317")));
   }
 
   private static Properties createFileContent(Map<String, String> configMap) throws IOException {

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/NoopSnapshotProfilingSpanProcessor.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/NoopSnapshotProfilingSpanProcessor.java
@@ -44,4 +44,7 @@ class NoopSnapshotProfilingSpanProcessor implements SnapshotProfilingSpanProcess
   public boolean isEnabled() {
     return false;
   }
+
+  @Override
+  public void setSnapshotSelectionProbability(double probability) {}
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSpanProcessor.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSpanProcessor.java
@@ -26,4 +26,6 @@ public interface SnapshotProfilingSpanProcessor extends SpanProcessor {
   void setEnabled(boolean enabled);
 
   boolean isEnabled();
+
+  void setSnapshotSelectionProbability(double probability);
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSpanProcessorImpl.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSpanProcessorImpl.java
@@ -41,6 +41,11 @@ public class SnapshotProfilingSpanProcessorImpl implements SnapshotProfilingSpan
   }
 
   @Override
+  public void setSnapshotSelectionProbability(double probability) {
+    this.selector.setSnapshotSelectionProbability(probability);
+  }
+
+  @Override
   public void onStart(Context context, ReadWriteSpan span) {
     if (!isEnabled()) {
       return;

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSpanProcessorImpl.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSpanProcessorImpl.java
@@ -42,7 +42,7 @@ public class SnapshotProfilingSpanProcessorImpl implements SnapshotProfilingSpan
 
   @Override
   public void setSnapshotSelectionProbability(double probability) {
-    this.selector.setSnapshotSelectionProbability(probability);
+    selector.setSnapshotSelectionProbability(probability);
   }
 
   @Override

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSupervisor.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSupervisor.java
@@ -167,6 +167,10 @@ public class SnapshotProfilingSupervisor {
     // Enable components created during SDK initialization
     spanTrackerSupplier.get().setEnabled(true);
     traceThreadChangeDetectorSupplier.get().setEnabled(true);
+
+    profilingSpanProcessorSupplier
+        .get()
+        .setSnapshotSelectionProbability(configuration.getSnapshotSelectionProbability());
     profilingSpanProcessorSupplier.get().setEnabled(true);
 
     running = true;

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotSelector.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotSelector.java
@@ -20,4 +20,6 @@ import io.opentelemetry.api.trace.SpanContext;
 
 interface SnapshotSelector {
   boolean select(SpanContext context);
+
+  void setSnapshotSelectionProbability(double probability);
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/TraceIdBasedSnapshotSelector.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/TraceIdBasedSnapshotSelector.java
@@ -18,7 +18,7 @@ package com.splunk.opentelemetry.profiler.snapshot;
 
 import io.opentelemetry.api.trace.SpanContext;
 
-class TraceIdBasedSnapshotSelector implements SnapshotSelector {
+final class TraceIdBasedSnapshotSelector implements SnapshotSelector {
   // the length of trace-id represented as a hex string
   private static final int TRACE_ID_LENGTH = 32;
   // number of characters taken from the tail of trace-id as the trace randomness
@@ -26,14 +26,10 @@ class TraceIdBasedSnapshotSelector implements SnapshotSelector {
   private static final String HEX_FORMATTER = "%07x";
   // to convert probability to threshold
   private static final int MULTIPLIER = (1 << (4 * CHARS)) - 1;
-  private final String threshold;
+  private volatile String threshold;
 
   TraceIdBasedSnapshotSelector(double selectionProbability) {
-    if (selectionProbability < 0 || selectionProbability > 1) {
-      throw new IllegalArgumentException("Selection probability must be between 0 and 1.");
-    }
-
-    this.threshold = thresholdFor(selectionProbability);
+    setSnapshotSelectionProbability(selectionProbability);
   }
 
   private static String thresholdFor(double probability) {
@@ -47,13 +43,23 @@ class TraceIdBasedSnapshotSelector implements SnapshotSelector {
 
   @Override
   public boolean select(SpanContext spanContext) {
-    if (threshold == null || !spanContext.isValid()) {
+    String currentThreshold = threshold;
+    if (currentThreshold == null || !spanContext.isValid()) {
       return false;
     }
 
     String traceId = spanContext.getTraceId();
     String randomness = traceId.substring(TRACE_ID_LENGTH - CHARS);
     // Select if randomness is lesser or equal to threshold
-    return randomness.compareTo(threshold) < 1;
+    return randomness.compareTo(currentThreshold) < 1;
+  }
+
+  @Override
+  public void setSnapshotSelectionProbability(double selectionProbability) {
+    if (selectionProbability < 0 || selectionProbability > 1) {
+      throw new IllegalArgumentException("Selection probability must be between 0 and 1.");
+    }
+
+    this.threshold = thresholdFor(selectionProbability);
   }
 }

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/TraceIdBasedSnapshotSelector.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/snapshot/TraceIdBasedSnapshotSelector.java
@@ -43,6 +43,8 @@ final class TraceIdBasedSnapshotSelector implements SnapshotSelector {
 
   @Override
   public boolean select(SpanContext spanContext) {
+    // Capture the volatile threshold into a local variable so a concurrent configuration update
+    // cannot change the threshold value used during method execution.
     String currentThreshold = threshold;
     if (currentThreshold == null || !spanContext.isValid()) {
       return false;

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSupervisorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/SnapshotProfilingSupervisorTest.java
@@ -131,6 +131,9 @@ class SnapshotProfilingSupervisorTest {
         .during(Duration.ofMillis(200))
         .untilAsserted(
             () -> {
+              verify(profilingSpanProcessor)
+                  .setSnapshotSelectionProbability(
+                      SnapshotProfilingConfiguration.DEFAULT_SELECTION_PROBABILITY);
               verifyEnabled(true);
               assertThat(stackTraceSamplerSupplier.get()).isSameAs(configuredSampler);
               assertThat(stagingAreaSupplier.get()).isSameAs(configuredStagingArea);
@@ -156,6 +159,9 @@ class SnapshotProfilingSupervisorTest {
     verify(traceThreadChangeDetector).setEnabled(false);
     verify(profilingSpanProcessor).setEnabled(true);
     verify(profilingSpanProcessor).setEnabled(false);
+    verify(profilingSpanProcessor)
+        .setSnapshotSelectionProbability(
+            SnapshotProfilingConfiguration.DEFAULT_SELECTION_PROBABILITY);
     verifyNoMoreInteractions(spanTracker, traceThreadChangeDetector, profilingSpanProcessor);
     assertRuntimeComponentsReset();
   }
@@ -200,6 +206,9 @@ class SnapshotProfilingSupervisorTest {
               verify(traceThreadChangeDetector).setEnabled(false);
               verify(traceThreadChangeDetector).setEnabled(true);
               verify(profilingSpanProcessor).setEnabled(false);
+              verify(profilingSpanProcessor)
+                  .setSnapshotSelectionProbability(
+                      SnapshotProfilingConfiguration.DEFAULT_SELECTION_PROBABILITY);
               verify(profilingSpanProcessor).setEnabled(true);
               verifyNoMoreInteractions(
                   spanTracker, traceThreadChangeDetector, profilingSpanProcessor);
@@ -208,6 +217,25 @@ class SnapshotProfilingSupervisorTest {
     assertThat(stagingAreaSupplier.get()).isNotSameAs(initialStagingArea);
     assertThat(stackTraceExporterSupplier.get()).isNotSameAs(initialExporter);
     assertRuntimeComponentsConfigured();
+  }
+
+  @Test
+  void selectionProbabilityIsUpdatedWhenReinitialized() {
+    configurationSupplier.configure(configuration(true));
+    requestStartProfiling();
+    clearInvocations(spanTracker, traceThreadChangeDetector, profilingSpanProcessor);
+
+    configurationSupplier.configure(
+        configuration(true).toBuilder().setSnapshotSelectionProbability(0.5).build());
+    supervisor.requestReinitializeProfiling();
+
+    await()
+        .untilAsserted(
+            () -> {
+              verify(profilingSpanProcessor).setEnabled(false);
+              verify(profilingSpanProcessor).setSnapshotSelectionProbability(0.5);
+              verify(profilingSpanProcessor).setEnabled(true);
+            });
   }
 
   @Test

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/TraceIdBasedSnapshotSelectorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/TraceIdBasedSnapshotSelectorTest.java
@@ -43,6 +43,21 @@ class TraceIdBasedSnapshotSelectorTest {
     assertThat(selector.select(spanContext)).isTrue();
   }
 
+  @Test
+  void useUpdatedSelectionProbability() {
+    var spanContext =
+        Snapshotting.spanContext()
+            .withTraceId(SnapshotSelectorTestTraceIds.forPercentile(6).get(0))
+            .build();
+    var selector = new TraceIdBasedSnapshotSelector(0.05);
+
+    assertThat(selector.select(spanContext)).isFalse();
+
+    selector.setSnapshotSelectionProbability(0.06);
+
+    assertThat(selector.select(spanContext)).isTrue();
+  }
+
   @ParameterizedTest
   @MethodSource("traceIdsToSelect")
   void selectTraceWhenTraceIdIsComputedToBeLessThanOrEqualToSelectionRate(String traceId) {

--- a/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/TraceIdBasedSnapshotSelectorTest.java
+++ b/profiler/src/test/java/com/splunk/opentelemetry/profiler/snapshot/TraceIdBasedSnapshotSelectorTest.java
@@ -35,6 +35,16 @@ class TraceIdBasedSnapshotSelectorTest {
         IllegalArgumentException.class, () -> new TraceIdBasedSnapshotSelector(selectionRate));
   }
 
+  @ParameterizedTest
+  @ValueSource(doubles = {-0.01, 1.01})
+  void requireUpdatedSelectionRateBetween0_0And1_0(double selectionRate) {
+    var selector = new TraceIdBasedSnapshotSelector(0.5);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> selector.setSnapshotSelectionProbability(selectionRate));
+  }
+
   @Test
   void doSelectTraceWhenRoot() {
     var spanContext =
@@ -56,6 +66,17 @@ class TraceIdBasedSnapshotSelectorTest {
     selector.setSnapshotSelectionProbability(0.06);
 
     assertThat(selector.select(spanContext)).isTrue();
+  }
+
+  @Test
+  void doNotSelectTraceAfterProbabilityIsUpdatedToZero() {
+    var spanContext =
+        Snapshotting.spanContext().withTraceId("00000000000000004adb3965a6cbec2d").build();
+    var selector = new TraceIdBasedSnapshotSelector(1.0);
+
+    selector.setSnapshotSelectionProbability(0.0);
+
+    assertThat(selector.select(spanContext)).isFalse();
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Until now it was only possible to turn on and off snapshot profiling with remote config.
This PR introduces support for sampling interval and snapshot selection probability settings.