### PR TITLE
Try an alternative way for commiting updated license report

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,4 +27,4 @@ jobs:
           branch: main
           path-to-signatures: signatures/version1/cla.json
           path-to-document: https://github.com/splunk/cla-agreement/blob/main/CLA.md
-          allowlist: dependabot[bot],renovate[bot],srv-gh-o11y-gdi
+          allowlist: dependabot[bot],renovate[bot],github-actions[bot],srv-gh-o11y-gdi

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -305,7 +305,7 @@ jobs:
       - name: Commit and push generated license report
         id: commit-licenses
         uses: IAreKyleW00t/verified-bot-commit@42a042b0407248f3c0acac00c389e729e3476e86 # v2.3.5
-        if: steps.check-licenses.outputs.changed == 'true'
+        if: ${{ success() && steps.check-licenses.outputs.changed == 'true'  }}
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           auto-stage: false
@@ -319,7 +319,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        if: steps.commit-licenses.outputs.committed == 'true'
+        if: ${{ success() && steps.commit-licenses.outputs.commit != '' }}
         run: |
           gh workflow run pr.yaml --ref "$HEAD_REF" -f pull_request_number="$PR_NUMBER"
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -307,6 +307,7 @@ jobs:
         uses: IAreKyleW00t/verified-bot-commit@42a042b0407248f3c0acac00c389e729e3476e86 # v2.3.5
         if: steps.check-licenses.outputs.changed == 'true'
         with:
+          ref: ${{ github.event.pull_request.head.ref }}
           auto-stage: false
           if-no-commit: info
           message: "Regenerate license report"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -290,24 +290,32 @@ jobs:
       - name: Generate license report
         run: ./gradlew generateLicenseReport
 
-      - name: Commit and push generated license report
-        env:
-          GH_TOKEN: ${{ github.token }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+      - name: Check generated license report
         run: |
           git add licenses
 
           if git diff --cached --quiet
           then
             echo "License report is already up-to-date on the Renovate branch."
-            exit 0
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -m "Regenerate license report"
-          git push origin "HEAD:${HEAD_REF}"
+      - name: Commit and push generated license report
+        id: commit-licenses
+        uses: IAreKyleW00t/verified-bot-commit@42a042b0407248f3c0acac00c389e729e3476e86 # v2.3.5
+        with:
+          auto-stage: false
+          if-no-commit: info
+          message: "Regenerate license report"
+          files: |
+            licenses/**
+
+      - name: Run workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        if: steps.commit-licenses.outputs.committed == 'true'
+        run: |
           gh workflow run pr.yaml --ref "$HEAD_REF" -f pull_request_number="$PR_NUMBER"
 
   generate-metadata:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -291,17 +291,21 @@ jobs:
         run: ./gradlew generateLicenseReport
 
       - name: Check generated license report
+        id: check-licenses
         run: |
           git add licenses
 
           if git diff --cached --quiet
           then
             echo "License report is already up-to-date on the Renovate branch."
+            exit 0
           fi
+          echo "changed=true" >> $GITHUB_OUTPUT
 
       - name: Commit and push generated license report
         id: commit-licenses
         uses: IAreKyleW00t/verified-bot-commit@42a042b0407248f3c0acac00c389e729e3476e86 # v2.3.5
+        if: steps.check-licenses.outputs.changed == 'true'
         with:
           auto-stage: false
           if-no-commit: info


### PR DESCRIPTION
The problem with the current approach is that the commit isn't signed which makes the PR unmergeable because we have a rule that allows only signed commits. Instead of committing the changes manually this PR uses https://github.com/IAreKyleW00t/verified-bot-commit that goes through github api and should produce a verified commit from `github-actions[bot]`. Didn't test.