### PR TITLE
Fix profiling smoke tests

### DIFF
--- a/profiler/build.gradle.kts
+++ b/profiler/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
   compileOnly("io.opentelemetry.semconv:opentelemetry-semconv")
   // required to access InstrumentationHolder
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-bootstrap")
+  compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling")
   implementation("io.opentelemetry:opentelemetry-sdk-logs")
   implementation("io.opentelemetry:opentelemetry-exporter-otlp")
   implementation("com.google.protobuf:protobuf-java")
@@ -45,6 +46,7 @@ dependencies {
   testImplementation(testFixtures(project(":custom")))
   testImplementation(project(":instrumentation:jvm-metrics"))
   testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api")
+  testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling")
   testImplementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
   testImplementation("io.grpc:grpc-netty")
   testImplementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api")

--- a/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrAgentListener.java
+++ b/profiler/src/main/java/com/splunk/opentelemetry/profiler/JfrAgentListener.java
@@ -19,11 +19,12 @@ package com.splunk.opentelemetry.profiler;
 import com.google.auto.service.AutoService;
 import com.google.common.annotations.VisibleForTesting;
 import io.opentelemetry.javaagent.extension.AgentListener;
+import io.opentelemetry.javaagent.tooling.BeforeAgentListener;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import java.util.logging.Logger;
 
-@AutoService(AgentListener.class)
-public class JfrAgentListener implements AgentListener {
+@AutoService({AgentListener.class, BeforeAgentListener.class})
+public class JfrAgentListener implements AgentListener, BeforeAgentListener {
   private static final Logger logger = Logger.getLogger(JfrAgentListener.class.getName());
   private final JFR jfr;
 
@@ -37,11 +38,14 @@ public class JfrAgentListener implements AgentListener {
   }
 
   @Override
-  public void afterAgent(AutoConfiguredOpenTelemetrySdk sdk) {
+  public void beforeAgent(AutoConfiguredOpenTelemetrySdk sdk) {
     if (jfr.isAvailable()) {
       ProfilingSupervisor.setupJfrContextStorage();
     }
+  }
 
+  @Override
+  public void afterAgent(AutoConfiguredOpenTelemetrySdk sdk) {
     // Always start the supervisor, so it can start profiling later elsewhere.
     ProfilingSupervisor supervisor = makeProfilingSupervisor(sdk);
 


### PR DESCRIPTION
Resolves https://github.com/signalfx/splunk-otel-java/issues/3044
An upstream change forces context to be initialized before our profiling context wrapper is added, move adding the wrapper earlier. The upstream change may need to be reverted.